### PR TITLE
Enhance the tests on bundle error message.

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -319,6 +319,26 @@ var bundleTests = []bundleTest{
 		false,
 		1003,
 	},
+
+	{
+		"",
+		testLeafKeyFile,
+		testLeafKeyFile,
+		"",
+		http.StatusBadRequest,
+		false,
+		1003,
+	},
+
+	{
+		"",
+		testLeafCertFile,
+		testLeafCertFile,
+		"",
+		http.StatusBadRequest,
+		false,
+		2003,
+	},
 }
 
 func TestBundle(t *testing.T) {
@@ -327,9 +347,6 @@ func TestBundle(t *testing.T) {
 		if resp.StatusCode != test.ExpectedHTTPStatus {
 			t.Fatalf("Test %d: expected: %d, have %d", i, test.ExpectedHTTPStatus, resp.StatusCode)
 			t.Fatal(resp.Status, test.ExpectedHTTPStatus, string(body))
-		}
-		if test.ExpectedHTTPStatus != http.StatusOK {
-			continue
 		}
 
 		message := new(Response)

--- a/errors/error.go
+++ b/errors/error.go
@@ -156,6 +156,8 @@ func New(category Category, reason Reason, err error) *Error {
 			switch reason {
 			case DecodeFailed:
 				msg = "Failed to decode certificate"
+			case ParseFailed:
+				msg = "Failed to parse certificate"
 			case SelfSigned:
 				msg = "Certificate is self signed"
 			}
@@ -169,6 +171,8 @@ func New(category Category, reason Reason, err error) *Error {
 			switch reason {
 			case DecodeFailed:
 				msg = "Failed to decode private key"
+			case ParseFailed:
+				msg = "Failed to parse private key"
 			case Encrypted:
 				msg = "Private key is encrypted"
 			case NotRSAOrECC:

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/log"
 )
 
 // OneYear is a time.Duration representing a year's worth of seconds.
@@ -121,7 +122,7 @@ func ParseCertificatesPEM(certsPEM []byte) ([]*x509.Certificate, error) {
 		var cert *x509.Certificate
 		cert, certsPEM, err = ParseOneCertificateFromPEM(certsPEM)
 		if err != nil {
-			return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, err)
+			return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, nil)
 		} else if cert == nil {
 			break
 		}
@@ -151,7 +152,9 @@ func ParseCertificatePEM(certPEM []byte) (*x509.Certificate, error) {
 	certPEM = bytes.TrimSpace(certPEM)
 	cert, rest, err := ParseOneCertificateFromPEM(certPEM)
 	if err != nil {
-		return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, err)
+		// Log the actual parsing error but throw a default parse error message.
+		log.Debugf("Certificate parsing error: %v", err)
+		return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, nil)
 	} else if cert == nil {
 		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed, nil)
 	} else if len(rest) > 0 {


### PR DESCRIPTION
Hide the actual certificate ASN1 parsing errors and throw a
human readable one.
