### PR TITLE
Add a new member 'Root' to the bundler's output structure.

### DIFF
--- a/bundler/bundle.go
+++ b/bundler/bundle.go
@@ -21,6 +21,7 @@ import (
 type Bundle struct {
 	Chain     []*x509.Certificate
 	Cert      *x509.Certificate
+	Root      *x509.Certificate
 	Key       interface{}
 	Issuer    *pkix.Name
 	Subject   *pkix.Name
@@ -111,7 +112,7 @@ func (b *Bundle) MarshalJSON() ([]byte, error) {
 	}
 	if rsaKey, ok := b.Key.(*rsa.PrivateKey); ok {
 		keyBytes = x509.MarshalPKCS1PrivateKey(rsaKey)
-		typeString = "PRIVATE KEY"
+		typeString = "RSA PRIVATE KEY"
 	} else if ecdsaKey, ok := b.Key.(*ecdsa.PrivateKey); ok {
 		keyBytes, _ = x509.MarshalECPrivateKey(ecdsaKey)
 		typeString = "EC PRIVATE KEY"
@@ -129,6 +130,7 @@ func (b *Bundle) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(map[string]interface{}{
 		"bundle":       chain(b.Chain),
+		"root":         pemBlockToString(&pem.Block{Type: "CERTIFICATE", Bytes: b.Root.Raw}),
 		"crt":          pemBlockToString(&pem.Block{Type: "CERTIFICATE", Bytes: b.Cert.Raw}),
 		"key":          pemBlockToString(&pem.Block{Type: typeString, Bytes: keyBytes}),
 		"key_type":     keyType,

--- a/bundler/bundle_from_pem_test.go
+++ b/bundler/bundle_from_pem_test.go
@@ -24,7 +24,7 @@ type pemTest struct {
 // BundleFromPEM test cases.
 var pemTests = []pemTest{
 	{
-		cert:               validRootCert,
+		cert:               GoDaddyIntermediateCert,
 		bundlerConstructor: newBundler,
 		errorCallback:      nil,
 		bundleChecking:     ExpectBundleLength(1),
@@ -59,7 +59,7 @@ var pemTests = []pemTest{
 	// With a empty root cert pool, the valid root cert
 	// is seen as issued by an unknown authority.
 	{
-		cert:               validRootCert,
+		cert:               GoDaddyIntermediateCert,
 		bundlerConstructor: newBundlerWithoutRoots,
 		errorCallback:      ExpectErrorMessage("\"code\":1220"),
 	},
@@ -83,8 +83,34 @@ func TestBundleFromPEM(t *testing.T) {
 	}
 }
 
-// GoDaddy root cert valid until year 2026
-var validRootCert = []byte(`-----BEGIN CERTIFICATE-----
+// GoDaddy intermeidate cert valid until year 2034
+var GoDaddyRootCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIEADCCAuigAwIBAgIBADANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEh
+MB8GA1UEChMYVGhlIEdvIERhZGR5IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBE
+YWRkeSBDbGFzcyAyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTA0MDYyOTE3
+MDYyMFoXDTM0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRo
+ZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3Mg
+MiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggEN
+ADCCAQgCggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCA
+PVYYYwhv2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6w
+wdhFJ2+qN1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXi
+EqITLdiOr18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMY
+avx4A6lNf4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+
+YihfukEHU1jPEX44dMX4/7VpkI+EdOqXG68CAQOjgcAwgb0wHQYDVR0OBBYEFNLE
+sNKR1EwRcbNhyz2h/t2oatTjMIGNBgNVHSMEgYUwgYKAFNLEsNKR1EwRcbNhyz2h
+/t2oatTjoWekZTBjMQswCQYDVQQGEwJVUzEhMB8GA1UEChMYVGhlIEdvIERhZGR5
+IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBEYWRkeSBDbGFzcyAyIENlcnRpZmlj
+YXRpb24gQXV0aG9yaXR5ggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQAD
+ggEBADJL87LKPpH8EsahB4yOd6AzBhRckB4Y9wimPQoZ+YeAEW5p5JYXMP80kWNy
+OO7MHAGjHZQopDH2esRU1/blMVgDoszOYtuURXO1v0XJJLXVggKtI3lpjbi2Tc7P
+TMozI+gciKqdi0FuFskg5YmezTvacPd+mSYgFFQlq25zheabIZ0KbIIOqPjCDPoQ
+HmyW74cNxA9hi63ugyuV+I6ShHI56yDqg+2DzZduCLzrTia2cyvk0/ZM/iZx4mER
+dEr/VxqHD3VILs9RaRegAhJhldXRQLIQTO7ErBBDpqWeCtWVYpoNz4iCxTIM5Cuf
+ReYNnyicsbkqWletNw+vHX/bvZ8=
+-----END CERTIFICATE-----`)
+
+// GoDaddy intermeidate cert valid until year 2026
+var GoDaddyIntermediateCert = []byte(`-----BEGIN CERTIFICATE-----
 MIIE3jCCA8agAwIBAgICAwEwDQYJKoZIhvcNAQEFBQAwYzELMAkGA1UEBhMCVVMx
 ITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28g
 RGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjExMTYw

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -612,6 +612,7 @@ func (b *Bundler) Bundle(certs []*x509.Certificate, key crypto.Signer, flavor Bu
 	}
 	// Add root store presence info
 	root := matchingChains[0][len(matchingChains[0])-1]
+	bundle.Root = root
 	log.Infof("the anchoring root is %v", root.Subject)
 	// Check if there is any platform that doesn't trust the chain.
 	untrusted := ubiquity.UntrustedPlatforms(root)


### PR DESCRIPTION
- expose root CA of a bundle, with tests on the new format.

- Add a few tests for better code coverage.