### PR TITLE
Properly marshal JSON error messages.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -140,7 +140,7 @@ func matchKeywords(blob map[string]string, keywords []string) bool {
 // ResponseMessage implements the standard for response errors and
 // messages. A message has a code and a string message.
 type ResponseMessage struct {
-	Code    int    `json:"int"`
+	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
 

--- a/api/api_bundler.go
+++ b/api/api_bundler.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/cloudflare/cfssl/bundler"
@@ -66,8 +65,5 @@ func (h *BundlerHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 		result = bundle
 	}
 	response := newSuccessResponse(result)
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	err = enc.Encode(response)
-	return err
+	return sendResponse(w, response)
 }

--- a/bundler/bundle_from_file_test.go
+++ b/bundler/bundle_from_file_test.go
@@ -93,13 +93,13 @@ var fileTests = []fileTest{
 		cert:          "not_such_cert.pem",
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":1001"),
+		errorCallback: ExpectErrorMessage("1001 - "),
 	},
 	{
 		cert:          emptyPEM,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":1002"),
+		errorCallback: ExpectErrorMessage("1002 - "),
 	},
 
 	// Normal Keyless bundling for all supported public key types
@@ -228,7 +228,7 @@ var fileTests = []fileTest{
 		cert:          leafletRSA4096,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":1220"),
+		errorCallback: ExpectErrorMessage("1220 - "),
 	},
 	// Expect TooManyIntermediates error because max path length is 1 for
 	// inter-L1 but the leaflet cert is 2 CA away from inter-L1.
@@ -237,7 +237,7 @@ var fileTests = []fileTest{
 		extraIntermediates: leafRSA4096,
 		caBundleFile:       testCFSSLRootBundle,
 		intBundleFile:      testCFSSLIntBundle,
-		errorCallback:      ExpectErrorMessage("\"code\":1213"),
+		errorCallback:      ExpectErrorMessage("1213 - "),
 	},
 	// Bundle with expired inter-L1 intermediate cert only, expect error 1211 VerifyFailed:Expired.
 	{
@@ -245,7 +245,7 @@ var fileTests = []fileTest{
 		extraIntermediates: interL1Expired,
 		caBundleFile:       testCFSSLRootBundle,
 		intBundleFile:      emptyPEM,
-		errorCallback:      ExpectErrorMessage("\"code\":1211"),
+		errorCallback:      ExpectErrorMessage("1211 - "),
 	},
 
 	// Bundle with bad partial bundle, expected error 1220: UnknownAuthority
@@ -256,7 +256,7 @@ var fileTests = []fileTest{
 		key:           leafKeyECDSA256,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":2300"),
+		errorCallback: ExpectErrorMessage("2300 - "),
 	},
 	// ECC cert, RSA private key
 	{
@@ -264,7 +264,7 @@ var fileTests = []fileTest{
 		key:           leafKeyRSA4096,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":2300"),
+		errorCallback: ExpectErrorMessage("2300 - "),
 	},
 	// RSA 2048 cert, RSA 4096  private key
 	{
@@ -272,7 +272,7 @@ var fileTests = []fileTest{
 		key:           leafKeyRSA4096,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":2300"),
+		errorCallback: ExpectErrorMessage("2300 - "),
 	},
 	// ECDSA 256 cert, ECDSA 384  private key
 	{
@@ -280,7 +280,7 @@ var fileTests = []fileTest{
 		key:           leafKeyECDSA384,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":2300"),
+		errorCallback: ExpectErrorMessage("2300 - "),
 	},
 
 	// DSA is NOT supported.
@@ -289,7 +289,7 @@ var fileTests = []fileTest{
 		cert:          certDSA2048,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":2200"),
+		errorCallback: ExpectErrorMessage("2200 - "),
 	},
 	// Bundling with DSA private key, expect error "Unknown private key"
 	{
@@ -297,7 +297,7 @@ var fileTests = []fileTest{
 		key:           keyDSA2048,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: testCFSSLIntBundle,
-		errorCallback: ExpectErrorMessage("\"code\":2003"),
+		errorCallback: ExpectErrorMessage("2003 - "),
 	},
 
 	// Smart Bundling
@@ -345,7 +345,7 @@ var fileTests = []fileTest{
 		cert:          badBundle,
 		caBundleFile:  testCFSSLRootBundle,
 		intBundleFile: interL1,
-		errorCallback: ExpectErrorMessage("\"code\":1220"),
+		errorCallback: ExpectErrorMessage("1220 - "),
 	},
 }
 

--- a/bundler/bundle_from_pem_test.go
+++ b/bundler/bundle_from_pem_test.go
@@ -32,36 +32,36 @@ var pemTests = []pemTest{
 	{
 		cert:               []byte(""),
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessage("\"code\":1002"),
+		errorCallback:      ExpectErrorMessage("1002 - "),
 	},
 	{
 		cert:               corruptCert,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessage("\"code\":1002"),
+		errorCallback:      ExpectErrorMessage("1002 - "),
 	},
 	{
 		cert:               garbageCert,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessage("\"code\":1003"),
+		errorCallback:      ExpectErrorMessage("1003 - "),
 	},
 	{
 		cert:               selfSignedCert,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessage("\"code\":1100"),
+		errorCallback:      ExpectErrorMessage("1100 - "),
 	},
 	// 121X errors are X509.CertificateInvalidError. This test
 	// covers the code path leads to all 121X errors.
 	{
 		cert:               expiredCert,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessage("\"code\":1211"),
+		errorCallback:      ExpectErrorMessage("1211 - "),
 	},
 	// With a empty root cert pool, the valid root cert
 	// is seen as issued by an unknown authority.
 	{
 		cert:               validRootCert,
 		bundlerConstructor: newBundlerWithoutRoots,
-		errorCallback:      ExpectErrorMessage("\"code\":1220"),
+		errorCallback:      ExpectErrorMessage("1220 - "),
 	},
 }
 

--- a/bundler/bundle_from_remote_test.go
+++ b/bundler/bundle_from_remote_test.go
@@ -62,22 +62,22 @@ var remoteTests = []remoteTest{
 	{
 		hostname:           SelfSignedSSLSite,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessages([]string{`"code":1220`, "x509: certificate signed by unknown authority"}),
+		errorCallback:      ExpectErrorMessages([]string{"1220 - x509: certificate signed by unknown authority"}),
 	},
 	{
 		hostname:           MismatchedHostnameSite,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessages([]string{`"code":1200`, "x509: certificate is valid for"}),
+		errorCallback:      ExpectErrorMessages([]string{"1200 - x509: certificate is valid for"}),
 	},
 	{
 		hostname:           ExpiredCertSite,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessages([]string{`"code":1211`, "x509: certificate has expired or is not yet valid"}),
+		errorCallback:      ExpectErrorMessages([]string{"1211 - x509: certificate has expired or is not yet valid"}),
 	},
 	{
 		hostname:           InvalidSite,
 		bundlerConstructor: newBundler,
-		errorCallback:      ExpectErrorMessages([]string{`"code":6000`, "dial tcp: lookup cloudflare1337.com: no such host"}),
+		errorCallback:      ExpectErrorMessages([]string{"6000 - dial tcp: lookup cloudflare1337.com: no such host"}),
 	},
 	{
 		hostname:           ValidSNI,

--- a/errors/error.go
+++ b/errors/error.go
@@ -2,7 +2,6 @@ package errors
 
 import (
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -126,11 +125,7 @@ const (
 
 // The error interface implementation, which formats to a JSON object string.
 func (e *Error) Error() string {
-	marshaled, err := json.Marshal(e)
-	if err != nil {
-		panic(err)
-	}
-	return string(marshaled)
+	return fmt.Sprintf("%d - %s", e.ErrorCode, e.Message)
 
 }
 

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -38,7 +38,7 @@ func TestErrorString(t *testing.T) {
 	msg := "Arbitrary error message"
 	err := New(CertificateError, Unknown, errors.New(msg))
 	str := err.Error()
-	if str != `{"code":1000,"message":"`+msg+`"}` {
+	if str != `1000 - `+msg {
 		t.Fatal("Incorrect Error():", str)
 	}
 }


### PR DESCRIPTION
Fixes the @toekneestuck pointed out.
