### PR TITLE
Remove mercurial dependence

### DIFF
--- a/revoke/revoke.go
+++ b/revoke/revoke.go
@@ -17,7 +17,7 @@ import (
 	neturl "net/url"
 	"time"
 
-	"code.google.com/p/go.crypto/ocsp"
+	"golang.org/x/crypto/ocsp"
 
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"


### PR DESCRIPTION
Edit the import of the ocsp to use the new, git location, thus
ending cfssl's dependence on mercurial