### PR TITLE
remove extra f

### DIFF
--- a/mkbundle/mkbundle.go
+++ b/mkbundle/mkbundle.go
@@ -131,7 +131,7 @@ func scanFiles(paths chan string) {
 	for _, path := range flag.Args() {
 		err := filepath.Walk(path, walker)
 		if err != nil {
-			log.Errorf("Walk failed: %vf", err)
+			log.Errorf("Walk failed: %v", err)
 		}
 	}
 	close(paths)


### PR DESCRIPTION
This fixes the below issue:

```
2014/10/30 05:22:45 [ERROR] Walk failed: lstat intermediates: no such file or directoryf
```
