### PR TITLE
Use crypto.Signer for private keys.

### DIFF
--- a/selfsign/selfsign.go
+++ b/selfsign/selfsign.go
@@ -3,6 +3,7 @@
 package selfsign
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/x509"
@@ -23,7 +24,7 @@ const threeMonths = 2190 * time.Hour
 
 // parseCertificateRequest takes an incoming certificate request and
 // builds a certificate template from it.
-func parseCertificateRequest(priv interface{}, csrBytes []byte) (template *x509.Certificate, err error) {
+func parseCertificateRequest(priv crypto.Signer, csrBytes []byte) (template *x509.Certificate, err error) {
 
 	csr, err := x509.ParseCertificateRequest(csrBytes)
 	if err != nil {
@@ -53,7 +54,7 @@ type subjectPublicKeyInfo struct {
 }
 
 // Sign creates a new self-signed certificate.
-func Sign(priv interface{}, csrPEM []byte, profile *config.SigningProfile) ([]byte, error) {
+func Sign(priv crypto.Signer, csrPEM []byte, profile *config.SigningProfile) ([]byte, error) {
 	if profile == nil {
 		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("no profile for self-signing"))
 	}

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -2,6 +2,7 @@
 package local
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
@@ -20,14 +21,14 @@ import (
 // support both ECDSA and RSA CA keys.
 type Signer struct {
 	ca      *x509.Certificate
-	priv    interface{}
+	priv    crypto.Signer
 	policy  *config.Signing
 	sigAlgo x509.SignatureAlgorithm
 }
 
 // NewSigner creates a new Signer directly from a
 // private key and certificate, with optional policy.
-func NewSigner(priv interface{}, cert *x509.Certificate, sigAlgo x509.SignatureAlgorithm, policy *config.Signing) (*Signer, error) {
+func NewSigner(priv crypto.Signer, cert *x509.Certificate, sigAlgo x509.SignatureAlgorithm, policy *config.Signing) (*Signer, error) {
 	if policy == nil {
 		policy = &config.Signing{
 			Profiles: map[string]*config.SigningProfile{},

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -77,10 +77,11 @@ type Signer interface {
 
 // DefaultSigAlgo returns an appropriate X.509 signature algorithm given
 // the CA's private key.
-func DefaultSigAlgo(priv interface{}) x509.SignatureAlgorithm {
-	switch priv := priv.(type) {
-	case *rsa.PrivateKey:
-		keySize := priv.N.BitLen()
+func DefaultSigAlgo(priv crypto.Signer) x509.SignatureAlgorithm {
+	pub := priv.Public()
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		keySize := pub.N.BitLen()
 		switch {
 		case keySize >= 4096:
 			return x509.SHA512WithRSA
@@ -91,8 +92,8 @@ func DefaultSigAlgo(priv interface{}) x509.SignatureAlgorithm {
 		default:
 			return x509.SHA1WithRSA
 		}
-	case *ecdsa.PrivateKey:
-		switch priv.Curve {
+	case *ecdsa.PublicKey:
+		switch pub.Curve {
 		case elliptic.P256():
 			return x509.ECDSAWithSHA256
 		case elliptic.P384():


### PR DESCRIPTION
This PR changes the private keys used in the signer package from `interface{}` to `crypto.Signer`. Once the changes to `crypto/x509` make it into mainline Go, this will permit a more fleixble signature system.