### PR TITLE
Fixes from golint and go vet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ The version command takes no arguments.
 #### Signing
 
 ```
-cfssl sign [-ca cert] [-ca-key key] hostname clientcert
+cfssl sign [-ca cert] [-ca-key key] hostname csr
 ```
 
-The hostname and clientcert are the client's host name and client
-certificate. The `-ca` and `-ca-key` flags are the CA's certificate
-and private key, respectively. By default, they are "ca.pem" and "ca_key.pem".
-For example, assuming the CA's private key is in
-`/etc/ssl/private/cfssl_key.pem` and the CA's certificate is
-in `/etc/ssl/certs/cfssl.pem`, to sign the `cloudflare.pem` certificate for
-cloudflare.com:
+The hostname and csr are the client's host name and certificate
+request. The `-ca` and `-ca-key` flags are the CA's certificate
+and private key, respectively. By default, they are "ca.pem" and
+"ca_key.pem".  For example, assuming the CA's private key is in
+`/etc/ssl/private/cfssl_key.pem` and the CA's certificate is in
+`/etc/ssl/certs/cfssl.pem`, to sign the `cloudflare.pem` certificate
+for cloudflare.com:
 
 ```
 cfssl sign -ca /etc/ssl/certs/cfssl.pem \

--- a/api/api.go
+++ b/api/api.go
@@ -16,16 +16,17 @@ type Handler interface {
 	Handle(w http.ResponseWriter, r *http.Request) error
 }
 
-// HttpHandler is a wrapper that encapsulates Handler interface as http.Handler.
+// HTTPHandler is a wrapper that encapsulates Handler interface as http.Handler.
 // HttpHandler also enforces that the Handler only responds to requests with registered HTTP method.
-type HttpHandler struct {
+type HTTPHandler struct {
 	Handler        // CFSSL handler
 	Method  string // The assoicated HTTP method
 }
 
-// Similar to http.HandlerFunc, HandlerFunc type is an adapter to allow the use of
-// ordinary functions as Handlers. If f is a function
-// with the appropriate signature, HandlerFunc(f) is a Handler object that calls f.
+// HandlerFunc is similar to the http.HandlerFunc type; it serves as
+// an adapter allowing the use of ordinary functions as Handlers. If
+// f is a function with the appropriate signature, HandlerFunc(f) is a
+// Handler object that calls f.
 type HandlerFunc func(http.ResponseWriter, *http.Request) error
 
 // Handle calls f(w, r)
@@ -42,7 +43,7 @@ func handleError(w http.ResponseWriter, err error) (code int) {
 	code = http.StatusInternalServerError
 	// If it is recognized as HttpError emitted from cf-ssl,
 	// we rewrite the status code accordingly.
-	if err, ok := err.(*errors.HttpError); ok && err.StatusCode != 0 {
+	if err, ok := err.(*errors.HTTPError); ok && err.StatusCode != 0 {
 		code = err.StatusCode
 	}
 
@@ -59,7 +60,7 @@ func handleError(w http.ResponseWriter, err error) (code int) {
 
 // ServeHTTP encapsulates the call to underlying Handler to handle the request
 // and return the response with proper HTTP status code
-func (h HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
 	// Throw 405 when requested with an unsupported verb.
 	if r.Method != h.Method {

--- a/api/api_bundler.go
+++ b/api/api_bundler.go
@@ -16,6 +16,8 @@ type BundlerHandler struct {
 	bundler *bundler.Bundler
 }
 
+// NewBundleHandler creates a new bundler that uses the root bundle and
+// intermediate bundle in the trust chain.
 func NewBundleHandler(caBundleFile, intBundleFile string) (http.Handler, error) {
 	var err error
 
@@ -25,9 +27,10 @@ func NewBundleHandler(caBundleFile, intBundleFile string) (http.Handler, error) 
 	}
 
 	log.Info("bundler API ready")
-	return HttpHandler{b, "POST"}, nil
+	return HTTPHandler{b, "POST"}, nil
 }
 
+// Handle implements an http.Handler interface for the bundle handler.
 func (h *BundlerHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 	blob, matched, err := processRequestOneOf(r,
 		[][]string{
@@ -50,7 +53,7 @@ func (h *BundlerHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 		result = bundle
 	case "certificate":
 		flavor := blob["flavor"]
-		var bf bundler.BundleFlavor = bundler.Ubiquitous
+		bf := bundler.Ubiquitous
 		if flavor != "" {
 			bf = bundler.BundleFlavor(flavor)
 		}

--- a/api/api_initca.go
+++ b/api/api_initca.go
@@ -53,5 +53,5 @@ func initialCAHandler(w http.ResponseWriter, r *http.Request) error {
 // NewInitCAHandler returns a new http.Handler that handles request to
 // initialize a CA.
 func NewInitCAHandler() http.Handler {
-	return HttpHandler{HandlerFunc(initialCAHandler), "POST"}
+	return HTTPHandler{HandlerFunc(initialCAHandler), "POST"}
 }

--- a/api/api_signer.go
+++ b/api/api_signer.go
@@ -25,13 +25,13 @@ func NewSignHandler(caFile, cakeyFile string) (http.Handler, error) {
 		log.Errorf("setting up signer failed: %v", err)
 		return nil, err
 	}
-	return HttpHandler{s, "POST"}, nil
+	return HTTPHandler{s, "POST"}, nil
 }
 
 // NewSignHandlerFromSigner generates a new SignHandler directly from
 // an existing signer.
-func NewSignHandlerFromSigner(signer signer.Signer) HttpHandler {
-	return HttpHandler{
+func NewSignHandlerFromSigner(signer signer.Signer) HTTPHandler {
+	return HTTPHandler{
 		&SignHandler{
 			signer: signer,
 		},

--- a/bundler/bundle.go
+++ b/bundler/bundle.go
@@ -145,26 +145,26 @@ func (b *Bundle) MarshalJSON() ([]byte, error) {
 // buildHostnames sets bundle.Hostnames by the x509 cert's subject CN and DNS names
 // Since the subject CN may overlap with one of the DNS names, it needs to handle
 // the duplication by a set.
-func (bundle *Bundle) buildHostnames() {
-	if bundle.Cert == nil {
+func (b *Bundle) buildHostnames() {
+	if b.Cert == nil {
 		return
 	}
 	// hset keeps a set of unique hostnames.
 	hset := make(map[string]bool)
 	// insert CN into hset
-	if bundle.Cert.Subject.CommonName != "" {
-		hset[bundle.Cert.Subject.CommonName] = true
+	if b.Cert.Subject.CommonName != "" {
+		hset[b.Cert.Subject.CommonName] = true
 	}
 	// insert all DNS names into hset
-	for _, h := range bundle.Cert.DNSNames {
+	for _, h := range b.Cert.DNSNames {
 		hset[h] = true
 	}
 
 	// convert hset to an array of hostnames
-	bundle.Hostnames = make([]string, len(hset))
+	b.Hostnames = make([]string, len(hset))
 	i := 0
-	for h, _ := range hset {
-		bundle.Hostnames[i] = h
+	for h := range hset {
+		b.Hostnames[i] = h
 		i++
 	}
 }

--- a/bundler/bundle_from_file_test.go
+++ b/bundler/bundle_from_file_test.go
@@ -358,7 +358,7 @@ func TestBundleFromFile(t *testing.T) {
 			test.errorCallback(t, err)
 		} else {
 			if err != nil {
-				t.Fatal("expected no error. but an error occurred: %s", err.Error())
+				t.Fatalf("expected no error. but an error occurred: %v", err)
 			}
 			if test.bundleChecking != nil {
 				test.bundleChecking(t, bundle)

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -1,12 +1,11 @@
-// package bundler implements certificate bundling functionality for CF-SSL.
+// Package bundler implements certificate bundling functionality for
+// CF-SSL.
 package bundler
 
 import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -33,8 +32,13 @@ var IntermediateStash = "intermediates"
 type BundleFlavor string
 
 const (
-	Optimal    BundleFlavor = "optimal"    // Optimal means the shortest chain with newest intermediates and the most advanced crypto.
-	Ubiquitous BundleFlavor = "ubiquitous" // Ubiquitous is aimed to provide the chain which is accepted by the most platforms.
+	// Optimal means the shortest chain with newest intermediates and
+	// the most advanced crypto.
+	Optimal BundleFlavor = "optimal"
+
+	// Ubiquitous is aimed to provide the chain which is accepted
+	// by the most platforms.
+	Ubiquitous BundleFlavor = "ubiquitous"
 )
 
 const (
@@ -74,7 +78,8 @@ func NewBundler(caBundleFile, intBundleFile string) (*Bundler, error) {
 		log.Infof("intermediate stash directory %s doesn't exist, creating", IntermediateStash)
 		err = os.MkdirAll(IntermediateStash, 0755)
 		if err != nil {
-			log.Errorf("failed to create intermediate stash directory %s: %v", err)
+			log.Errorf("failed to create intermediate stash directory %s: %v",
+				IntermediateStash, err)
 			return nil, err
 		}
 		log.Infof("intermediate stash directory %s created", IntermediateStash)
@@ -144,7 +149,7 @@ func (b *Bundler) BundleFromFile(bundleFile, keyFile string, flavor BundleFlavor
 		return nil, errors.New(errors.CertificateError, errors.ReadFailed, err)
 	}
 
-	var keyPEM []byte = nil
+	var keyPEM []byte
 	// Load private key PEM only if a file is given
 	if keyFile != "" {
 		log.Debug("Loading private key: ", keyFile)
@@ -392,7 +397,7 @@ func (b *Bundler) fetchIntermediates(certs []*x509.Certificate) (err error) {
 		log.Infof("intermediate stash directory %s doesn't exist, creating", IntermediateStash)
 		err = os.MkdirAll(IntermediateStash, 0755)
 		if err != nil {
-			log.Errorf("failed to create intermediate stash directory %s: %v", err)
+			log.Errorf("failed to create intermediate stash directory %s: %v", IntermediateStash, err)
 			return err
 		}
 		log.Infof("intermediate stash directory %s created", IntermediateStash)

--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -458,7 +458,8 @@ func newCustomizedBundlerFromFile(t *testing.T, caBundle, intBundle, adhocInters
 	if adhocInters != "" {
 		moreIntersPEM, err := ioutil.ReadFile(adhocInters)
 		if err != nil {
-			t.Fatal("Read additional intermediates failed. %s", err.Error())
+			t.Fatalf("Read additional intermediates failed. %v",
+				err)
 		}
 		intermediates, err := helpers.ParseCertificatesPEM(moreIntersPEM)
 		if err != nil {
@@ -525,9 +526,11 @@ func ExpectErrorMessages(expectedContents []string) func(*testing.T, error) {
 func ExpectBundleLength(expectedLen int) func(*testing.T, *Bundle) {
 	return func(t *testing.T, bundle *Bundle) {
 		if bundle == nil {
-			t.Fatalf("Cert bundle should have a chain of length %d. Got nil.")
+			t.Fatalf("Cert bundle should have a chain of length %d. Got nil.",
+				expectedLen)
 		} else if len(bundle.Chain) != expectedLen {
-			t.Fatalf("Cert bundle should have a chain of length %d. Got chain length %d.", expectedLen, len(bundle.Chain))
+			t.Fatalf("Cert bundle should have a chain of length %d. Got chain length %d.",
+				expectedLen, len(bundle.Chain))
 		}
 	}
 }

--- a/cfssl_gencert.go
+++ b/cfssl_gencert.go
@@ -83,7 +83,7 @@ func gencertMain(args []string) (err error) {
 		}
 
 		var key, csrPEM []byte
-		g := &csr.Generator{validator}
+		g := &csr.Generator{Validator: validator}
 		csrPEM, key, err = g.ProcessRequest(&req)
 		if err != nil {
 			key = nil
@@ -126,7 +126,7 @@ func printCert(key, csrPEM, cert []byte) {
 func gencertRemotely(req csr.CertificateRequest) error {
 	srv := client.NewServer(Config.remote)
 
-	g := &csr.Generator{validator}
+	g := &csr.Generator{Validator: validator}
 	csrPEM, key, err := g.ProcessRequest(&req)
 	if err != nil {
 		key = nil
@@ -143,4 +143,6 @@ func gencertRemotely(req csr.CertificateRequest) error {
 	return nil
 }
 
+// CLIGenCert is a subcommand that generates a new certificate from a
+// JSON CSR request file.
 var CLIGenCert = &Command{gencertUsageText, gencertFlags, gencertMain}

--- a/cfssl_genkey.go
+++ b/cfssl_genkey.go
@@ -62,7 +62,7 @@ func genkeyMain(args []string) (err error) {
 
 	} else {
 		var key, csrPEM []byte
-		g := &csr.Generator{validator}
+		g := &csr.Generator{Validator: validator}
 		csrPEM, key, err = g.ProcessRequest(&req)
 		if err != nil {
 			key = nil
@@ -91,4 +91,6 @@ func validator(req *csr.CertificateRequest) error {
 	return nil
 }
 
+// CLIGenKey is a subcommand for generating a new key and CSR from a
+// JSON CSR request file.
 var CLIGenKey = &Command{genkeyUsageText, genkeyFlags, genkeyMain}

--- a/cfssl_serve.go
+++ b/cfssl_serve.go
@@ -64,12 +64,12 @@ func registerHandlers() error {
 
 	if Config.remote != "" {
 		log.Info("Remote CFSSL endpoint given, setting up remote certificate generator")
-		if rcg, err := api.NewRemoteCertGenerator(api.CSRValidate, Config.remote); err != nil {
+		rcg, err := api.NewRemoteCertGenerator(api.CSRValidate, Config.remote)
+		if err != nil {
 			log.Errorf("Failed to set up remote certificate generator: %v", err)
 			return err
-		} else {
-			http.Handle("/api/v1/cfssl/remotecert", rcg)
 		}
+		http.Handle("/api/v1/cfssl/remotecert", rcg)
 	}
 
 	log.Info("Handler set up complete.")
@@ -81,7 +81,7 @@ func registerHandlers() error {
 func serverMain(args []string) error {
 	// serve doesn't support arguments.
 	if len(args) > 0 {
-		return errors.New("Arguments is provided but not defined. Please refer to the usage by flag -h.")
+		return errors.New("argument is provided but not defined; please refer to the usage by flag -h")
 	}
 
 	bundler.IntermediateStash = Config.intDir

--- a/config/config.go
+++ b/config/config.go
@@ -37,14 +37,17 @@ func (p *SigningProfile) parse() bool {
 	} else if p.ExpiryString == "" {
 		log.Debugf("failed: empty expiry string")
 		return false
-	} else if dur, err := time.ParseDuration(p.ExpiryString); err != nil {
+	}
+
+	dur, err := time.ParseDuration(p.ExpiryString)
+	if err != nil {
 		log.Debugf("failed to parse expiry: %v", err)
 		return false
-	} else {
-		log.Debugf("expiry is valid")
-		p.Expiry = dur
-		return true
 	}
+
+	log.Debugf("expiry is valid")
+	p.Expiry = dur
+	return true
 }
 
 // Usages parses the list of key uses in the profile, translating them
@@ -102,18 +105,21 @@ func (c *Config) Valid() bool {
 	return c.Signing.Valid()
 }
 
-// Signing specifically validates the signature policies.
+// Valid checks the signature policies, ensuring they are valid
+// policies. A policy is valid if it has defined at least key usages
+// to be used, and a valid default profile has defined at least a
+// default expiration.
 func (s *Signing) Valid() bool {
 	log.Debugf("validating configuration")
 	if !s.Default.validProfile(true) {
 		log.Debugf("default profile is invalid")
 		return false
-	} else {
-		for _, p := range s.Profiles {
-			if !p.validProfile(false) {
-				log.Debugf("invalid profile")
-				return false
-			}
+	}
+
+	for _, p := range s.Profiles {
+		if !p.validProfile(false) {
+			log.Debugf("invalid profile")
+			return false
 		}
 	}
 	return true
@@ -194,11 +200,11 @@ func LoadFile(path string) *Config {
 
 	if !cfg.Valid() {
 		return nil
-	} else {
-		for k := range cfg.Signing.Profiles {
-			if !cfg.Signing.Profiles[k].parse() {
-				return nil
-			}
+	}
+
+	for k := range cfg.Signing.Profiles {
+		if !cfg.Signing.Profiles[k].parse() {
+			return nil
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,7 +90,7 @@ func TestValidConfig(t *testing.T) {
 		t.Fatal("Valid config is not valid")
 	}
 	bytes, _ := json.Marshal(validConfig)
-	fmt.Println("%v", string(bytes))
+	fmt.Printf("%v", string(bytes))
 }
 func TestDefaultConfig(t *testing.T) {
 	if !DefaultConfig().validProfile(false) {

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
-	_ "crypto/sha512"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"

--- a/errors/http.go
+++ b/errors/http.go
@@ -5,40 +5,43 @@ import (
 	"net/http"
 )
 
-// HttpError is an augmented error with a HTTP status code.
-type HttpError struct {
+// HTTPError is an augmented error with a HTTP status code.
+type HTTPError struct {
 	StatusCode int
 	error
 }
 
-// The error interface implementation
-func (e *HttpError) Error() string {
+// Error implements the error interface.
+func (e *HTTPError) Error() string {
 	return e.error.Error()
 }
 
-func NewMethodNotAllowed(method string) *HttpError {
-	return &HttpError{http.StatusMethodNotAllowed, errors.New(`Method is not allowed:"` + method + `"`)}
+// NewMethodNotAllowed returns an appropriate error in the case that
+// an HTTP client uses an invalid method (i.e. a GET in place of a POST)
+// on an API endpoint.
+func NewMethodNotAllowed(method string) *HTTPError {
+	return &HTTPError{http.StatusMethodNotAllowed, errors.New(`Method is not allowed:"` + method + `"`)}
 }
 
 // NewBadRequest creates a HttpError with the given error and error code 400.
-func NewBadRequest(err error) *HttpError {
-	return &HttpError{http.StatusBadRequest, err}
+func NewBadRequest(err error) *HTTPError {
+	return &HTTPError{http.StatusBadRequest, err}
 }
 
 // NewBadRequestString returns a HttpError with the supplied message
 // and error code 400.
-func NewBadRequestString(s string) *HttpError {
+func NewBadRequestString(s string) *HTTPError {
 	return NewBadRequest(errors.New(s))
 }
 
 // NewBadRequestMissingParameter returns a 400 HttpError as a required
 // parameter is missing in the HTTP request.
-func NewBadRequestMissingParameter(s string) *HttpError {
+func NewBadRequestMissingParameter(s string) *HTTPError {
 	return NewBadRequestString(`Missing parameter "` + s + `"`)
 }
 
 // NewBadRequestUnwantedParameter returns a 400 HttpError as a unnecessary
 // parameter is present in the HTTP request.
-func NewBadRequestUnwantedParameter(s string) *HttpError {
+func NewBadRequestUnwantedParameter(s string) *HTTPError {
 	return NewBadRequestString(`Unwanted parameter "` + s + `"`)
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -15,6 +15,7 @@ import (
 	cferr "github.com/cloudflare/cfssl/errors"
 )
 
+// OneYear is a time.Duration representing a year's worth of seconds.
 const OneYear = 8760 * time.Hour
 
 // KeyLength returns the bit size of ECDSA or RSA PublicKey
@@ -156,6 +157,8 @@ func ParsePrivateKeyPEM(keyPEM []byte) (key interface{}, err error) {
 	return ParsePrivateKeyDER(keyDER.Bytes)
 }
 
+// ParsePrivateKeyDER parses a PKCS #1, PKCS #8, or elliptic curve
+// DER-encoded private key. The key must not be in PEM format.
 func ParsePrivateKeyDER(keyDER []byte) (key interface{}, err error) {
 	key, err = x509.ParsePKCS8PrivateKey(keyDER)
 	if err != nil {
@@ -163,10 +166,12 @@ func ParsePrivateKeyDER(keyDER []byte) (key interface{}, err error) {
 		if err != nil {
 			key, err = x509.ParseECPrivateKey(keyDER)
 			if err != nil {
-				// We don't include the actual error into the final error.
-				// The reason might be we don't want to leak any info about
+				// We don't include the actual error into
+				// the final error. The reason might be
+				// we don't want to leak any info about
 				// the private key.
-				return nil, cferr.New(cferr.PrivateKeyError, cferr.ParseFailed, nil)
+				return nil, cferr.New(cferr.PrivateKeyError,
+					cferr.ParseFailed, nil)
 			}
 		}
 	}

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -1,4 +1,4 @@
-// initca contains code to initialise a certificate authority,
+// Package initca contains code to initialise a certificate authority,
 // generating a new root key and certificate.
 package initca
 
@@ -33,7 +33,7 @@ func validator(req *csr.CertificateRequest) error {
 // New creates a new root certificate from the certificate request.
 func New(req *csr.CertificateRequest) (cert, key []byte, err error) {
 	log.Infof("creating root certificate from CSR")
-	g := &csr.Generator{validator}
+	g := &csr.Generator{Validator: validator}
 	csr, key, err := g.ProcessRequest(req)
 	if err != nil {
 		log.Errorf("failed to process request: %v", err)

--- a/revoke/revoke.go
+++ b/revoke/revoke.go
@@ -17,13 +17,16 @@ import (
 )
 
 // HardFail determines whether the failure to check the revocation
-// status of a certificate (i.e. due to network failure) causes verification to fail (a hard failure).
-var HardFail bool = false
+// status of a certificate (i.e. due to network failure) causes
+// verification to fail (a hard failure).
+var HardFail = false
 
 // TODO (kyle): figure out a good mechanism for OCSP; this requires
 // presenting both the certificate and the issuer, and we don't have a
 // good way at this time of getting the issuer.
 
+// CRLSet associates a PKIX certificate list with the URL the CRL is
+// fetched from.
 var CRLSet = map[string]*pkix.CertificateList{}
 
 // We can't handle LDAP certificates, so this checks to see if the

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -6,8 +6,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
@@ -27,8 +25,8 @@ type Signer interface {
 	Sign(string, []byte, string) (cert []byte, err error)
 }
 
-// DefaultSigAlgo returns an appropriate X.509 signature algorithm given the
-// CA's private key.
+// DefaultSigAlgo returns an appropriate X.509 signature algorithm given
+// the CA's private key.
 func DefaultSigAlgo(priv interface{}) x509.SignatureAlgorithm {
 	switch priv := priv.(type) {
 	case *rsa.PrivateKey:

--- a/signer/standard_signer.go
+++ b/signer/standard_signer.go
@@ -4,8 +4,6 @@ package signer
 import (
 	"crypto/rand"
 	"crypto/sha1"
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -21,7 +19,7 @@ import (
 	"github.com/cloudflare/cfssl/log"
 )
 
-// SoftwareSigner contains a signer that uses the standard library to
+// StandardSigner contains a signer that uses the standard library to
 // support both ECDSA and RSA CA keys.
 type StandardSigner struct {
 	ca      *x509.Certificate
@@ -199,7 +197,8 @@ func (s *StandardSigner) Sign(hostName string, in []byte, profileName string) (c
 	}
 
 	if block.Type != "CERTIFICATE REQUEST" {
-		return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, errors.New("Not a certificate or csr."))
+		return nil, cferr.New(cferr.CertificateError,
+			cferr.ParseFailed, errors.New("not a certificate or csr"))
 	}
 
 	template, err := ParseCertificateRequest(s, block.Bytes)

--- a/ubiquity/ubiquity_crypto.go
+++ b/ubiquity/ubiquity_crypto.go
@@ -9,7 +9,14 @@ import (
 	"math"
 )
 
+// HashUbiquity represents a score for how ubiquitous a given hash
+// algorithm is; the higher the score, the more preferable the algorithm
+// is.
 type HashUbiquity int
+
+// KeyAlgoUbiquity represents a score for how ubiquitous a given
+// public-key algorithm is; the higher the score, the more preferable
+// the algorithm is.
 type KeyAlgoUbiquity int
 
 // SHA1 is ubiquitous. SHA2 is not supported on some legacy platforms.
@@ -22,10 +29,10 @@ const (
 	MD2Ubiquity         HashUbiquity = 0
 )
 
-// RSA and DSA are considered ubiquitous.
-// ECDSA256 and ECDSA384 should be supported by TLS 1.2 and have limited support
-// from TLS 1.0 and 1.1, based on RFC6460.  And ECDSA521 are relatively less supported
-// as a standard.
+// RSA and DSA are considered ubiquitous. ECDSA256 and ECDSA384 should be
+// supported by TLS 1.2 and have limited support from TLS 1.0 and
+// 1.1, based on RFC6460, but ECDSA521 is less well-supported as
+// a standard.
 const (
 	RSAUbiquity         KeyAlgoUbiquity = 100
 	DSAUbiquity         KeyAlgoUbiquity = 100
@@ -71,9 +78,8 @@ func keyAlgoUbiquity(cert *x509.Certificate) KeyAlgoUbiquity {
 	case x509.RSA:
 		if cert.PublicKey.(*rsa.PublicKey).N.BitLen() >= 1024 {
 			return RSAUbiquity
-		} else {
-			return UnknownAlgoUbiquity
 		}
+		return UnknownAlgoUbiquity
 	case x509.DSA:
 		return DSAUbiquity
 	default:
@@ -81,7 +87,8 @@ func keyAlgoUbiquity(cert *x509.Certificate) KeyAlgoUbiquity {
 	}
 }
 
-// Hash ubiquity of a chain is the lowest hash ubiquity among certs in it.
+// ChainHashUbiquity scores a chain based on the hash algorithms used
+// by the certificates in the chain.
 func ChainHashUbiquity(chain []*x509.Certificate) HashUbiquity {
 	ret := math.MaxInt32
 	for _, cert := range chain {
@@ -93,7 +100,8 @@ func ChainHashUbiquity(chain []*x509.Certificate) HashUbiquity {
 	return HashUbiquity(ret)
 }
 
-// Key algorithm ubiquity of a chain is the lowest key algorithm ubiquity among certs in it.
+// ChainKeyAlgoUbiquity scores a chain based on the public-key algorithms
+// used by the certificates in the chain.
 func ChainKeyAlgoUbiquity(chain []*x509.Certificate) KeyAlgoUbiquity {
 	ret := math.MaxInt32
 	for _, cert := range chain {
@@ -105,16 +113,18 @@ func ChainKeyAlgoUbiquity(chain []*x509.Certificate) KeyAlgoUbiquity {
 	return KeyAlgoUbiquity(ret)
 }
 
-// Return positive value if hash function ubiquity of chain1 is greater than that of chain2,
-// negative value if ubiquity rank of chain1 is lower than that of chain2, 0 if they are ranked equal.
+// CompareChainHashUbiquity returns a positive, zero, or negative value
+// if the hash ubiquity of the first chain is greater, equal, or less
+// than the second chain.
 func CompareChainHashUbiquity(chain1, chain2 []*x509.Certificate) int {
 	hu1 := ChainHashUbiquity(chain1)
 	hu2 := ChainHashUbiquity(chain2)
 	return int(hu1) - int(hu2)
 }
 
-// Return positive value if key algorithm ubiquity of chain1 is greater than that of chain2,
-// negative value if ubiquity rank of chain1 is lower than that of chain2, 0 if they are ranked equal.
+// CompareChainKeyAlgoUbiquity returns a positive, zero, or negative value
+// if the public-key ubiquity of the first chain is greater, equal,
+// or less than the second chain.
 func CompareChainKeyAlgoUbiquity(chain1, chain2 []*x509.Certificate) int {
 	kau1 := ChainKeyAlgoUbiquity(chain1)
 	kau2 := ChainKeyAlgoUbiquity(chain2)

--- a/ubiquity/ubiquity_platform.go
+++ b/ubiquity/ubiquity_platform.go
@@ -134,7 +134,7 @@ func LoadPlatforms(filename string) {
 	for _, platform := range rawPlatforms {
 		ok := platform.ParseAndLoad()
 		if !ok {
-			log.Errorf("fail to finalize the parsing of platform metadata:", err)
+			log.Errorf("fail to finalize the parsing of platform metadata (err = %v)", err)
 		} else {
 			log.Infof("Platform metadata is loaded: %v %v", platform.Name, len(platform.KeyStore))
 			Platforms = append(Platforms, platform)


### PR DESCRIPTION
[golint](https://github.com/golang/lint) and `go vet` pointed out a number of cleanups that could be made on the code base. This PR addresses those suggestions, cleans up the relevant comments, and changes the README signing section to describe the current behaviour.
