### PR TITLE
Load the configuration properly and use this for the API

### DIFF
--- a/api/api_generator.go
+++ b/api/api_generator.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/cloudflare/cfssl/api/client"
+	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
@@ -91,11 +92,11 @@ type CertGeneratorHandler struct {
 // sign the generated request. If remote is not an empty string, the
 // handler will send signature requests to the CFSSL instance contained
 // in remote.
-func NewCertGeneratorHandler(validator Validator, caFile, caKeyFile, remote string) (http.Handler, error) {
+func NewCertGeneratorHandler(validator Validator, caFile, caKeyFile, remote string, config *config.Signing) (http.Handler, error) {
 	var err error
 	log.Info("setting up new generator / signer")
 	cg := new(CertGeneratorHandler)
-	if cg.signer, err = signer.NewSigner(caFile, caKeyFile, nil); err != nil {
+	if cg.signer, err = signer.NewSigner(caFile, caKeyFile, config); err != nil {
 		return nil, err
 	}
 	cg.generator = &csr.Generator{Validator: validator}

--- a/cfssl.go
+++ b/cfssl.go
@@ -185,6 +185,10 @@ func main() {
 	args = cfsslFlagSet.Args()
 
 	Config.cfg = config.LoadFile(Config.configFile)
+	if Config.configFile != "" && Config.cfg == nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config file\n")
+		os.Exit(1)
+	}
 
 	if err := cmd.Main(args); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cfssl_serve.go
+++ b/cfssl_serve.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cloudflare/cfssl/api"
 	"github.com/cloudflare/cfssl/bundler"
+	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/ubiquity"
 )
@@ -59,8 +60,12 @@ func registerHandlers() error {
 	http.Handle("/api/v1/cfssl/newkey", generatorHandler)
 
 	log.Info("Setting up new cert endpoint")
+	var profile *config.Signing
+	if Config.cfg != nil {
+		profile = Config.cfg.Signing
+	}
 	newCertGenerator, err := api.NewCertGeneratorHandler(api.CSRValidate,
-		Config.caFile, Config.caKeyFile, Config.remote)
+		Config.caFile, Config.caKeyFile, Config.remote, profile)
 	if err != nil {
 		log.Errorf("endpoint '/api/v1/cfssl/newcert' is disabled")
 	} else {


### PR DESCRIPTION
Based on troubleshooting in conjunction with @lziest, this change causes the API to actually use the signing profiles in the API. If a configuration file is specified and it fails to load, exit with an error.
