### PR TITLE
Clean up error reporting in API

### DIFF
--- a/api/api_bundler.go
+++ b/api/api_bundler.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/cloudflare/cfssl/bundler"
-	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
 )
 
@@ -54,14 +53,14 @@ func (h *BundlerHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 		bundle, err := h.bundler.BundleFromRemote(blob["domain"], blob["ip"], bf)
 		if err != nil {
 			log.Warningf("couldn't bundle from remote: %v", err)
-			return errors.NewBadRequest(err)
+			return err
 		}
 		result = bundle
 	case "certificate":
 		bundle, err := h.bundler.BundleFromPEM([]byte(blob["certificate"]), []byte(blob["private_key"]), bf)
 		if err != nil {
 			log.Warning("bad PEM certifcate or private key")
-			return errors.NewBadRequest(err)
+			return err
 		}
 		log.Infof("request for flavour %v", flavor)
 		result = bundle

--- a/api/api_initca.go
+++ b/api/api_initca.go
@@ -40,7 +40,7 @@ func initialCAHandler(w http.ResponseWriter, r *http.Request) error {
 	key, cert, err := initca.New(req)
 	if err != nil {
 		log.Warningf("failed to initialise new CA: %v", err)
-		return errors.NewBadRequest(err)
+		return err
 	}
 
 	response := NewSuccessResponse(&NewCA{string(key), string(cert)})

--- a/api/api_signer.go
+++ b/api/api_signer.go
@@ -102,7 +102,7 @@ func (h *SignHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 	}
 	if err != nil {
 		log.Warningf("failed to sign request: %v", err)
-		return errors.NewBadRequest(err)
+		return err
 	}
 
 	result := map[string]string{"certificate": string(cert)}

--- a/api/client/api.go
+++ b/api/client/api.go
@@ -3,7 +3,7 @@ package client
 // ResponseMessage implements the standard for response errors and
 // messages. A message has a code and a string message.
 type ResponseMessage struct {
-	Code    int    `json:"int"`
+	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
 


### PR DESCRIPTION
If the error is a CFSSL error, display it in the API response with
an http 400 status.
