### PR TITLE
Fix tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 go:
-        - tip
         - 1.3
-script: go get golang.org/x/tools/cmd/vet && go get github.com/cloudflare/cfssl && go test github.com/cloudflare/cfssl/... && go vet github.com/cloudflare/cfssl/...
+script: go get code.google.com/p/go.tools/cmd/vet && go get github.com/cloudflare/cfssl && go test github.com/cloudflare/cfssl/... && go vet github.com/cloudflare/cfssl/...
 notifications:
         email:
                 recipients:

--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -175,12 +175,12 @@ func TestBundleNonKeylessMarshalJSON(t *testing.T) {
 // Test marshal to JSON on hostnames
 func TestBundleHostnamesMarshalJSON(t *testing.T) {
 	b := newBundler(t)
-	bundle, _ := b.BundleFromRemote("cloudflare.com", "", Ubiquitous)
+	bundle, _ := b.BundleFromRemote("www.cloudflare.com", "", Ubiquitous)
 	hostnames, _ := json.Marshal(bundle.Hostnames)
 	expectedOne := []byte(`["www.cloudflare.com","cloudflare.com"]`)
 	expectedTheOther := []byte(`["cloudflare.com","www.cloudflare.com"]`)
 	if !bytes.Equal(hostnames, expectedOne) && !bytes.Equal(hostnames, expectedTheOther) {
-		t.Fatal("Hostnames construction failed for cloudflare.com.")
+		t.Fatal("Hostnames construction failed for cloudflare.com.", string(hostnames))
 	}
 
 	bundle, _ = b.BundleFromPEM(validRootCert, nil, Optimal)

--- a/bundler/testdata/ca-bundle.crt.metadata
+++ b/bundler/testdata/ca-bundle.crt.metadata
@@ -1,7 +1,7 @@
 [
 {
 	"name":"Chrome Browser M39",
-	"weight": 1,
+	"weight": 0,
 	"hash_algo": "SHA2",
 	"key_algo": "ECDSA256",
 	"hash_algo_expiry":	{
@@ -12,23 +12,23 @@
 },
 {
 	"name":"Chrome Browser M40",
-	"weight": 1,
+	"weight": 0,
 	"hash_algo": "SHA2",
 	"key_algo": "ECDSA256",
 	"hash_algo_expiry":	{
 					"target": "SHA1",
-					"effective_date": "2014-11-07T00:00:00Z",
+					"effective_date": "2014-09-26T00:00:00Z",
 					"expiry_deadline": "2016-06-01T00:00:00Z"
 				}
 },
 {
 	"name":"Chrome Browser M41 and later",
-	"weight": 1,
+	"weight": 0,
 	"hash_algo": "SHA2",
 	"key_algo": "ECDSA256",
 	"hash_algo_expiry":	{
 					"target": "SHA1",
-					"effective_date": "2015-01-12T00:00:00Z",
+					"effective_date": "2014-09-26T00:00:00Z",
 					"expiry_deadline": "2016-01-01T00:00:00Z"
 				}
 },

--- a/bundler/testdata/ca.pem.metadata
+++ b/bundler/testdata/ca.pem.metadata
@@ -1,7 +1,7 @@
 [
 {
 	"name":"Chrome Browser M39",
-	"weight": 1,
+	"weight": 0,
 	"hash_algo": "SHA2",
 	"key_algo": "ECDSA256",
 	"hash_algo_expiry":	{
@@ -12,7 +12,7 @@
 },
 {
 	"name":"Chrome Browser M40",
-	"weight": 1,
+	"weight": 0,
 	"hash_algo": "SHA2",
 	"key_algo": "ECDSA256",
 	"hash_algo_expiry":	{
@@ -23,7 +23,7 @@
 },
 {
 	"name":"Chrome Browser M41",
-	"weight": 1,
+	"weight": 0,
 	"hash_algo": "SHA2",
 	"key_algo": "ECDSA256",
 	"hash_algo_expiry":	{


### PR DESCRIPTION
1. Test data tweaks: Exclude latest Chrome platforms from ubiquity selection.
2. Travis config rollback, now only test under go 1.3.
3. Tweaks on TestBundleHostnamesMarshalJSON
