### PR TITLE
Add remote signing and consolidate remote cert generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ command:
 
 ```
 cfssl serve [-address address] [-ca cert] [-ca-bundle bundle] \
-            [-ca-key key] [-int-bundle bundle] [-port port]
+            [-ca-key key] [-int-bundle bundle] [-port port]   \
+            [-remote remote_server]
 ```
 
 Address and port default to "127.0.0.1:8888". The `-ca` and `-ca-key`
@@ -180,7 +181,8 @@ arguments should be the PEM-encoded certificate and private key to use
 for signing; by default, they are "ca.pem" and "ca_key.pem". The
 `-ca-bundle` and `-int-bundle` should be the certificate bundles used
 for the root and intermediate certificate pools, respectively. These
-default to "ca-bundle.crt" and "int-bundle."
+default to "ca-bundle.crt" and "int-bundle." If the "remote" option is
+provided, all signature operations will be forwarded to the remote CFSSL.
 
 The amount of logging can be controlled with the `-loglevel` option. This
 comes *before* the serve command:

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 func newTestSignHandler(t *testing.T) (h http.Handler) {
-	h, err := NewSignHandler(testCaFile, testCaKeyFile)
+	h, err := NewSignHandler(testCaFile, testCaKeyFile, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestNewSignHandler(t *testing.T) {
 }
 
 func TestNewSignHandlerError(t *testing.T) {
-	_, err := NewSignHandler(testCaFile, testBrokenCSRFile)
+	_, err := NewSignHandler(testCaFile, testBrokenCSRFile, "")
 	if err == nil {
 		t.Fatal("Expect error when create a signer with broken file.")
 	}

--- a/cfssl_serve.go
+++ b/cfssl_serve.go
@@ -35,7 +35,7 @@ func registerHandlers() error {
 	}
 
 	log.Info("Setting up signer endpoint")
-	signHandler, err := api.NewSignHandler(Config.caFile, Config.caKeyFile)
+	signHandler, err := api.NewSignHandler(Config.caFile, Config.caKeyFile, Config.remote)
 	if err != nil {
 		log.Warningf("endpoint '/api/v1/cfssl/sign' is disabled: %v", err)
 	} else {
@@ -60,7 +60,7 @@ func registerHandlers() error {
 
 	log.Info("Setting up new cert endpoint")
 	newCertGenerator, err := api.NewCertGeneratorHandler(api.CSRValidate,
-		Config.caFile, Config.caKeyFile)
+		Config.caFile, Config.caKeyFile, Config.remote)
 	if err != nil {
 		log.Errorf("endpoint '/api/v1/cfssl/newcert' is disabled")
 	} else {
@@ -69,16 +69,6 @@ func registerHandlers() error {
 
 	log.Info("Setting up initial CA endpoint")
 	http.Handle("/api/v1/cfssl/init_ca", api.NewInitCAHandler())
-
-	if Config.remote != "" {
-		log.Info("Remote CFSSL endpoint given, setting up remote certificate generator")
-		rcg, err := api.NewRemoteCertGenerator(api.CSRValidate, Config.remote)
-		if err != nil {
-			log.Errorf("Failed to set up remote certificate generator: %v", err)
-			return err
-		}
-		http.Handle("/api/v1/cfssl/remotecert", rcg)
-	}
 
 	log.Info("Handler set up complete.")
 	return nil

--- a/doc/api.txt
+++ b/doc/api.txt
@@ -59,7 +59,6 @@ Parameters:
         CSR.
 
 The subject contains:
-
         * hosts: an array of strings containing DNS names and IP
         addresses that should be used as the Subject Alternative Names
         for the certificate.
@@ -218,7 +217,11 @@ Required parameters:
 Optional parameters:
 
          * profile: names the profile that should be used for the
-           the new certificate.
+         the new certificate.
+         * remote (optional): the remote CFSSL that should perform the
+         signing. This might be used, for example, to generate the key
+         on a local CFSSL instance, but use another CFSSL instance for
+         signatures.
 
 Example:
 


### PR DESCRIPTION
- CFSSL now accepts a "remote" parameter in the signature and new certificate requests. This remote parameter may specify a remote CFSSL instance to perform the signature operation. In the case of new certificate generation, the private key remains on the originating CFSSL instance.
- The "remotecert" endpoint has been removed in favour of the following approach.
- The remote argument now applies to the serve command. If supplied, both the signing API and certificate generation endpoints will automatically ship out signature requests to this remote without clients having to supply a "remote" parameter. Note that the "remote" parameter overrides this option.
