### PR TITLE
Add authentication module

### DIFF
--- a/api/api_signer.go
+++ b/api/api_signer.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/cloudflare/cfssl/api/client"
+	"github.com/cloudflare/cfssl/auth"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
@@ -18,20 +19,30 @@ import (
 // profile name.
 type SignHandler struct {
 	signer signer.Signer
+	server *client.Server
 }
 
 // NewSignHandler generates a new SignHandler using the certificate
 // authority private key and certficate to sign certificates. If remote
 // is not an empty string, the handler will send signature requests to
 // the CFSSL instance contained in remote by default.
-func NewSignHandler(caFile, cakeyFile string, policy *config.Signing) (http.Handler, error) {
+func NewSignHandler(caFile, cakeyFile string, remote string, policy *config.Signing) (http.Handler, error) {
 	var err error
 	s := new(SignHandler)
 
 	if s.signer, err = signer.NewSigner(caFile, cakeyFile, policy); err != nil {
-		log.Errorf("setting up signer failed: %v", err)
-		return nil, err
+		if remote == "" {
+			log.Errorf("setting up signer failed: %v", err)
+			return nil, err
+		}
+		s.signer = nil
+		log.Infof("remote signer activated")
 	}
+
+	if remote != "" {
+		s.server = client.NewServer(remote)
+	}
+
 	return HTTPHandler{s, "POST"}, nil
 }
 
@@ -53,9 +64,7 @@ type SignRequest struct {
 	Request  string          `json:"certificate_request"`
 	Subject  *signer.Subject `json:"subject,omitempty"`
 	Profile  string          `json:"profile"`
-	Remote   string          `json:"remote"`
-
-	AuthKey *config.AuthKey
+	Label    string          `json:"label"`
 }
 
 // Handle responds to requests for the CA to sign the certificate request
@@ -87,16 +96,185 @@ func (h *SignHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var cert []byte
-	if req.Remote != "" {
-		log.Info("sending signature request to remote", req.Remote)
-		srv := client.NewServer(req.Remote)
-		cert, err = srv.Sign(req.Hostname, []byte(req.Request), req.Profile)
+	var profile *config.SigningProfile
+
+	policy := h.signer.Policy()
+	if policy != nil && policy.Profiles != nil && req.Profile != "" {
+		profile = policy.Profiles[req.Profile]
+	}
+
+	if profile == nil && policy != nil {
+		profile = policy.Default
+	}
+
+	// Signing priorities: the first match wins.
+	// 1. If the profile specifies a remote, that overrides any
+	// global remote.
+	// 2. If CFSSL was configured with a remote on the command line,
+	// CFSSL will make a remote signature request.
+	// 3. Finally, CFSSL will sign the certificate itself.
+	if profile != nil && profile.Remote != nil {
+		if profile.Provider != nil {
+			cert, err = h.handleAuthSign(w, &req, profile)
+		} else {
+			cert, err = profile.Remote.Sign(req.Hostname, []byte(req.Request), req.Profile, req.Label)
+		}
+	} else if h.server != nil {
+		if profile != nil && profile.Provider != nil {
+			cert, err = h.handleAuthSign(w, &req, profile)
+		} else {
+			cert, err = h.server.Sign(req.Hostname, []byte(req.Request), req.Profile, req.Label)
+		}
 	} else {
 		cert, err = h.signer.Sign(req.Hostname, []byte(req.Request), req.Subject, req.Profile)
 	}
 
 	if err != nil {
 		log.Warningf("failed to sign request: %v", err)
+		return err
+	}
+
+	result := map[string]string{"certificate": string(cert)}
+	log.Info("wrote response")
+	return sendResponse(w, result)
+}
+
+// handleAuthSign takes care of packaging the request and sending it
+// off to the authenticated signing endpoint.
+func (h *SignHandler) handleAuthSign(w http.ResponseWriter, req *SignRequest, profile *config.SigningProfile) ([]byte, error) {
+	if req == nil || profile == nil {
+		return nil, errors.NewBadRequestString("invalid parameters to authsign")
+	}
+
+	server := profile.Remote
+	if server == nil {
+		server = h.server
+	}
+
+	if server == nil {
+		return nil, errors.NewBadRequestString("no remote server could be used")
+	}
+
+	request := map[string]string{
+		"certificate_request": req.Request,
+		"hostname":            req.Hostname,
+		"profile":             req.Profile,
+		"label":               req.Label,
+	}
+
+	jsonOut, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// AuthSign supports setting the ID, but this isn't used with
+	// most providers.
+	return server.AuthSign(jsonOut, nil, req.Profile, profile.Provider)
+}
+
+// An AuthSignHandler verifies and signs incoming signature requests.
+type AuthSignHandler struct {
+	signer signer.Signer
+}
+
+// NewAuthSignHandler creates a new AuthSignHandler from the signer
+// that is passed in.
+func NewAuthSignHandler(signer signer.Signer) (http.Handler, error) {
+	policy := signer.Policy()
+	if policy == nil {
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy, nil)
+	}
+
+	if policy.Default == nil && policy.Profiles == nil {
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy, nil)
+	}
+
+	// If not every profile has an auth provider, the
+	// configuration for this endpoint is invalid. We start the
+	// check with the initial value that indicates the presence of
+	// a default authentication provider.
+	var hasProviders = (policy.Default.Provider != nil)
+	for _, profile := range policy.Profiles {
+		// A single profile without a provider will cause hasProviders to be false.
+		hasProviders = hasProviders && (profile.Provider != nil)
+	}
+
+	if !hasProviders {
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy, nil)
+	}
+
+	return &HTTPHandler{
+		&AuthSignHandler{
+			signer: signer,
+		},
+		"POST",
+	}, nil
+}
+
+// Handle receives the incoming request, validates it, and processes it.
+func (h *AuthSignHandler) Handle(w http.ResponseWriter, r *http.Request) error {
+	log.Info("signature request received")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Errorf("failed to read response body: %v", err)
+		return err
+	}
+	r.Body.Close()
+
+	var aReq auth.AuthenticatedRequest
+	err = json.Unmarshal(body, &aReq)
+	if err != nil {
+		log.Errorf("failed to unmarshal authenticated request: %v", err)
+		return errors.NewBadRequest(err)
+	}
+
+	var req SignRequest
+	err = json.Unmarshal(aReq.Request, &req)
+	if err != nil {
+		log.Errorf("failed to unmarshal request from authenticated request: %v", err)
+		return errors.NewBadRequest(err)
+	}
+
+	// Sanity checks to ensure that we have a valid policy. This
+	// should have been checked in NewAuthSignHandler.
+	policy := h.signer.Policy()
+	if policy == nil {
+		log.Critical("signer was initialised without a signing policy")
+		return errors.NewBadRequestString("invalid policy")
+	}
+	profile := policy.Default
+
+	if policy.Profiles != nil {
+		profile = policy.Profiles[req.Profile]
+	}
+
+	if profile == nil {
+		log.Critical("signer was initialised without any valid profiles")
+		return errors.NewBadRequestString("invalid profile")
+	}
+
+	if profile.Provider == nil {
+		log.Error("profile has no authentication provider")
+		return errors.NewBadRequestString("no authentication provider")
+	}
+
+	if !profile.Provider.Verify(&aReq) {
+		log.Warning("received authenticated request with invalid token")
+		return errors.NewBadRequestString("invalid token")
+	}
+
+	if req.Hostname == "" {
+		return errors.NewBadRequestString("missing hostname parameter")
+	}
+
+	if req.Request == "" {
+		return errors.NewBadRequestString("missing certificate_request parameter")
+	}
+
+	cert, err := h.signer.Sign(req.Hostname, []byte(req.Request), req.Subject, req.Profile)
+	if err != nil {
+		log.Errorf("signature failed: %v", err)
 		return err
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 func newTestSignHandler(t *testing.T) (h http.Handler) {
-	h, err := NewSignHandler(testCaFile, testCaKeyFile, "")
+	h, err := NewSignHandler(testCaFile, testCaKeyFile, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestNewSignHandler(t *testing.T) {
 }
 
 func TestNewSignHandlerError(t *testing.T) {
-	_, err := NewSignHandler(testCaFile, testBrokenCSRFile, "")
+	_, err := NewSignHandler(testCaFile, testBrokenCSRFile, "", nil)
 	if err == nil {
 		t.Fatal("Expect error when create a signer with broken file.")
 	}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3,14 +3,16 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
+	stderr "errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/cloudflare/cfssl/auth"
+	"github.com/cloudflare/cfssl/errors"
 )
 
 // A Server points to a remote CFSSL instance.
@@ -19,6 +21,9 @@ type Server struct {
 	Port    int
 }
 
+// NewServer sets up a new server target. The address should be the
+// DNS name (or "name:port") of the remote CFSSL instance. If no port
+// is specified, the CFSSL default port (8888) is used.
 func NewServer(addr string) *Server {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -45,51 +50,97 @@ func (srv *Server) getURL(endpoint string) string {
 	return fmt.Sprintf("http://%s:%d/api/v1/cfssl/%s", srv.Address, srv.Port, endpoint)
 }
 
-func (srv *Server) AuthSign(hostname string, csr []byte, profileName string, provider auth.Provider) ([]byte, error) {
-	req, err := srv.Sign(hostname, csr, profileName)
-	if err != nil {
-		return nil, err
-	}
-	return provider.Token(req)
-}
+// AuthSign fills out an authenticated request to the server,
+// receiving a certificate or error in response.
+func (srv *Server) AuthSign(req, ID []byte, profileName string, provider auth.Provider) ([]byte, error) {
+	url := srv.getURL("authsign")
 
-// Sign sends a signature request to the remote CFSSL server,
-// receiving a signed certificate or an error in response.
-func (srv *Server) Sign(hostname string, csr []byte, profileName string) ([]byte, error) {
-	url := srv.getURL("sign")
-	var request = map[string]string{
-		"certificate_request": string(csr),
-		"hostname":            hostname,
-		"profile":             profileName,
+	token, err := provider.Token(req)
+	if err != nil {
+		return nil, errors.New(errors.APIClientError, errors.AuthenticationFailure, err)
 	}
 
-	jsonData, err := json.Marshal(request)
+	aReq := &auth.AuthenticatedRequest{
+		Timestamp:     time.Now().Unix(),
+		RemoteAddress: ID,
+		Token:         token,
+		Request:       req,
+	}
+
+	jsonData, err := json.Marshal(aReq)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
 	}
 
 	buf := bytes.NewBuffer(jsonData)
 	resp, err := http.Post(url, "application/json", buf)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(errors.APIClientError, errors.ClientHTTPError, err)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(errors.APIClientError, errors.IOError, err)
 	}
 	resp.Body.Close()
 
 	var response Response
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
 	}
 
 	if !response.Success || response.Result == nil {
 		if len(response.Errors) > 0 {
-			return nil, errors.New(response.Errors[0].Message)
+			return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, stderr.New(response.Errors[0].Message))
 		}
-		return nil, errors.New("API response was not successful")
+		return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, nil)
+	}
+	result := response.Result.(map[string]interface{})
+	cert := result["certificate"].(string)
+
+	return []byte(cert), nil
+}
+
+// Sign sends a signature request to the remote CFSSL server,
+// receiving a signed certificate or an error in response. The hostname,
+// csr, and profileName are used as with a local signing operation, and
+// the label is used to select a signing root in a multi-root CA.
+func (srv *Server) Sign(hostname string, csr []byte, profileName, label string) ([]byte, error) {
+	url := srv.getURL("sign")
+	var request = map[string]string{
+		"certificate_request": string(csr),
+		"hostname":            hostname,
+		"profile":             profileName,
+		"label":               label,
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
+	}
+
+	buf := bytes.NewBuffer(jsonData)
+	resp, err := http.Post(url, "application/json", buf)
+	if err != nil {
+		return nil, errors.New(errors.APIClientError, errors.ClientHTTPError, err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.New(errors.APIClientError, errors.IOError, err)
+	}
+	resp.Body.Close()
+
+	var response Response
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
+	}
+
+	if !response.Success || response.Result == nil {
+		if len(response.Errors) > 0 {
+			return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, stderr.New(response.Errors[0].Message))
+		}
+		return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, nil)
 	}
 	result := response.Result.(map[string]interface{})
 	cert := result["certificate"].(string)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+
+	"github.com/cloudflare/cfssl/auth"
 )
 
 // A Server points to a remote CFSSL instance.
@@ -41,6 +43,14 @@ func NewServer(addr string) *Server {
 
 func (srv *Server) getURL(endpoint string) string {
 	return fmt.Sprintf("http://%s:%d/api/v1/cfssl/%s", srv.Address, srv.Port, endpoint)
+}
+
+func (srv *Server) AuthSign(hostname string, csr []byte, profileName string, provider auth.Provider) ([]byte, error) {
+	req, err := srv.Sign(hostname, csr, profileName)
+	if err != nil {
+		return nil, err
+	}
+	return provider.Token(req)
 }
 
 // Sign sends a signature request to the remote CFSSL server,

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -52,7 +52,7 @@ func New(key string, ad []byte) (*Standard, error) {
 }
 
 // Token generates a new authentication token from the request.
-func (p *Standard) Token(req []byte) (token []byte, err error) {
+func (p Standard) Token(req []byte) (token []byte, err error) {
 	h := hmac.New(sha256.New, p.key)
 	h.Write(req)
 	h.Write(p.ad)
@@ -60,7 +60,7 @@ func (p *Standard) Token(req []byte) (token []byte, err error) {
 }
 
 // Verify determines whether an authenticated request is valid.
-func (p *Standard) Verify(ad *AuthenticatedRequest) bool {
+func (p Standard) Verify(ad *AuthenticatedRequest) bool {
 	if ad == nil {
 		return false
 	}

--- a/cfssl_gencert.go
+++ b/cfssl_gencert.go
@@ -151,7 +151,7 @@ func gencertRemotely(req csr.CertificateRequest) error {
 	}
 
 	var cert []byte
-	cert, err = srv.Sign(Config.hostname, csrPEM, Config.profile)
+	cert, err = srv.Sign(Config.hostname, csrPEM, Config.profile, "")
 	if err != nil {
 		return err
 	}

--- a/cfssl_serve.go
+++ b/cfssl_serve.go
@@ -40,7 +40,7 @@ func registerHandlers() error {
 	if Config.cfg != nil {
 		signConfig = Config.cfg.Signing
 	}
-	signHandler, err := api.NewSignHandler(Config.caFile, Config.caKeyFile, signConfig)
+	signHandler, err := api.NewSignHandler(Config.caFile, Config.caKeyFile, Config.remote, signConfig)
 	if err != nil {
 		log.Warningf("endpoint '/api/v1/cfssl/sign' is disabled: %v", err)
 	} else {

--- a/cfssl_serve.go
+++ b/cfssl_serve.go
@@ -36,7 +36,11 @@ func registerHandlers() error {
 	}
 
 	log.Info("Setting up signer endpoint")
-	signHandler, err := api.NewSignHandler(Config.caFile, Config.caKeyFile, Config.remote)
+	var signConfig *config.Signing = nil
+	if Config.cfg != nil {
+		signConfig = Config.cfg.Signing
+	}
+	signHandler, err := api.NewSignHandler(Config.caFile, Config.caKeyFile, signConfig)
 	if err != nil {
 		log.Warningf("endpoint '/api/v1/cfssl/sign' is disabled: %v", err)
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/cloudflare/cfssl/api/client"
+	"github.com/cloudflare/cfssl/auth"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"
 )
@@ -18,18 +20,29 @@ type SigningProfile struct {
 	IssuerURL    []string `json:"issuer_urls"`
 	OCSP         string   `json:"ocsp_url"`
 	CRL          string   `json:"crl_url"`
-	ExpiryString string   `json:"expiry"`
 	CA           bool     `json:"is_ca"`
-	Expiry       time.Duration
+	ExpiryString string   `json:"expiry"`
+	AuthKeyName  string   `json:"auth_key"`
+	RemoteName   string   `json:"remote"`
+
+	Expiry   time.Duration
+	Provider auth.Provider
+	Remote   *client.Server
 }
 
-// parse, and the ExpiryString parameter, are needed to parse
+// populate is used to fill in the fields that are not in JSON
+//
+// First, the ExpiryString parameter is needed to parse
 // expiration timestamps from JSON. The JSON decoder is not able to
 // decode a string time duration to a time.Duration, so this is called
 // when loading the configuration to properly parse and fill out the
-// Expiry parameter. It returns true if there was a valid string
-// representation of a time.Duration, and false if an error occurred.
-func (p *SigningProfile) parse() bool {
+// Expiry parameter.
+// This function is also used to create references to the auth key
+// and default remote for the profile.
+// It returns true if ExpiryString is a valid representation of a
+// time.Duration, and the AuthKeyString and hkoteName point to
+// valid objects. It returns false otherwise.
+func (p *SigningProfile) populate(cfg *Config) bool {
 	log.Debugf("parse expiry in profile")
 	if p == nil {
 		log.Debugf("failed: no timestamp in profile")
@@ -47,6 +60,38 @@ func (p *SigningProfile) parse() bool {
 
 	log.Debugf("expiry is valid")
 	p.Expiry = dur
+
+	if p.AuthKeyName != "" {
+		if key, ok := cfg.AuthKeys[p.AuthKeyName]; ok == true {
+			if key.Type == "standard" {
+				p.Provider, err = auth.New(key.Key, nil)
+				if err != nil {
+					log.Debugf("failed to create new stanard auth provider: %v", err)
+					return false
+				}
+			} else {
+				log.Debugf("unknown authentication type %v", key.Type)
+				return false
+			}
+		} else {
+			log.Debugf("failed to find auth_key %v in auth_keys section", p.AuthKeyName)
+			return false
+		}
+	}
+
+	if p.RemoteName != "" {
+		if remote := cfg.Remotes[p.RemoteName]; remote != "" {
+			p.Remote = client.NewServer(remote)
+			if p.Remote == nil {
+				log.Debugf("failed to connect to remote %v", remote)
+				return false
+			}
+		} else {
+			log.Debugf("failed to find remote %v in remotes section %v", p.RemoteName, cfg)
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -97,7 +142,8 @@ type Signing struct {
 // Config stores configuration information for the CA.
 type Config struct {
 	Signing  *Signing           `json:"signing"`
-	AuthKeys map[string]AuthKey `json:"auth_key,omitempty"`
+	AuthKeys map[string]AuthKey `json:"auth_keys,omitempty"`
+	Remotes  map[string]string  `json:"remotes,omitempty"`
 }
 
 // Valid ensures that Config is a valid configuration. It should be
@@ -163,10 +209,10 @@ type AuthKey struct {
 	// constructor. For example, "standard" for HMAC-SHA-256,
 	// "standard-ip" for HMAC-SHA-256 incorporating the client's
 	// IP.
-	Type string
+	Type string `json:"type"`
 	// Key contains the key information, such as a hex-encoded
 	// HMAC key.
-	Key string
+	Key string `json:"key"`
 }
 
 // DefaultConfig returns a default configuration specifying basic key
@@ -206,7 +252,7 @@ func LoadFile(path string) *Config {
 		log.Debugf("no default given: using default config")
 		cfg.Signing.Default = DefaultConfig()
 	} else {
-		if !cfg.Signing.Default.parse() {
+		if !cfg.Signing.Default.populate(cfg) {
 			return nil
 		}
 	}
@@ -216,7 +262,7 @@ func LoadFile(path string) *Config {
 	}
 
 	for k := range cfg.Signing.Profiles {
-		if !cfg.Signing.Profiles[k].parse() {
+		if !cfg.Signing.Profiles[k].populate(cfg) {
 			return nil
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ type SigningProfile struct {
 // This function is also used to create references to the auth key
 // and default remote for the profile.
 // It returns true if ExpiryString is a valid representation of a
-// time.Duration, and the AuthKeyString and hkoteName point to
+// time.Duration, and the AuthKeyString and RemoteName point to
 // valid objects. It returns false otherwise.
 func (p *SigningProfile) populate(cfg *Config) bool {
 	log.Debugf("parse expiry in profile")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -92,6 +92,7 @@ func TestValidConfig(t *testing.T) {
 	bytes, _ := json.Marshal(validConfig)
 	fmt.Printf("%v", string(bytes))
 }
+
 func TestDefaultConfig(t *testing.T) {
 	if !DefaultConfig().validProfile(false) {
 		t.Fatal("global default signing profile should be a valid profile.")
@@ -132,13 +133,13 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, p := range validProfiles {
-		if !p.parse() {
+		if !p.populate(nil) {
 			t.Fatalf("Failed to parse ExpiryString=%s", p.ExpiryString)
 		}
 	}
 
 	for _, p := range invalidProfiles {
-		if p.parse() {
+		if p.populate(nil) {
 			if p != nil {
 				t.Fatalf("ExpiryString=%s should not be parseable", p.ExpiryString)
 			}
@@ -148,7 +149,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestLoadFile(t *testing.T) {
-	validConfigFiles := []string{"testdata/valid_config.json", "testdata/valid_config_no_default.json"}
+	validConfigFiles := []string{"testdata/valid_config.json", "testdata/valid_config_auth.json", "testdata/valid_config_no_default.json"}
 	for _, configFile := range validConfigFiles {
 		config := LoadFile(configFile)
 		if config == nil {
@@ -162,7 +163,9 @@ func TestLoadInvalidConfigFile(t *testing.T) {
 		"testdata/invalid_default.json",
 		"testdata/invalid_profiles.json",
 		"testdata/invalid_usage.json",
-		"testdata/invalid_config.json"}
+		"testdata/invalid_config.json",
+		"testdata/invalid_auth.json",
+		"testdata/invalid_remote.json"}
 	for _, configFile := range invalidConfigFiles {
 		config := LoadFile(configFile)
 		if config != nil {

--- a/config/testdata/invalid_auth.json
+++ b/config/testdata/invalid_auth.json
@@ -3,7 +3,9 @@
 		"profiles": {
 			"CA": {
 				"usages": ["cert sign"],
-				"expiry": "720h"
+				"expiry": "720h",
+				"auth_key": "garbage"
+				"remote": "localhost",
 			},
 			"email": {
 				"usages": ["s/mime"],
@@ -15,10 +17,13 @@
 			"expiry": "8000h"
 		}
 	},
-	"auth_key": {
+	"auth_keys": {
 		"garbage": {
-			"type":"standard",
+			"type":"stadardo",
 			"key":"0123456789ABCDEF0123456789ABCDEF"
 		}
+	},
+	"remotes": {
+		"localhost": "127.0.0.1:8888"
 	}
 }

--- a/config/testdata/invalid_auth.json
+++ b/config/testdata/invalid_auth.json
@@ -4,8 +4,8 @@
 			"CA": {
 				"usages": ["cert sign"],
 				"expiry": "720h",
-				"auth_key": "garbage"
 				"remote": "localhost",
+				"auth_key": "garbage"
 			},
 			"email": {
 				"usages": ["s/mime"],

--- a/config/testdata/invalid_remotes.json
+++ b/config/testdata/invalid_remotes.json
@@ -3,7 +3,9 @@
 		"profiles": {
 			"CA": {
 				"usages": ["cert sign"],
-				"expiry": "720h"
+				"expiry": "720h",
+				"auth_key": "garbage",
+				"remote": "localhoster"
 			},
 			"email": {
 				"usages": ["s/mime"],
@@ -15,10 +17,13 @@
 			"expiry": "8000h"
 		}
 	},
-	"auth_key": {
+	"auth_keys": {
 		"garbage": {
 			"type":"standard",
 			"key":"0123456789ABCDEF0123456789ABCDEF"
 		}
+	},
+	"remotes": {
+		"localhost": "127.0.0.1:8888"
 	}
 }

--- a/config/testdata/valid_config_auth.json
+++ b/config/testdata/valid_config_auth.json
@@ -3,7 +3,9 @@
 		"profiles": {
 			"CA": {
 				"usages": ["cert sign"],
-				"expiry": "720h"
+				"expiry": "720h",
+				"auth_key": "garbage",
+				"remote": "localhost"
 			},
 			"email": {
 				"usages": ["s/mime"],
@@ -15,10 +17,13 @@
 			"expiry": "8000h"
 		}
 	},
-	"auth_key": {
+	"auth_keys": {
 		"garbage": {
 			"type":"standard",
 			"key":"0123456789ABCDEF0123456789ABCDEF"
 		}
+	},
+	"remotes": {
+		"localhost": "127.0.0.1:8888"
 	}
 }


### PR DESCRIPTION
This PR adds support for an authenticated signing endpoint and a default HMAC authentication provider. This extends the work originally done by @grittygrease.