### PR TITLE
Initial CLI Version of `cfssl scan`

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -44,7 +44,6 @@ type Command struct {
 	Main func(args []string, c Config) error
 }
 
-// Parsed command name
 var cmdName string
 
 // usage is the cfssl usage heading. It will be appended with names of defined commands in cmds

--- a/cli/config.go
+++ b/cli/config.go
@@ -43,6 +43,9 @@ type Config struct {
 	Reason            int
 	RevokedAt         string
 	Interval          int64
+	List              bool
+	Family            string
+	Scanner           string
 }
 
 // registerFlags defines all cfssl command flags and associates their values with variables.
@@ -74,6 +77,9 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.IntVar(&c.Reason, "reason", 0, "Reason code for revocation")
 	f.StringVar(&c.RevokedAt, "revoked-at", "now", "Date of revocation (YYYY-MM-DD)")
 	f.Int64Var(&c.Interval, "interval", int64(4*helpers.OneDay), "Interval between OCSP updates, in seconds (default: 4 days)")
+	f.BoolVar(&c.List, "list", false, "list possible scanners")
+	f.StringVar(&c.Family, "family", "", "scanner family regular expression")
+	f.StringVar(&c.Scanner, "scanner", "", "scanner regular expression")
 
 	if pkcs11.Enabled {
 		f.StringVar(&c.Module, "pkcs11-module", "", "PKCS #11 module")

--- a/cli/scan/scan.go
+++ b/cli/scan/scan.go
@@ -1,0 +1,106 @@
+package scan
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cloudflare/cfssl/cli"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/scan"
+)
+
+var scanUsageText = `cfssl scan -- scan a host for issues
+Usage of scan:
+        cfssl scan [-family regexp] [-scanner regexp] HOST+
+        cfssl scan -list [-family regexp] [-scanner regexp]
+
+Arguments:
+        HOST:    Host(s) to scan (including port)
+Flags:
+`
+var scanFlags = []string{"list", "family", "scanner"}
+
+// regexpLoop iterates through each scan Family and Scanner registered in scan.AllFamilies.
+// familyFunc is run on each Family with a name matching the family flag's regexp,
+// then scannerFunc is run on each Scanner in that Family that matches the scanner flag's regexp
+func regexpLoop(familyRegexp, scannerRegexp *regexp.Regexp,
+	familyFunc func(*scan.Family),
+	scannerFunc func(*scan.Scanner)) {
+	for _, family := range scan.AllFamilies {
+		if familyRegexp.MatchString(family.Name) {
+			familyFunc(family)
+			for _, scanner := range family.Scanners {
+				if scannerRegexp.MatchString(scanner.Name) {
+					scannerFunc(scanner)
+				}
+			}
+		}
+	}
+}
+
+// indentPrintln prints a multi-line block with the specified indentation.
+func indentPrintln(block string, indentLevel int) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
+	scanner := bufio.NewScanner(strings.NewReader(block))
+	for scanner.Scan() {
+		fmt.Fprintf(w, "%s%s\n", strings.Repeat("\t", indentLevel), scanner.Text())
+	}
+	w.Flush()
+}
+
+func scanMain(args []string, c cli.Config) (err error) {
+	familyRegexp, err := regexp.Compile(c.Family)
+	scannerRegexp, err := regexp.Compile(c.Scanner)
+	if err != nil {
+		return
+	}
+	if c.List {
+		regexpLoop(
+			familyRegexp, scannerRegexp,
+			func(f *scan.Family) {
+				fmt.Println(f)
+			},
+			func(s *scan.Scanner) {
+				indentPrintln(s.String(), 1)
+			},
+		)
+	} else {
+		// Execute for each HOST argument given
+		for len(args) > 0 {
+			var host string
+			host, args, err = cli.PopFirstArgument(args)
+			if err != nil {
+				return
+			}
+			// If no port is specified, default to 443
+			if _, _, err := net.SplitHostPort(host); err != nil {
+				host = net.JoinHostPort(host, "443")
+			}
+			log.Infof("Scanning %s...", host)
+			regexpLoop(
+				familyRegexp, scannerRegexp,
+				func(f *scan.Family) {
+					if log.Level == log.LevelDebug && c.Scanner == "" {
+						fmt.Printf("[%s]\n", f.Name)
+					}
+				},
+				func(s *scan.Scanner) {
+					grade, output, _ := s.Scan(host)
+					fmt.Printf("%s: %s\n", s.Name, grade)
+					if log.Level == log.LevelDebug && output != nil {
+						indentPrintln(output.String(), 1)
+					}
+				},
+			)
+		}
+	}
+	return
+}
+
+// Command assembles the definition of Command 'scan'
+var Command = &cli.Command{UsageText: scanUsageText, Flags: scanFlags, Main: scanMain}

--- a/cli/scan/scan_test.go
+++ b/cli/scan/scan_test.go
@@ -1,0 +1,1 @@
+package scan

--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudflare/cfssl/cli/gencert"
 	"github.com/cloudflare/cfssl/cli/genkey"
 	"github.com/cloudflare/cfssl/cli/ocspsign"
+	"github.com/cloudflare/cfssl/cli/scan"
 	"github.com/cloudflare/cfssl/cli/selfsign"
 	"github.com/cloudflare/cfssl/cli/serve"
 	"github.com/cloudflare/cfssl/cli/sign"
@@ -50,6 +51,7 @@ func main() {
 		"gencert":  gencert.Command,
 		"ocspsign": ocspsign.Command,
 		"selfsign": selfsign.Command,
+		"scan":     scan.Command,
 	}
 	// Register all command flags.
 	cli.Start(cmds)

--- a/scan/connectivity.go
+++ b/scan/connectivity.go
@@ -1,0 +1,81 @@
+package scan
+
+import (
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/cloudflare/cf-tls/tls"
+)
+
+// Connectivity contains scanners testing basic connectivity to the host
+var Connectivity = &Family{
+	Name:        "Connectivity",
+	Description: "Scans for basic connectivity with the host through DNS and TCP/TLS dials",
+	Scanners: []*Scanner{
+		{
+			"DNSLookup",
+			"Host can be resolved through DNS",
+			dnsLookupScan,
+		},
+		{
+			"TCPDial",
+			"Host accepts TCP connection",
+			tcpDialScan,
+		},
+		{
+			"TLSDial",
+			"Host can perform TLS handshake",
+			tlsDialScan,
+		},
+	},
+}
+
+// lookupAddrs is a list of host's addresses returned by DNS lookup
+type lookupAddrs []string
+
+func (addrs lookupAddrs) String() string {
+	return strings.Join(addrs, "\n")
+}
+
+// dnsLookupScan tests that DNS resolution of the host returns at least one address
+func dnsLookupScan(host string) (grade Grade, output Output, err error) {
+	host, _, err = net.SplitHostPort(host)
+	if err != nil {
+		return
+	}
+
+	var addrs lookupAddrs
+	addrs, err = net.LookupHost(host)
+	if err != nil {
+		return
+	}
+
+	if len(addrs) == 0 {
+		err = errors.New("no addresses found for host")
+	}
+	grade, output = Good, addrs
+	return
+}
+
+// tcpDialScan tests that the host can be connected to through TCP.
+func tcpDialScan(host string) (grade Grade, output Output, err error) {
+	conn, err := Dialer.Dial(Network, host)
+	if err != nil {
+		return
+	}
+	conn.Close()
+	grade = Good
+	return
+}
+
+// tlsDialScan tests that the host can perform a TLS Handshake.
+func tlsDialScan(host string) (grade Grade, output Output, err error) {
+	conn, err := tls.DialWithDialer(Dialer, Network, host, defaultTLSConfig(host))
+	if err != nil {
+		return
+	}
+	conn.Close()
+	grade = Good
+	return
+}

--- a/scan/pki.go
+++ b/scan/pki.go
@@ -1,0 +1,86 @@
+package scan
+
+import (
+	"crypto/x509"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/cloudflare/cf-tls/tls"
+	"github.com/cloudflare/cfssl/bundler"
+)
+
+// PKI contains scanners to test application layer HTTP(S) features
+var PKI = &Family{
+	Name:        "PKI",
+	Description: "Scans for the Public Key Infrastructure",
+	Scanners: []*Scanner{
+		{
+			"IntermediateCAs",
+			"Scans a CIDR IP range for unknown Intermediate CAs",
+			intermediateCAScan,
+		},
+	},
+}
+
+func incrementBytes(bytes []byte) {
+	lsb := len(bytes) - 1
+	bytes[lsb]++
+	if bytes[lsb] == 0 {
+		incrementBytes(bytes[:lsb])
+	}
+}
+
+var (
+	caBundleFile  = "/etc/cfssl/ca-bundle.crt"
+	intBundleFile = "/etc/cfssl/int-bundle.crt"
+	numWorkers    = 32
+	timeout       = time.Second
+)
+
+// intermediateCAScan scans for new intermediate CAs not in the trust store.
+func intermediateCAScan(host string) (grade Grade, output Output, err error) {
+	cidr, port, _ := net.SplitHostPort(host)
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return Skipped, nil, nil
+	}
+	b, err := bundler.NewBundler(caBundleFile, intBundleFile)
+	if err != nil {
+		return
+	}
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+	dialer := &net.Dialer{Timeout: timeout}
+	config := &tls.Config{InsecureSkipVerify: true}
+	addrs := make(chan string)
+	chains := make(chan []*x509.Certificate, numWorkers)
+	go func() {
+		for chain := range chains {
+			b.Bundle(chain, nil, bundler.Force)
+		}
+	}()
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			for addr := range addrs {
+				conn, err := tls.DialWithDialer(dialer, Network, addr, config)
+				if err != nil {
+					continue
+				}
+				conn.Close()
+				if conn.ConnectionState().HandshakeComplete {
+					chains <- conn.ConnectionState().PeerCertificates
+				}
+			}
+			wg.Done()
+		}()
+	}
+	for ip := ipnet.IP.To16(); ipnet.Contains(ip); incrementBytes(ip) {
+		addrs <- net.JoinHostPort(ip.String(), port)
+	}
+	close(addrs)
+	wg.Wait()
+	close(chains)
+	grade = Good
+	return
+}

--- a/scan/scan_common.go
+++ b/scan/scan_common.go
@@ -1,0 +1,116 @@
+package scan
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/cloudflare/cf-tls/tls"
+	"github.com/cloudflare/cfssl/log"
+)
+
+var (
+	// Network is the default network to use.
+	Network = "tcp"
+	// Dialer is the default dialer to use, with a 1s timeout.
+	Dialer = &net.Dialer{Timeout: time.Second}
+)
+
+// Grade gives a subjective rating of the host's success in a scan.
+type Grade int
+
+const (
+	// Bad describes a host with serious misconfiguration or vulnerability.
+	Bad Grade = iota
+	// Legacy describes a host with non-ideal configuration that maintains support for legacy clients.
+	Legacy
+	// Good describes host performing the expected state-of-the-art.
+	Good
+	// Skipped descibes the "grade" of a scan that has been skipped.
+	Skipped
+)
+
+// String gives the name of the Grade as a string.
+func (g Grade) String() string {
+	switch g {
+	case Bad:
+		return "Bad"
+	case Legacy:
+		return "Legacy"
+	case Good:
+		return "Good"
+	case Skipped:
+		return "Skipped"
+	default:
+		return "Invalid"
+	}
+}
+
+// Output is the result of a scan, to be stored for potential use by later Scanners.
+type Output interface {
+	fmt.Stringer
+}
+
+// Scanner describes a type of scan to perform on a host.
+type Scanner struct {
+	// Name provides a short name for the Scanner.
+	Name string
+	// Description describes the nature of the scan to be performed.
+	Description string
+	// scan is the function that scans the given host and provides a Grade and Output.
+	scan func(host string) (Grade, Output, error)
+}
+
+// Scan performs the scan to be performed on the given host and stores its result.
+func (s *Scanner) Scan(host string) (Grade, Output, error) {
+	grade, output, err := s.scan(host)
+	if err != nil {
+		log.Infof("%s: %s", s.Name, err)
+		return grade, output, err
+	}
+	return grade, output, err
+}
+
+// String gives the name of the Scanner, and its description if loglevel is 0.
+func (s *Scanner) String() string {
+	ret := fmt.Sprintf("%s", s.Name)
+	if log.Level == log.LevelDebug {
+		ret += fmt.Sprintf(": %s", s.Description)
+	}
+	return ret
+}
+
+func defaultTLSConfig(host string) *tls.Config {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+	return &tls.Config{ServerName: h, InsecureSkipVerify: true}
+}
+
+// Family defines a set of related scans meant to be run together in sequence.
+type Family struct {
+	// Name is a short name for the Family.
+	Name string
+	// Description gives a short description of the scans performed scan/scan_common.goon the host.
+	Description string
+	// Scanners is a list of scanners that are to be run in sequence.
+	Scanners []*Scanner
+}
+
+// String gives the name of the Family, and its description if loglevel is 0.
+func (f *Family) String() string {
+	ret := fmt.Sprintf("%s", f.Name)
+	if log.Level == 0 {
+		ret += fmt.Sprintf(": %s", f.Description)
+	}
+	return ret
+}
+
+// AllFamilies contains each scan Family that is defined
+var AllFamilies = []*Family{
+	Connectivity,
+	TLSHandshake,
+	TLSSession,
+	PKI,
+}

--- a/scan/scan_common_test.go
+++ b/scan/scan_common_test.go
@@ -1,0 +1,74 @@
+package scan
+
+import (
+	"fmt"
+	"testing"
+)
+
+type OutputString string
+
+func (os OutputString) String() string {
+	return string(os)
+}
+
+var TestingScanner = &Scanner{
+	"TestingScanner",
+	"Tests common scan functions",
+	func(host string) (Grade, Output, error) {
+		switch host {
+		case "bad.example.com:443":
+			return Bad, OutputString("bad.com"), nil
+		case "legacy.example.com:443":
+			return Legacy, OutputString("legacy.com"), nil
+		case "good.example.com:443":
+			return Good, OutputString("good.com"), nil
+		case "skipped.example.com:443/0":
+			return Skipped, OutputString("skipped"), nil
+		default:
+			return Grade(-1), OutputString("invalid"), fmt.Errorf("scan: invalid grade")
+		}
+	},
+}
+
+var TestingFamily = &Family{
+	Name:        "TestingFamily",
+	Description: "Tests the scan_common",
+	Scanners: []*Scanner{
+		TestingScanner,
+	},
+}
+
+func TestCommon(t *testing.T) {
+	if TestingScanner.Name != "TestingScanner" {
+		t.FailNow()
+	}
+
+	var grade Grade
+	var output Output
+	var err error
+
+	grade, output, err = TestingScanner.Scan("bad.example.com:443")
+	if grade != Bad || output.String() != "bad.com" || err != nil {
+		t.FailNow()
+	}
+
+	grade, output, err = TestingScanner.Scan("legacy.example.com:443")
+	if grade != Legacy || output.String() != "legacy.com" || err != nil {
+		t.FailNow()
+	}
+
+	grade, output, err = TestingScanner.Scan("good.example.com:443")
+	if grade != Good || output.String() != "good.com" || err != nil {
+		t.FailNow()
+	}
+
+	grade, output, err = TestingScanner.Scan("skipped.example.com:443/0")
+	if grade != Skipped || output.String() != "skipped" || err != nil {
+		t.FailNow()
+	}
+
+	_, _, err = TestingScanner.Scan("invalid")
+	if err == nil {
+		t.FailNow()
+	}
+}

--- a/scan/tls_handshake.go
+++ b/scan/tls_handshake.go
@@ -1,0 +1,120 @@
+package scan
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/cloudflare/cf-tls/tls"
+)
+
+// TLSHandshake contains scanners testing host cipher suite negotiation
+var TLSHandshake = &Family{
+	Name:        "TLSHandshake",
+	Description: "Scans for host's SSL/TLS version and cipher suite negotiation",
+	Scanners: []*Scanner{
+		{
+			"CipherSuite",
+			"Determines host's cipher suites accepted and prefered order",
+			cipherSuiteScan,
+		},
+	},
+}
+
+func sayHello(host string, ciphers []uint16, vers uint16) (cipherIndex int, err error) {
+	tcpConn, err := net.Dial(Network, host)
+	if err != nil {
+		return
+	}
+	config := defaultTLSConfig(host)
+	config.MinVersion = vers
+	config.MaxVersion = vers
+	config.CipherSuites = ciphers
+	conn := tls.Client(tcpConn, config)
+	serverCipher, serverVersion, err := conn.SayHello()
+	conn.Close()
+	if err != nil {
+		return
+	}
+
+	if serverVersion != vers {
+		err = fmt.Errorf("server negotiated protocol version we didn't send: %s", tls.Versions[serverVersion])
+		return
+	}
+
+	var cipherID uint16
+	for cipherIndex, cipherID = range ciphers {
+		if serverCipher == cipherID {
+			return
+		}
+	}
+	err = fmt.Errorf("server negotiated ciphersuite we didn't send: %s", tls.CipherSuites[serverCipher])
+	return
+}
+
+func allCiphersIDs() []uint16 {
+	ciphers := make([]uint16, 0, len(tls.CipherSuites))
+	for cipherID := range tls.CipherSuites {
+		ciphers = append(ciphers, cipherID)
+	}
+	return ciphers
+}
+
+// cipherVersions contains lists of host's supported cipher suites based on SSL/TLS Version
+type cipherVersions struct {
+	cipherID uint16
+	versions []uint16
+}
+
+type cipherVersionList []cipherVersions
+
+func (cvList cipherVersionList) String() string {
+	cvStrings := make([]string, len(cvList))
+	for i, c := range cvList {
+		versStrings := make([]string, len(c.versions))
+		for j, vers := range c.versions {
+			versStrings[j] = tls.Versions[vers]
+		}
+		cvStrings[i] = fmt.Sprintf("%s\t%s", tls.CipherSuites[c.cipherID], strings.Join(versStrings, ", "))
+	}
+	return strings.Join(cvStrings, "\n")
+}
+
+// cipherSuiteScan returns, by TLS Version, the sort list of cipher suites
+// supported by the host
+func cipherSuiteScan(host string) (grade Grade, output Output, err error) {
+	var cvList cipherVersionList
+	allCiphers := allCiphersIDs()
+	var vers uint16
+	for vers = tls.VersionTLS12; vers >= tls.VersionSSL30; vers-- {
+		ciphers := make([]uint16, len(allCiphers))
+		copy(ciphers, allCiphers)
+		for len(ciphers) > 0 {
+			cipherIndex, err := sayHello(host, ciphers, vers)
+			if err != nil {
+				break
+			}
+			if vers == tls.VersionSSL30 {
+				grade = Legacy
+			}
+			cipherID := ciphers[cipherIndex]
+			for i, c := range cvList {
+				if cipherID == c.cipherID {
+					cvList[i].versions = append(c.versions, vers)
+					goto exists
+				}
+			}
+			cvList = append(cvList, cipherVersions{cipherID, []uint16{vers}})
+		exists:
+			ciphers = append(ciphers[:cipherIndex], ciphers[cipherIndex+1:]...)
+		}
+	}
+	if grade != Legacy && len(cvList) > 0 {
+		grade = Good
+	} else {
+		err = errors.New("couldn't negotiate any cipher suites")
+	}
+	output = cvList
+	return
+}

--- a/scan/tls_session.go
+++ b/scan/tls_session.go
@@ -1,0 +1,58 @@
+package scan
+
+import (
+	"errors"
+	"net"
+
+	"github.com/cloudflare/cf-tls/tls"
+)
+
+// TLSSession contains tests of host TLS Session Resumption via
+// Session Tickets and Session IDs
+var TLSSession = &Family{
+	Name:        "TLSSession",
+	Description: "Scans host's implementation of TLS session resumption using session tickets/session IDs",
+	Scanners: []*Scanner{
+		{
+			"SessionResume",
+			"Host is able to resume sessions across all addresses",
+			sessionResumeScan,
+		},
+	},
+}
+
+// SessionResumeScan tests that host is able to resume sessions across all addresses.
+func sessionResumeScan(host string) (grade Grade, output Output, err error) {
+	var hostname, port string
+	hostname, port, err = net.SplitHostPort(host)
+	if err != nil {
+		return
+	}
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return
+	}
+	config := defaultTLSConfig(host)
+	config.ClientSessionCache = tls.NewLRUClientSessionCache(1)
+	var conn *tls.Conn
+	conn, err = tls.DialWithDialer(Dialer, Network, host, config)
+	if err != nil {
+		return
+	}
+	conn.Close()
+
+	for _, ip := range ips {
+		host = net.JoinHostPort(ip.String(), port)
+		conn, err = tls.Dial(Network, host, config)
+		if err != nil {
+			return
+		}
+		conn.Close()
+		if !conn.ConnectionState().DidResume {
+			err = errors.New("did not resume")
+			return
+		}
+	}
+	grade = Good
+	return
+}


### PR DESCRIPTION
Adds new `scan` command, that performs a variety of connectivity and TLS protocol tests.

Unfortunately, some of these require importing the go standard library's `crypto/tls` package's source in order to access private members. These are used in `scan/tls/cfsslscan_*.go` files to export additional functionality not supplied by the `crypto/tls` API.

Support for the standard CFSSL HTTP API is forthcoming, but comments on this initial structure might be useful first.