### PR TITLE
New feature of API 'bundle': verify bundle against input domain and/or ip

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -132,6 +132,25 @@ func ProcessRequestOneOf(r *http.Request, keywordSets [][]string) (map[string]st
 	return blob, matched, nil
 }
 
+// ProcessRequestFirstMatchOf reads a JSON blob for the request and returns
+// the first match of a set of keywords. For example, a request
+// might have one of the following combinations: (foo=1, bar=2), (foo=1), and (bar=2)
+// By giving a specific ordering of those combinations, we could decide how to accept
+// the request.
+func ProcessRequestFirstMatchOf(r *http.Request, keywordSets [][]string) (map[string]string, []string, error) {
+	blob, err := readRequestBlob(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, set := range keywordSets {
+		if matchKeywords(blob, set) {
+			return blob, set, nil
+		}
+	}
+	return nil, nil, errors.NewBadRequestString("no valid parameter sets found")
+}
+
 func missingParamsError(missing []string) error {
 	s := "Missing parameter"
 	if len(missing) > 1 {

--- a/doc/api.txt
+++ b/doc/api.txt
@@ -79,14 +79,15 @@ Endpoint: "/api/v1/cfssl/bundle"
 Method: POST
 Required Parameters:
 
-        One of the following two parameters is required; if both are
-        present, the result is undefined.
+        One of the following two parameters is required; If both are
+        present, "domain" becomes one of optional parameters with
+        "certificate", read on for details.
 
         * certificate: the PEM-encoded certificate to be bundled.
         * domain: a domain name indicating a remote host to retrieve a
           certificate for.
 
-        If the "certificate" parameter is present, the following two
+        If the "certificate" parameter is present, the following four
         parameters are valid:
 
         * private_key: the PEM-encoded private key to be included with
@@ -96,9 +97,12 @@ Required Parameters:
         value of "ubiquitous". A ubiquitous bundle is one that has a
         higher probability of being verified everywhere, even by
         clients using outdated or unusual trust stores.
+        * domain: the domain name to verify as the hostname of the
+        certificate.
+        * ip: the IP address to verify against the certificate IP SANs
 
-        If the "domain" parameter is present, the following parameter
-        is valid:
+        If only the "domain" parameter is present, the following
+        parameter is valid:
 
         * ip: the IP address of the remote host as an alternative to
         domain.


### PR DESCRIPTION

- Also replace Dial() with DialWithDialer() in bundler.BundleFromRemote,
  so we can have a much shorter connection timeout.
- Improve the api 'bundle' test readability
- Enable some unit tests on BundleFromRemote. Keep a separate set of SNI
  tests disabled by default.