### PR TITLE
Fix gencert -initca and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ the key request as a JSON file. This file should follow the form
 #### Generating self-signed root CA certificate and private key
 
 ```
-cfssl gencert -initca csrjson
+cfssl genkey -initca csrjson | cfssljson -bare ca
 ```
 
 To generate a self-signed root CA certificate, specify the key request as

--- a/cfssl_gencert.go
+++ b/cfssl_gencert.go
@@ -56,19 +56,18 @@ func gencertMain(args []string) (err error) {
 
 	if Config.isCA {
 		var key, cert []byte
-		if Config.caKeyFile == "" {
+		cert, err = initca.NewFromPEM(&req, Config.caKeyFile)
+		if err != nil {
+			fmt.Printf("%v\n", err)
+			fmt.Println("generating a new CA key and certificate from CSR")
 			cert, key, err = initca.New(&req)
 			if err != nil {
 				return
 			}
-			printCert(key, nil, cert)
-		} else {
-			cert, err = initca.NewFromPEM(&req, Config.caKeyFile)
-			if err != nil {
-				return
-			}
-			printCert(nil, nil, cert)
+
 		}
+		printCert(key, nil, cert)
+
 	} else {
 		if Config.remote != "" {
 			return gencertRemotely(req)


### PR DESCRIPTION
This is based on internal feedback; previously, gencert would check to see if the CA keyfile parameter was empty in determining whether to generate a new CA key and certificate. However, the parameter has a default value, and is therefore not empty in the standard use case.

This change also updates the README based on a user report.
