### PR TITLE
Support PKCS#11 for certificate signing

### DIFF
--- a/api/api_generator.go
+++ b/api/api_generator.go
@@ -10,12 +10,12 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/api/client"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/cfssl/signer"
 )
 
 // Validator is a type of function that contains the logic for validating
@@ -155,7 +155,7 @@ func NewCertGeneratorHandler(validator Validator, caFile, caKeyFile, remote stri
 		}
 	}
 
-	if cg.signer, err = signer.NewSigner(caFile, caKeyFile, cfg); err != nil {
+	if cg.signer, err = signer.NewSignerFromFile(caFile, caKeyFile, cfg); err != nil {
 		if remote == "" {
 			return nil, err
 		}

--- a/api/api_signer.go
+++ b/api/api_signer.go
@@ -5,12 +5,12 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/api/client"
 	"github.com/cloudflare/cfssl/auth"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/cfssl/signer"
 )
 
 // A SignHandler accepts requests with a hostname and certficate
@@ -30,7 +30,7 @@ func NewSignHandler(caFile, cakeyFile string, remote string, policy *config.Sign
 	var err error
 	s := new(SignHandler)
 
-	if s.signer, err = signer.NewSigner(caFile, cakeyFile, policy); err != nil {
+	if s.signer, err = signer.NewSignerFromFile(caFile, cakeyFile, policy); err != nil {
 		if remote == "" {
 			log.Errorf("setting up signer failed: %v", err)
 			return nil, err

--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/helpers"
-	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/ubiquity"
 )
 
@@ -597,7 +597,7 @@ func newBundler(t *testing.T) (b *Bundler) {
 
 // create a test intermediate cert in PEM
 func createInterCert(t *testing.T, csrFile string, policy *config.Signing, profileName string) (certPEM []byte) {
-	signer, err := signer.NewSigner(testCAFile, testCAKeyFile, policy)
+	signer, err := signer.NewSignerFromFile(testCAFile, testCAKeyFile, policy)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cfssl.go
+++ b/cfssl.go
@@ -67,6 +67,10 @@ var Config struct {
 	domain            string
 	ip                string
 	remote            string
+	pkcs11Module      string
+	pkcs11Token       string
+	pkcs11PIN         string
+	pkcs11KeyLabel    string
 }
 
 // Parsed command name
@@ -94,6 +98,11 @@ func registerFlags() {
 	cfsslFlagSet.StringVar(&Config.domain, "domain", "", "remote server domain name")
 	cfsslFlagSet.StringVar(&Config.ip, "ip", "", "remote server ip")
 	cfsslFlagSet.StringVar(&Config.remote, "remote", "", "remote CFSSL server")
+
+	cfsslFlagSet.StringVar(&Config.pkcs11Module, "pkcs11-module", "", "PKCS#11 module")
+	cfsslFlagSet.StringVar(&Config.pkcs11Token, "pkcs11-token", "", "Name of the PKCS#11 token to use for signing")
+	cfsslFlagSet.StringVar(&Config.pkcs11PIN, "pkcs11-pin", "", "PIN to log in to PKCS#11 token")
+	cfsslFlagSet.StringVar(&Config.pkcs11KeyLabel, "pkcs11-key-label", "", "Private key label for a key on a PKCS#11 token")
 }
 
 // usage is the cfssl usage heading. It will be appended with names of defined commands in cmds

--- a/cfssl_gencert.go
+++ b/cfssl_gencert.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/api/client"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/initca"
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/cfssl/signer"
 )
 
 var gencertUsageText = `cfssl gencert -- generate a new key and signed certificate
@@ -104,7 +104,7 @@ func gencertMain(args []string) (err error) {
 		}
 
 		var sign signer.Signer
-		sign, err = signer.NewSigner(Config.caFile, Config.caKeyFile, policy)
+		sign, err = signer.NewSignerFromFile(Config.caFile, Config.caKeyFile, policy)
 		if err != nil {
 			return
 		}

--- a/cfssl_sign.go
+++ b/cfssl_sign.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/cfssl/signer"
 )
 
 // Usage text of 'cfssl sign'
@@ -28,7 +28,7 @@ Flags:
 `
 
 // Flags of 'cfssl sign'
-var signerFlags = []string{"hostname", "csr", "ca", "ca-key", "f", "profile"}
+var signerFlags = []string{"hostname", "csr", "ca", "ca-key", "f", "profile", "pkcs11-module", "pkcs11-token", "pkcs11-pin", "pkcs11-key-label"}
 
 // signerMain is the main CLI of signer functionality.
 // [TODO: zi] Decide whether to drop the argument list and only use flags to specify all the inputs.
@@ -82,10 +82,18 @@ func signerMain(args []string) (err error) {
 		policy = Config.cfg.Signing
 	}
 
-	signer, err := signer.NewSigner(Config.caFile, Config.caKeyFile, policy)
+	keyConfig := signer.SigningKeyConfig{
+		CaKeyFile:      Config.caKeyFile,
+		Pkcs11Module:   Config.pkcs11Module,
+		Pkcs11Token:    Config.pkcs11Token,
+		Pkcs11PIN:      Config.pkcs11PIN,
+		Pkcs11KeyLabel: Config.pkcs11KeyLabel,
+	}
+	signer, err := signer.NewSigner(Config.caFile, keyConfig, policy)
 	if err != nil {
 		return
 	}
+
 	cert, err := signer.Sign(Config.hostname, clientCert, subjectData, Config.profile)
 	if err != nil {
 		return

--- a/cfssl_sign.go
+++ b/cfssl_sign.go
@@ -82,19 +82,18 @@ func signerMain(args []string) (err error) {
 		policy = Config.cfg.Signing
 	}
 
-	keyConfig := signer.SigningKeyConfig{
-		CaKeyFile:      Config.caKeyFile,
-		Pkcs11Module:   Config.pkcs11Module,
-		Pkcs11Token:    Config.pkcs11Token,
-		Pkcs11PIN:      Config.pkcs11PIN,
-		Pkcs11KeyLabel: Config.pkcs11KeyLabel,
+	var certSigner *signer.StandardSigner
+	if Config.pkcs11Module != "" {
+		certSigner, err = signer.NewSignerPkcs11(Config.caFile, Config.pkcs11Module,
+			Config.pkcs11Token, Config.pkcs11PIN, Config.pkcs11KeyLabel, policy)
+	} else {
+		certSigner, err = signer.NewSignerFromFile(Config.caFile, Config.caKeyFile, policy)
 	}
-	signer, err := signer.NewSigner(Config.caFile, keyConfig, policy)
 	if err != nil {
 		return
 	}
 
-	cert, err := signer.Sign(Config.hostname, clientCert, subjectData, Config.profile)
+	cert, err := certSigner.Sign(Config.hostname, clientCert, subjectData, Config.profile)
 	if err != nil {
 		return
 	}

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -13,12 +13,12 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	cferr "github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/cfssl/signer"
 )
 
 // validator contains the default validation logic for certificate

--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
-	"github.com/cloudflare/cfssl/signer"
 )
 
 type KeyRequest struct {

--- a/selfsign/selfsign.go
+++ b/selfsign/selfsign.go
@@ -14,9 +14,9 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/bifurcation/cfssl/signer"
 	"github.com/cloudflare/cfssl/config"
 	cferr "github.com/cloudflare/cfssl/errors"
-	"github.com/cloudflare/cfssl/signer"
 )
 
 const threeMonths = 2190 * time.Hour

--- a/signer/pkcs11_key.go
+++ b/signer/pkcs11_key.go
@@ -1,0 +1,230 @@
+package signer
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"github.com/miekg/pkcs11"
+	"io"
+	"math/big"
+)
+
+type Pkcs11Error string
+
+func (err Pkcs11Error) Error() string {
+	return string(err)
+}
+
+// from src/pkg/crypto/rsa/pkcs1v15.go
+var hashPrefixes = map[crypto.Hash][]byte{
+	crypto.MD5:       {0x30, 0x20, 0x30, 0x0c, 0x06, 0x08, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x02, 0x05, 0x05, 0x00, 0x04, 0x10},
+	crypto.SHA1:      {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14},
+	crypto.SHA224:    {0x30, 0x2d, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04, 0x05, 0x00, 0x04, 0x1c},
+	crypto.SHA256:    {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20},
+	crypto.SHA384:    {0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0x04, 0x30},
+	crypto.SHA512:    {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40},
+	crypto.MD5SHA1:   {}, // A special TLS case which doesn't use an ASN1 prefix.
+	crypto.RIPEMD160: {0x30, 0x20, 0x30, 0x08, 0x06, 0x06, 0x28, 0xcf, 0x06, 0x03, 0x00, 0x31, 0x04, 0x14},
+}
+
+// Pkcs11Key is an implementation of the crypto.Signer interface
+// using a key stored in a PKCS#11 hardware token.  This enables
+// the use of PKCS#11 tokens with the Go x509 library's methods
+// for signing certificates.
+type Pkcs11Key struct {
+	// The PKCS#11 library to use
+	module *pkcs11.Ctx
+
+	// The name of the slot to be used.
+	// We will automatically search for this in the slot list.
+	slotDescription string
+
+	// The PIN to be used to log in to the device
+	pin string
+
+	// The public key corresponding to the private key.
+	publicKey rsa.PublicKey
+
+	// The an ObjectHandle pointing to the private key on the HSM.
+	privateKeyHandle pkcs11.ObjectHandle
+}
+
+func NewPkcs11Key(module, slot, pin, privLabel string) (ps *Pkcs11Key, err error) {
+	// Set up a new pkcs11 object and initialize it
+	p := pkcs11.New(module)
+	if p == nil {
+		err = Pkcs11Error("Unable to load PKCS#11 module")
+		return
+	}
+	if err = p.Initialize(); err != nil {
+		return
+	}
+
+	// Initialize a partial key
+	ps = &Pkcs11Key{
+		module:          p,
+		slotDescription: slot,
+		pin:             pin,
+	}
+	// XXX: defer ps.DestroyOnError(err) ?
+
+	// Look up the private key
+	session, err := ps.openSession()
+	if err != nil {
+		ps.Destroy()
+		return
+	}
+	defer ps.closeSession(session)
+
+	template := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, privLabel),
+	}
+	if err = p.FindObjectsInit(session, template); err != nil {
+		ps.Destroy()
+		return
+	}
+	objs, _, err := p.FindObjects(session, 2)
+	if err != nil {
+		ps.Destroy()
+		return
+	}
+	if err = p.FindObjectsFinal(session); err != nil {
+		ps.Destroy()
+		return
+	}
+
+	if len(objs) == 0 {
+		err = Pkcs11Error("Private key not found")
+		ps.Destroy()
+		return
+	}
+	ps.privateKeyHandle = objs[0]
+
+	// Populate the pubic key from the private key
+	// TODO: Add support for non-RSA keys, switching on CKA_KEY_TYPE
+	template = []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_MODULUS, nil),
+		pkcs11.NewAttribute(pkcs11.CKA_PUBLIC_EXPONENT, nil),
+	}
+	attr, err := p.GetAttributeValue(session, ps.privateKeyHandle, template)
+	if err != nil {
+		ps.Destroy()
+		return
+	}
+
+	n := big.NewInt(0)
+	e := int(0)
+	gotModulus, gotExponent := false, false
+	for _, a := range attr {
+		if a.Type == pkcs11.CKA_MODULUS {
+			n.SetBytes(a.Value)
+			gotModulus = true
+		} else if a.Type == pkcs11.CKA_PUBLIC_EXPONENT {
+			bigE := big.NewInt(0)
+			bigE.SetBytes(a.Value)
+			e = int(bigE.Int64())
+			gotExponent = true
+		}
+	}
+	if !gotModulus || !gotExponent {
+		ps.Destroy()
+		return
+	}
+	ps.publicKey = rsa.PublicKey{n, e}
+
+	return
+}
+
+// This method must be called before the Pkcs11Signer is GC'ed, in
+// order to ensure that the PKCS#11 module itself is properly finalized
+// and destroyed.
+//
+// The idiomatic way to do this (assuming no need for a long-lived
+// signer) is as follows:
+//
+//   ps, err := NewPkcs11Signer(...)
+//   if err != nil { ... }
+//   defer ps.Destroy()
+func (ps *Pkcs11Key) Destroy() {
+	if ps.module != nil {
+		ps.module.Finalize()
+		ps.module.Destroy()
+	}
+}
+
+func (ps *Pkcs11Key) openSession() (session pkcs11.SessionHandle, err error) {
+	// Find slot by description
+	slots, err := ps.module.GetSlotList(true)
+	if err != nil {
+		return
+	}
+	for _, slot := range slots {
+		slotInfo, err := ps.module.GetSlotInfo(slot)
+		if err != nil {
+			continue
+		}
+
+		if slotInfo.SlotDescription == ps.slotDescription {
+			// Open session
+			session, err = ps.module.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION)
+			if err != nil {
+				return session, err
+			}
+
+			// Login
+			if err = ps.module.Login(session, pkcs11.CKU_USER, ps.pin); err != nil {
+				return session, err
+			}
+
+			return session, err
+		}
+	}
+
+	err = Pkcs11Error("Slot not found")
+	return
+}
+
+func (ps *Pkcs11Key) closeSession(session pkcs11.SessionHandle) {
+	ps.module.Logout(session)
+	ps.module.CloseSession(session)
+}
+
+func (ps *Pkcs11Key) Public() crypto.PublicKey {
+	return &ps.publicKey
+}
+
+func (ps *Pkcs11Key) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	// Verify that the length of the hash is as expected
+	hash := opts.HashFunc()
+	hashLen := hash.Size()
+	if len(msg) != hashLen {
+		err = Pkcs11Error("Input size does not match hash function output size")
+		return
+	}
+
+	// Add DigestInfo prefix
+	// TODO: Switch mechanisms based on CKA_KEY_TYPE
+	mechanism := []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS, nil)}
+	prefix, ok := hashPrefixes[hash]
+	if !ok {
+		err = Pkcs11Error("Unknown hash function")
+		return
+	}
+	signatureInput := append(prefix, msg...)
+
+	// Open a session
+	session, err := ps.openSession()
+	if err != nil {
+		return
+	}
+	defer ps.closeSession(session)
+
+	// Perform the sign operation
+	err = ps.module.SignInit(session, mechanism, ps.privateKeyHandle)
+	if err != nil {
+		return
+	}
+
+	signature, err = ps.module.Sign(session, signatureInput)
+	return
+}

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -60,6 +60,7 @@ type Signer interface {
 
 // DefaultSigAlgo returns an appropriate X.509 signature algorithm given
 // the CA's private key.
+// TODO[bifurcation]: Change argument to crypto.Signer (and use Public())
 func DefaultSigAlgo(priv interface{}) x509.SignatureAlgorithm {
 	switch priv := priv.(type) {
 	case *rsa.PrivateKey:
@@ -85,6 +86,8 @@ func DefaultSigAlgo(priv interface{}) x509.SignatureAlgorithm {
 		default:
 			return x509.ECDSAWithSHA1
 		}
+	case *Pkcs11Key:
+		return DefaultSigAlgo(priv.Public())
 	default:
 		return x509.UnknownSignatureAlgorithm
 	}

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -24,7 +24,7 @@ var expiry = 1 * time.Minute
 
 // Start a signer with the testing RSA CA cert and key.
 func newTestSigner(t *testing.T) (s Signer) {
-	s, err := NewSigner(testCaFile, testCaKeyFile, nil)
+	s, err := NewSignerFromFile(testCaFile, testCaKeyFile, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestNewSignerPolicy(t *testing.T) {
 			},
 		},
 	}
-	_, err := NewSigner(testCaFile, testCaKeyFile, CAConfig.Signing)
+	_, err := NewSignerFromFile(testCaFile, testCaKeyFile, CAConfig.Signing)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestNewSignerInvalidPolicy(t *testing.T) {
 			},
 		},
 	}
-	_, err := NewSigner(testCaFile, testCaKeyFile, invalidConfig.Signing)
+	_, err := NewSignerFromFile(testCaFile, testCaKeyFile, invalidConfig.Signing)
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestNewSignerNoUsageInPolicy(t *testing.T) {
 			},
 		},
 	}
-	_, err := NewSigner(testCaFile, testCaKeyFile, invalidConfig.Signing)
+	_, err := NewSignerFromFile(testCaFile, testCaKeyFile, invalidConfig.Signing)
 	if err == nil {
 		t.Fatal("expect InvalidPolicy error")
 	}
@@ -107,14 +107,14 @@ func TestNewSignerNoUsageInPolicy(t *testing.T) {
 }
 
 func newCustomSigner(t *testing.T, testCaFile, testCaKeyFile string) (s Signer) {
-	s, err := NewSigner(testCaFile, testCaKeyFile, nil)
+	s, err := NewSignerFromFile(testCaFile, testCaKeyFile, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return
 }
 
-func TestNewSigner(t *testing.T) {
+func TestNewSignerFromFile(t *testing.T) {
 	newTestSigner(t)
 }
 

--- a/signer/standard_signer.go
+++ b/signer/standard_signer.go
@@ -88,7 +88,13 @@ func NewSigner(caFile string, keyConfig SigningKeyConfig, policy *config.Signing
 	}
 
 	var priv interface{}
-	if keyConfig.CaKeyFile != "" {
+	if keyConfig.Pkcs11Module != "" {
+		log.Debug("Configuring PKCS#11: ", keyConfig.Pkcs11Module)
+		priv, err = NewPkcs11Key(keyConfig.Pkcs11Module, keyConfig.Pkcs11Token, keyConfig.Pkcs11PIN, keyConfig.Pkcs11KeyLabel)
+		if err != nil {
+			return nil, err
+		}
+	} else {
 		log.Debug("Loading CA key: ", keyConfig.CaKeyFile)
 		cakey, err := ioutil.ReadFile(keyConfig.CaKeyFile)
 		if err != nil {
@@ -96,12 +102,6 @@ func NewSigner(caFile string, keyConfig SigningKeyConfig, policy *config.Signing
 		}
 
 		priv, err = helpers.ParsePrivateKeyPEM(cakey)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		log.Debug("Configuring PKCS#11: ", keyConfig.Pkcs11Module)
-		priv, err = NewPkcs11Key(keyConfig.Pkcs11Module, keyConfig.Pkcs11Token, keyConfig.Pkcs11PIN, keyConfig.Pkcs11KeyLabel)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR adds support for signing certificates with a private key stored on a PKCS#11 token.  

In terms of code, the main impacts here are:
1. Adding a "Pkcs11Key" type that implements crypto.Signer with a token-backed key
2. Tweaking the signer.NewSigner interface to allow either file-backed or token-backed keys
3. Wiring all this through to the CLI

This extension has a couple dependency impacts:
* [PKCS#11 interface library](https://github.com/miekg/pkcs11)
* Latest version of "crypto/x509", which allows the use of [crypto.Signer with CreateCertificate](https://github.com/golang/go/commit/fe40cdd756763982db6815ee87318f418218fcf5)

I have tested this using the PKCS#11 capabilities on a [Yubikey Neo-N](https://www.yubico.com/products/yubikey-hardware/yubikey-neo/) and with [SoftHSM](https://www.opendnssec.org/softhsm/).

Obviously, the references to "github.com/bifurcation/cfssl" will need to be changed before merging.