### PR TITLE
Add info endpoint.

### DIFF
--- a/api/api_info.go
+++ b/api/api_info.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cloudflare/cfssl/bundler"
+	"github.com/cloudflare/cfssl/helpers"
+)
+
+// InfoHandler is a type that contains the root certificates for the CA,
+// and serves information on them for clients that need the certificates.
+type InfoHandler struct {
+	roots []*x509.Certificate
+}
+
+// NewInfoHandler creates a new handler to serve information on the
+// CA's certificates.
+func NewInfoHandler(roots []*x509.Certificate) http.Handler {
+	return &HTTPHandler{
+		Handler: &InfoHandler{
+			roots: roots,
+		},
+		Method: "GET",
+	}
+}
+
+// NewInfoHandlerFromPEM creates a new handler to serve information on the
+// CA's certificates, taking a list of PEM-encoded certificates to use.
+func NewInfoHandlerFromPEM(pemRoots []string) (http.Handler, error) {
+	var roots []*x509.Certificate
+	for i := range pemRoots {
+		fileData, err := ioutil.ReadFile(pemRoots[i])
+		if err != nil {
+			return nil, err
+		}
+
+		cert, err := helpers.ParseCertificatePEM(fileData)
+		if err != nil {
+			return nil, err
+		}
+		roots = append(roots, cert)
+	}
+
+	return &HTTPHandler{
+		Handler: &InfoHandler{
+			roots: roots,
+		},
+		Method: "GET",
+	}, nil
+}
+
+// Handle listens for incoming requests for CA information, and returns
+// a list containing information on each root certificate.
+func (h *InfoHandler) Handle(w http.ResponseWriter, r *http.Request) error {
+	var bundles []bundler.Bundle
+
+	for i := range h.roots {
+		bundles = append(bundles, bundler.Bundle{
+			Chain:     []*x509.Certificate{h.roots[i]},
+			Cert:      h.roots[i],
+			Issuer:    &h.roots[i].Issuer,
+			Subject:   &h.roots[i].Subject,
+			Expires:   &h.roots[i].NotAfter,
+			Hostnames: h.roots[i].DNSNames,
+			Status:    nil,
+		})
+	}
+
+	response := newSuccessResponse(bundles)
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	return enc.Encode(response)
+}

--- a/cfssl_serve.go
+++ b/cfssl_serve.go
@@ -24,8 +24,16 @@ Flags:
 // Flags used by 'cfssl serve'
 var serverFlags = []string{"address", "port", "ca", "ca-key", "ca-bundle", "int-bundle", "int-dir", "metadata", "remote", "f"}
 
-// registerHandlers instantiates various handlers and assoicate them to corresponding endpoints.
+// registerHandlers instantiates various handlers and associate them to corresponding endpoints.
 func registerHandlers() error {
+	log.Info("Setting up info endpoint")
+	infoHandler, err := api.NewInfoHandlerFromPEM([]string{Config.caFile})
+	if err != nil {
+		log.Warningf("endpoint '/api/v1/cfssl/info' is disabled: %v", err)
+	} else {
+		http.Handle("/api/v1/cfssl/info", infoHandler)
+	}
+
 	log.Info("Setting up signer endpoint")
 	signHandler, err := api.NewSignHandler(Config.caFile, Config.caKeyFile)
 	if err != nil {

--- a/doc/api.txt
+++ b/doc/api.txt
@@ -17,9 +17,9 @@ The API currently provides endpoints for the following functions:
 
 2. ENDPOINTS
 
-The endpoints respond to JSON-encoded POST requests. Except where
-noted, the request body should be a dictionary of string keys to
-string values. For example:
+Endpoints return JSON-encoded responses in the standard format described
+below. Except where noted, the request body should be a dictionary of
+string keys to string values. For example:
 
        {
          "key": "value",
@@ -46,6 +46,7 @@ a message or error has the form
 2.1 SIGNING
 
 Endpoint: "/api/v1/cfssl/sign"
+Method: POST
 Parameters:
         * hostname: the SAN to use for the new certificate
         * cert: the PEM-encoded certificate that should be signed
@@ -58,6 +59,7 @@ Result: { "certificate": "-----BEGIN CERTIFICATE..." }
 2.2 BUNDLING
 
 Endpoint: "/api/v1/cfssl/bundle"
+Method: POST
 Required Parameters:
 
         One of the following two parameters is required; if both are
@@ -137,6 +139,7 @@ Result:
 2.3 CERTIFICATE REQUESTS
 
 Endpoint: "/api/v1/cfssl/newkey"
+Method: POST
 Required parameters:
 
          * hosts: a list of hostnames to be used for the certificate.
@@ -190,6 +193,7 @@ Result:
 2.4. SIGNED CERTIFICATE REQUESTS
 
 Endpoint: "/api/v1/cfssl/newcert"
+Method: POST
 Required parameters:
 
          * hostname: the hostname for the certificate
@@ -237,6 +241,7 @@ CFSSL server. It is identical in use to newcert; it generates a key and
 CSR locally, and submits the CSR to the remote cfssl for signing.
 
 Endpoint: "/api/v1/cfssl/remotecert"
+Method: POST
 Required parameters:
 
          * hostname: the hostname for the certificate
@@ -272,6 +277,19 @@ Example:
     cURL call:
     curl -XPOST -H "Content-Type: application/json" -d @csr.json \
          127.0.0.1:8888/api/v1/cfssl/newcert
+
+2.6 INFO
+
+The info endpoint returns a list of information on all the CA's
+certificates (those corresponding to the CA's private keys).
+
+Endpoint: "/api/v1/cfssl/remotecert"
+Method: GET
+
+Example:
+
+    cURL call:
+    curl 127.0.0.1:8888/api/v1/cfssl/info | python -m json.tool
 
 3. CONFIGURATION
 


### PR DESCRIPTION
The new endpoint is being added to /api/v1/cfssl/info, and returns a list of Bundle objects containing information the about the root certificates for the CA. If no CA certificate is provided, this endpoint will be disabled.
