### PR TITLE
The initca option can be used with an existing private key.

### DIFF
--- a/api/api_generator.go
+++ b/api/api_generator.go
@@ -56,6 +56,11 @@ func (g *GeneratorHandler) Handle(w http.ResponseWriter, r *http.Request) error 
 		return errors.NewBadRequest(err)
 	}
 
+	if req.CA != nil {
+		log.Warningf("request received with CA section")
+		return errors.NewBadRequestString("ca section only permitted in initca")
+	}
+
 	csr, key, err := g.generator.ProcessRequest(req)
 	if err != nil {
 		log.Warningf("failed to process CSR: %v", err)
@@ -132,6 +137,16 @@ func (cg *CertGeneratorHandler) Handle(w http.ResponseWriter, r *http.Request) e
 		return errors.NewBadRequest(err)
 	}
 
+	if req.Request == nil {
+		log.Warning("empty request received")
+		return errors.NewBadRequestString("missing request section")
+	}
+
+	if req.Request.CA != nil {
+		log.Warningf("request received with CA section")
+		return errors.NewBadRequestString("ca section only permitted in initca")
+	}
+
 	csr, key, err := cg.generator.ProcessRequest(req.Request)
 	if err != nil {
 		log.Warningf("failed to process CSR: %v", err)
@@ -191,6 +206,16 @@ func (rcg *RemoteCertGeneratorHandler) Handle(w http.ResponseWriter, r *http.Req
 	} else if req == nil || req.Request == nil {
 		log.Warningf("invalid request received")
 		return errors.NewBadRequestString("invalid request")
+	}
+
+	if req.Request == nil {
+		log.Warning("empty request received")
+		return errors.NewBadRequestString("missing request section")
+	}
+
+	if req.Request.CA != nil {
+		log.Warningf("request received with CA section")
+		return errors.NewBadRequestString("ca section only permitted in initca")
 	}
 
 	csrPEM, key, err := rcg.generator.ProcessRequest(req.Request)

--- a/cfssl_genkey.go
+++ b/cfssl_genkey.go
@@ -61,6 +61,11 @@ func genkeyMain(args []string) (err error) {
 		fmt.Printf("%s\n", string(jsonOut))
 
 	} else {
+		if req.CA != nil {
+			err = errors.New("ca section only permitted in initca")
+			return
+		}
+
 		var key, csrPEM []byte
 		g := &csr.Generator{Validator: validator}
 		csrPEM, key, err = g.ProcessRequest(&req)

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -103,6 +103,12 @@ func (kr *KeyRequest) SigAlgo() x509.SignatureAlgorithm {
 	}
 }
 
+// CAConfig is a section used in the requests initialising a new CA.
+type CAConfig struct {
+	PathLength int    `json:"pathlen"`
+	Expiry     string `json:"expiry"`
+}
+
 // A CertificateRequest encapsulates the API interface to the
 // certificate request functionality.
 type CertificateRequest struct {
@@ -110,6 +116,7 @@ type CertificateRequest struct {
 	Names      []Name      `json:"names"`
 	Hosts      []string    `json:"hosts"`
 	KeyRequest *KeyRequest `json:"key,omitempty"`
+	CA         *CAConfig   `json:"ca,omitempty"`
 }
 
 // appendIf appends to a if s is not an empty string.

--- a/doc/bootstrap.txt
+++ b/doc/bootstrap.txt
@@ -74,7 +74,7 @@ following (perhaps in `ca.json`):
 Then, initialise the CA:
 
 ```
-cfssl genkey -initca ca.json | cfssljson ca
+cfssl genkey -initca ca.json | cfssljson -bare ca
 ```
 
 When `cfssl` starts up, it will look by default for a CA key named

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -3,7 +3,15 @@
 package initca
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"io/ioutil"
+	"time"
 
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
@@ -32,7 +40,17 @@ func validator(req *csr.CertificateRequest) error {
 
 // New creates a new root certificate from the certificate request.
 func New(req *csr.CertificateRequest) (cert, key []byte, err error) {
-	log.Infof("creating root certificate from CSR")
+	if req.CA != nil {
+		if req.CA.Expiry != "" {
+			CAPolicy.Default.ExpiryString = req.CA.Expiry
+			CAPolicy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
+		}
+
+		if req.CA.PathLength != 0 {
+			signer.MaxPathLen = req.CA.PathLength
+		}
+	}
+
 	g := &csr.Generator{Validator: validator}
 	csr, key, err := g.ProcessRequest(req)
 	if err != nil {
@@ -53,6 +71,89 @@ func New(req *csr.CertificateRequest) (cert, key []byte, err error) {
 	cert, err = s.Sign("", csr, "")
 	return
 
+}
+
+// NewFromPEM creates a new root certificate from the key file passed in.
+func NewFromPEM(req *csr.CertificateRequest, keyFile string) (cert []byte, err error) {
+	if req.CA != nil {
+		if req.CA.Expiry != "" {
+			CAPolicy.Default.ExpiryString = req.CA.Expiry
+			CAPolicy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
+		}
+
+		if req.CA.PathLength != 0 {
+			signer.MaxPathLen = req.CA.PathLength
+		}
+	}
+
+	privData, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	priv, err := helpers.ParsePrivateKeyPEM(privData)
+	if err != nil {
+		return nil, err
+	}
+
+	var sigAlgo x509.SignatureAlgorithm
+	switch priv := priv.(type) {
+	case *rsa.PrivateKey:
+		bitLength := priv.PublicKey.N.BitLen()
+		switch {
+		case bitLength >= 4096:
+			sigAlgo = x509.SHA512WithRSA
+		case bitLength >= 3072:
+			sigAlgo = x509.SHA384WithRSA
+		case bitLength >= 2048:
+			sigAlgo = x509.SHA256WithRSA
+		default:
+			sigAlgo = x509.SHA1WithRSA
+		}
+	case *ecdsa.PrivateKey:
+		switch priv.Curve {
+		case elliptic.P521():
+			sigAlgo = x509.ECDSAWithSHA512
+		case elliptic.P384():
+			sigAlgo = x509.ECDSAWithSHA384
+		case elliptic.P256():
+			sigAlgo = x509.ECDSAWithSHA256
+		default:
+			sigAlgo = x509.ECDSAWithSHA1
+		}
+	default:
+		sigAlgo = x509.UnknownSignatureAlgorithm
+	}
+
+	var tpl = x509.CertificateRequest{
+		Subject:            req.Name(),
+		SignatureAlgorithm: sigAlgo,
+		DNSNames:           req.Hosts,
+	}
+
+	certReq, err := x509.CreateCertificateRequest(rand.Reader, &tpl, priv)
+	if err != nil {
+		log.Errorf("failed to generate a CSR: %v", err)
+		// The use of PrivateKeyError was a matter of some
+		// debate; it is the one edge case in which a new
+		// error category specifically for CSRs might be
+		// useful, but it was deemed that one edge case did
+		// not a new category justify.
+		err = cferr.New(cferr.PrivateKeyError, cferr.BadRequest, err)
+		return
+	}
+
+	p := &pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: certReq,
+	}
+	certReq = pem.EncodeToMemory(p)
+
+	s := signer.NewStandardSigner(priv, nil, signer.DefaultSigAlgo(priv))
+	s.SetPolicy(CAPolicy)
+
+	cert, err = s.Sign("", certReq, "")
+	return
 }
 
 // CAPolicy contains the CA issuing policy as default policy.

--- a/signer/standard_signer.go
+++ b/signer/standard_signer.go
@@ -19,6 +19,9 @@ import (
 	"github.com/cloudflare/cfssl/log"
 )
 
+// MaxPathLen is the default path length for a new CA certificate.
+var MaxPathLen = 2
+
 // StandardSigner contains a signer that uses the standard library to
 // support both ECDSA and RSA CA keys.
 type StandardSigner struct {
@@ -164,7 +167,7 @@ func (s *StandardSigner) sign(template *x509.Certificate, profile *config.Signin
 		template.DNSNames = nil
 		s.ca = template
 		initRoot = true
-		template.MaxPathLen = 2
+		template.MaxPathLen = MaxPathLen
 	} else if template.IsCA {
 		template.MaxPathLen = 1
 		template.DNSNames = nil


### PR DESCRIPTION
This is useful for generating a new certificate (i.e. with updated signature scheme) from an existing private key.

This commit also adds the -bare option to cfssljson, which is used for the responses from the command line that do not use the API response.
