### PR TITLE
refactor func errors.New()

### DIFF
--- a/api/api_bundler.go
+++ b/api/api_bundler.go
@@ -71,7 +71,7 @@ func (h *BundlerHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 		if serverName != "" {
 			err := bundle.Cert.VerifyHostname(serverName)
 			if err != nil {
-				return errors.New(errors.CertificateError, errors.VerifyFailed, err)
+				return errors.Wrap(errors.CertificateError, errors.VerifyFailed, err)
 			}
 
 		}
@@ -79,7 +79,7 @@ func (h *BundlerHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 		if ip != "" {
 			err := bundle.Cert.VerifyHostname(ip)
 			if err != nil {
-				return errors.New(errors.CertificateError, errors.VerifyFailed, err)
+				return errors.Wrap(errors.CertificateError, errors.VerifyFailed, err)
 			}
 		}
 

--- a/api/api_generator.go
+++ b/api/api_generator.go
@@ -168,7 +168,7 @@ func NewCertGeneratorHandler(validator Validator, caFile, caKeyFile, remote stri
 	if remote != "" {
 		cg.server = client.NewServer(remote)
 		if cg.server == nil {
-			return nil, errors.New(errors.DialError, errors.None, nil)
+			return nil, errors.New(errors.DialError, errors.None)
 		}
 	}
 

--- a/api/api_signer.go
+++ b/api/api_signer.go
@@ -36,11 +36,14 @@ func NewSignHandler(caFile, cakeyFile string, remote string, policy *config.Sign
 			return nil, err
 		}
 		s.signer = nil
-		log.Infof("remote signer activated")
 	}
 
 	if remote != "" {
 		s.server = client.NewServer(remote)
+		if s.server == nil {
+			return nil, errors.New(errors.DialError, errors.None)
+		}
+		log.Infof("remote signer activated")
 	}
 
 	return HTTPHandler{s, "POST"}, nil
@@ -182,11 +185,11 @@ type AuthSignHandler struct {
 func NewAuthSignHandler(signer signer.Signer) (http.Handler, error) {
 	policy := signer.Policy()
 	if policy == nil {
-		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy, nil)
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
 	}
 
 	if policy.Default == nil && policy.Profiles == nil {
-		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy, nil)
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
 	}
 
 	// If not every profile has an auth provider, the
@@ -200,7 +203,7 @@ func NewAuthSignHandler(signer signer.Signer) (http.Handler, error) {
 	}
 
 	if !hasProviders {
-		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy, nil)
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
 	}
 
 	return &HTTPHandler{

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -57,7 +57,7 @@ func (srv *Server) AuthSign(req, ID []byte, profileName string, provider auth.Pr
 
 	token, err := provider.Token(req)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.AuthenticationFailure, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.AuthenticationFailure, err)
 	}
 
 	aReq := &auth.AuthenticatedRequest{
@@ -69,31 +69,31 @@ func (srv *Server) AuthSign(req, ID []byte, profileName string, provider auth.Pr
 
 	jsonData, err := json.Marshal(aReq)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.JSONError, err)
 	}
 
 	buf := bytes.NewBuffer(jsonData)
 	resp, err := http.Post(url, "application/json", buf)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.ClientHTTPError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.ClientHTTPError, err)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.IOError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.IOError, err)
 	}
 	resp.Body.Close()
 
 	var response Response
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.JSONError, err)
 	}
 
 	if !response.Success || response.Result == nil {
 		if len(response.Errors) > 0 {
-			return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, stderr.New(response.Errors[0].Message))
+			return nil, errors.Wrap(errors.APIClientError, errors.ServerRequestFailed, stderr.New(response.Errors[0].Message))
 		}
-		return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, nil)
+		return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed)
 	}
 	result := response.Result.(map[string]interface{})
 	cert := result["certificate"].(string)
@@ -116,31 +116,31 @@ func (srv *Server) Sign(hostname string, csr []byte, profileName, label string) 
 
 	jsonData, err := json.Marshal(request)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.JSONError, err)
 	}
 
 	buf := bytes.NewBuffer(jsonData)
 	resp, err := http.Post(url, "application/json", buf)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.ClientHTTPError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.ClientHTTPError, err)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.IOError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.IOError, err)
 	}
 	resp.Body.Close()
 
 	var response Response
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return nil, errors.New(errors.APIClientError, errors.JSONError, err)
+		return nil, errors.Wrap(errors.APIClientError, errors.JSONError, err)
 	}
 
 	if !response.Success || response.Result == nil {
 		if len(response.Errors) > 0 {
-			return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, stderr.New(response.Errors[0].Message))
+			return nil, errors.Wrap(errors.APIClientError, errors.ServerRequestFailed, stderr.New(response.Errors[0].Message))
 		}
-		return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed, nil)
+		return nil, errors.New(errors.APIClientError, errors.ServerRequestFailed)
 	}
 	result := response.Result.(map[string]interface{})
 	cert := result["certificate"].(string)

--- a/cfssl_genkey.go
+++ b/cfssl_genkey.go
@@ -90,7 +90,7 @@ func genkeyMain(args []string) (err error) {
 
 func validator(req *csr.CertificateRequest) error {
 	if len(req.Hosts) == 0 {
-		return cferr.New(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing hosts field"))
+		return cferr.Wrap(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing hosts field"))
 	}
 	return nil
 }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -6,9 +6,22 @@ import (
 	"testing"
 )
 
-func TestNew(t *testing.T) {
+func testNew(t *testing.T) {
+	err := New(CertificateError, Unknown)
+	if err == nil {
+		t.Fatal("Error creation failed.")
+	}
+	if err.ErrorCode != int(CertificateError)+int(Unknown) {
+		t.Fatal("Error code construction failed.")
+	}
+	if err.Message != "Unknown certificate error" {
+		t.Fatal("Error message construction failed.")
+	}
+}
+
+func TestWrap(t *testing.T) {
 	msg := "Arbitrary error message"
-	err := New(CertificateError, Unknown, errors.New(msg))
+	err := Wrap(CertificateError, Unknown, errors.New(msg))
 	if err == nil {
 		t.Fatal("Error creation failed.")
 	}
@@ -22,7 +35,7 @@ func TestNew(t *testing.T) {
 
 func TestMarshal(t *testing.T) {
 	msg := "Arbitrary error message"
-	err := New(CertificateError, Unknown, errors.New(msg))
+	err := Wrap(CertificateError, Unknown, errors.New(msg))
 	bytes, _ := json.Marshal(err)
 	var received Error
 	json.Unmarshal(bytes, &received)
@@ -36,7 +49,7 @@ func TestMarshal(t *testing.T) {
 
 func TestErrorString(t *testing.T) {
 	msg := "Arbitrary error message"
-	err := New(CertificateError, Unknown, errors.New(msg))
+	err := Wrap(CertificateError, Unknown, errors.New(msg))
 	str := err.Error()
 	if str != `{"code":1000,"message":"`+msg+`"}` {
 		t.Fatal("Incorrect Error():", str)

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -122,7 +122,7 @@ func ParseCertificatesPEM(certsPEM []byte) ([]*x509.Certificate, error) {
 		var cert *x509.Certificate
 		cert, certsPEM, err = ParseOneCertificateFromPEM(certsPEM)
 		if err != nil {
-			return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, nil)
+			return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed)
 		} else if cert == nil {
 			break
 		}
@@ -130,7 +130,7 @@ func ParseCertificatesPEM(certsPEM []byte) ([]*x509.Certificate, error) {
 		certs = append(certs, cert)
 	}
 	if len(certsPEM) > 0 {
-		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed, nil)
+		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed)
 	}
 	return certs, nil
 }
@@ -142,7 +142,7 @@ func ParseSelfSignedCertificatePEM(certPEM []byte) (*x509.Certificate, error) {
 		return nil, err
 	}
 	if err := cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature); err != nil {
-		return nil, cferr.New(cferr.CertificateError, cferr.VerifyFailed, err)
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.VerifyFailed, err)
 	}
 	return cert, nil
 }
@@ -154,11 +154,11 @@ func ParseCertificatePEM(certPEM []byte) (*x509.Certificate, error) {
 	if err != nil {
 		// Log the actual parsing error but throw a default parse error message.
 		log.Debugf("Certificate parsing error: %v", err)
-		return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, nil)
+		return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed)
 	} else if cert == nil {
-		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed, nil)
+		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed)
 	} else if len(rest) > 0 {
-		return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed, errors.New("The PEM file should contain only one certificate."))
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, errors.New("The PEM file should contain only one certificate."))
 	}
 	return cert, nil
 }
@@ -183,11 +183,11 @@ func ParseOneCertificateFromPEM(certsPEM []byte) (cert *x509.Certificate, rest [
 func ParsePrivateKeyPEM(keyPEM []byte) (key interface{}, err error) {
 	keyDER, _ := pem.Decode(keyPEM)
 	if keyDER == nil {
-		return nil, cferr.New(cferr.PrivateKeyError, cferr.DecodeFailed, nil)
+		return nil, cferr.New(cferr.PrivateKeyError, cferr.DecodeFailed)
 	}
 	if procType, ok := keyDER.Headers["Proc-Type"]; ok {
 		if strings.Contains(procType, "ENCRYPTED") {
-			return nil, cferr.New(cferr.PrivateKeyError, cferr.Encrypted, nil)
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.Encrypted)
 		}
 	}
 	return ParsePrivateKeyDER(keyDER.Bytes)
@@ -207,7 +207,7 @@ func ParsePrivateKeyDER(keyDER []byte) (key interface{}, err error) {
 				// we don't want to leak any info about
 				// the private key.
 				return nil, cferr.New(cferr.PrivateKeyError,
-					cferr.ParseFailed, nil)
+					cferr.ParseFailed)
 			}
 		}
 	}

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -33,7 +33,7 @@ import (
 // SubjectAltName extension."
 func validator(req *csr.CertificateRequest) error {
 	if len(req.Hosts) == 0 {
-		return cferr.New(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing hosts field"))
+		return cferr.Wrap(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing hosts field"))
 	}
 	return nil
 }
@@ -134,12 +134,12 @@ func NewFromPEM(req *csr.CertificateRequest, keyFile string) (cert []byte, err e
 	certReq, err := x509.CreateCertificateRequest(rand.Reader, &tpl, priv)
 	if err != nil {
 		log.Errorf("failed to generate a CSR: %v", err)
-		// The use of PrivateKeyError was a matter of some
+		// The use of CertificateError was a matter of some
 		// debate; it is the one edge case in which a new
 		// error category specifically for CSRs might be
 		// useful, but it was deemed that one edge case did
 		// not a new category justify.
-		err = cferr.New(cferr.PrivateKeyError, cferr.BadRequest, err)
+		err = cferr.Wrap(cferr.CertificateError, cferr.BadRequest, err)
 		return
 	}
 

--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -180,6 +181,10 @@ func TestNoHostname(t *testing.T) {
 	if err == nil {
 		t.Fatal("InitCA should failed.")
 	}
+
+	if !strings.Contains(err.Error(), `"code":5300`) {
+		t.Fatal(err)
+	}
 }
 
 func TestInvalidCryptoParams(t *testing.T) {
@@ -206,6 +211,10 @@ func TestInvalidCryptoParams(t *testing.T) {
 		_, _, err := New(req)
 		if err == nil {
 			t.Fatal("InitCA with bad params should fail:", err)
+		}
+
+		if !strings.Contains(err.Error(), `"code":2400`) {
+			t.Fatal(err)
 		}
 	}
 }

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -97,13 +97,13 @@ func DefaultSigAlgo(priv interface{}) x509.SignatureAlgorithm {
 func ParseCertificateRequest(s Signer, csrBytes []byte, req *Subject) (template *x509.Certificate, err error) {
 	csr, err := x509.ParseCertificateRequest(csrBytes)
 	if err != nil {
-		err = cferr.New(cferr.CertificateError, cferr.ParseFailed, err)
+		err = cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
 		return
 	}
 
 	err = CheckSignature(csr, csr.SignatureAlgorithm, csr.RawTBSCertificateRequest, csr.Signature)
 	if err != nil {
-		err = cferr.New(cferr.CertificateError, cferr.KeyMismatch, err)
+		err = cferr.Wrap(cferr.CertificateError, cferr.KeyMismatch, err)
 		return
 	}
 

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -3,6 +3,7 @@ package signer
 import (
 	"crypto/x509"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,6 +75,35 @@ func TestNewSignerInvalidPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if !strings.Contains(err.Error(), `"code":5200`) {
+		t.Fatal(err)
+	}
+}
+
+func TestNewSignerNoUsageInPolicy(t *testing.T) {
+	var invalidConfig = &config.Config{
+		Signing: &config.Signing{
+			Profiles: map[string]*config.SigningProfile{
+				"invalid": &config.SigningProfile{
+					Usage:  []string{},
+					Expiry: expiry,
+				},
+				"empty": &config.SigningProfile{},
+			},
+			Default: &config.SigningProfile{
+				Usage:  []string{"digital signature"},
+				Expiry: expiry,
+			},
+		},
+	}
+	_, err := NewSigner(testCaFile, testCaKeyFile, invalidConfig.Signing)
+	if err == nil {
+		t.Fatal("expect InvalidPolicy error")
+	}
+
+	if !strings.Contains(err.Error(), `"code":5200`) {
+		t.Fatal(err)
+	}
 }
 
 func newCustomSigner(t *testing.T, testCaFile, testCaKeyFile string) (s Signer) {

--- a/signer/standard_signer.go
+++ b/signer/standard_signer.go
@@ -61,7 +61,7 @@ func NewSigner(caFile, cakeyFile string, policy *config.Signing) (*StandardSigne
 	}
 
 	if !policy.Valid() {
-		return nil, cferr.New(cferr.PolicyError, cferr.InvalidPolicy, errors.New("invalid policy"))
+		return nil, cferr.New(cferr.PolicyError, cferr.InvalidPolicy)
 	}
 
 	log.Debug("Loading CA: ", caFile)
@@ -129,7 +129,7 @@ func (s *StandardSigner) sign(template *x509.Certificate, profile *config.Signin
 	}
 
 	if ku == 0 && len(eku) == 0 {
-		err = cferr.New(cferr.PolicyError, cferr.NoKeyUsages, errors.New("no key usage available"))
+		err = cferr.New(cferr.PolicyError, cferr.NoKeyUsages)
 		return
 	}
 
@@ -147,7 +147,7 @@ func (s *StandardSigner) sign(template *x509.Certificate, profile *config.Signin
 	now := time.Now()
 	serialNumber, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
 	if err != nil {
-		err = cferr.New(cferr.CertificateError, cferr.Unknown, err)
+		err = cferr.Wrap(cferr.CertificateError, cferr.Unknown, err)
 		return
 	}
 
@@ -174,7 +174,7 @@ func (s *StandardSigner) sign(template *x509.Certificate, profile *config.Signin
 	var initRoot bool
 	if s.ca == nil {
 		if !template.IsCA {
-			err = cferr.New(cferr.PolicyError, cferr.InvalidRequest, nil)
+			err = cferr.New(cferr.PolicyError, cferr.InvalidRequest)
 			return
 		}
 		template.DNSNames = nil
@@ -193,7 +193,7 @@ func (s *StandardSigner) sign(template *x509.Certificate, profile *config.Signin
 	if initRoot {
 		s.ca, err = x509.ParseCertificate(derBytes)
 		if err != nil {
-			err = cferr.New(cferr.CertificateError, cferr.ParseFailed, err)
+			err = cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
 			return
 		}
 	}
@@ -215,11 +215,11 @@ func (s *StandardSigner) Sign(hostName string, in []byte, subject *Subject, prof
 
 	block, _ := pem.Decode(in)
 	if block == nil {
-		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed, err)
+		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed)
 	}
 
 	if block.Type != "CERTIFICATE REQUEST" {
-		return nil, cferr.New(cferr.CertificateError,
+		return nil, cferr.Wrap(cferr.CertificateError,
 			cferr.ParseFailed, errors.New("not a certificate or csr"))
 	}
 


### PR DESCRIPTION
- separate default error message from dynamic message wrapping.
- fix a few double-wrapped or inconsistent error reporting.