### PR TITLE
crypto.Signer

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -4,6 +4,7 @@ package helpers
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
@@ -180,7 +181,7 @@ func ParseOneCertificateFromPEM(certsPEM []byte) (cert *x509.Certificate, rest [
 // ParsePrivateKeyPEM parses and returns a PEM-encoded private
 // key. The private key may be either an unencrypted PKCS#8, PKCS#1,
 // or elliptic private key.
-func ParsePrivateKeyPEM(keyPEM []byte) (key interface{}, err error) {
+func ParsePrivateKeyPEM(keyPEM []byte) (key crypto.Signer, err error) {
 	keyDER, _ := pem.Decode(keyPEM)
 	if keyDER == nil {
 		return nil, cferr.New(cferr.PrivateKeyError, cferr.DecodeFailed)
@@ -195,12 +196,12 @@ func ParsePrivateKeyPEM(keyPEM []byte) (key interface{}, err error) {
 
 // ParsePrivateKeyDER parses a PKCS #1, PKCS #8, or elliptic curve
 // DER-encoded private key. The key must not be in PEM format.
-func ParsePrivateKeyDER(keyDER []byte) (key interface{}, err error) {
-	key, err = x509.ParsePKCS8PrivateKey(keyDER)
+func ParsePrivateKeyDER(keyDER []byte) (key crypto.Signer, err error) {
+	generalKey, err := x509.ParsePKCS8PrivateKey(keyDER)
 	if err != nil {
-		key, err = x509.ParsePKCS1PrivateKey(keyDER)
+		generalKey, err = x509.ParsePKCS1PrivateKey(keyDER)
 		if err != nil {
-			key, err = x509.ParseECPrivateKey(keyDER)
+			generalKey, err = x509.ParseECPrivateKey(keyDER)
 			if err != nil {
 				// We don't include the actual error into
 				// the final error. The reason might be
@@ -211,5 +212,13 @@ func ParsePrivateKeyDER(keyDER []byte) (key interface{}, err error) {
 			}
 		}
 	}
-	return
+
+	switch generalKey.(type) {
+	case *rsa.PrivateKey:
+		return generalKey.(*rsa.PrivateKey), nil
+	case *ecdsa.PrivateKey:
+		return generalKey.(*ecdsa.PrivateKey), nil
+	}
+
+	return nil, cferr.New(cferr.PrivateKeyError, cferr.ParseFailed)
 }

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -2,6 +2,7 @@
 package local
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
@@ -20,14 +21,14 @@ import (
 // support both ECDSA and RSA CA keys.
 type Signer struct {
 	ca      *x509.Certificate
-	priv    interface{}
+	priv    crypto.Signer
 	policy  *config.Signing
 	sigAlgo x509.SignatureAlgorithm
 }
 
 // NewSigner creates a new Signer directly from a
 // private key and certificate, with optional policy.
-func NewSigner(priv interface{}, cert *x509.Certificate, sigAlgo x509.SignatureAlgorithm, policy *config.Signing) (*Signer, error) {
+func NewSigner(priv crypto.Signer, cert *x509.Certificate, sigAlgo x509.SignatureAlgorithm, policy *config.Signing) (*Signer, error) {
 	if policy == nil {
 		policy = &config.Signing{
 			Profiles: map[string]*config.SigningProfile{},


### PR DESCRIPTION
Currently, private keys are represented as type interface{}.  It is better clearer to use crypto.Signer.  That's the direction that crypto/x509 is headed, and it's compatible with the current version.