### PR TITLE
Add support for remote 'info' endpoint

### DIFF
--- a/api/api_info.go
+++ b/api/api_info.go
@@ -1,75 +1,60 @@
 package api
 
 import (
-	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/cloudflare/cfssl/api/client"
 	"github.com/cloudflare/cfssl/bundler"
-	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/signer"
 )
 
 // InfoHandler is a type that contains the root certificates for the CA,
 // and serves information on them for clients that need the certificates.
 type InfoHandler struct {
-	roots []*x509.Certificate
+	sign signer.Signer
 }
 
-// NewInfoHandler creates a new handler to serve information on the
-// CA's certificates.
-func NewInfoHandler(roots []*x509.Certificate) http.Handler {
+// NewInfoHandler creates a new handler to serve information on the CA's
+// certificates, taking a signer to use.
+func NewInfoHandler(s signer.Signer) (http.Handler, error) {
 	return &HTTPHandler{
 		Handler: &InfoHandler{
-			roots: roots,
+			sign: s,
 		},
-		Method: "GET",
-	}
-}
-
-// NewInfoHandlerFromPEM creates a new handler to serve information on the
-// CA's certificates, taking a list of PEM-encoded certificates to use.
-func NewInfoHandlerFromPEM(pemRoots []string) (http.Handler, error) {
-	var roots []*x509.Certificate
-	for i := range pemRoots {
-		fileData, err := ioutil.ReadFile(pemRoots[i])
-		if err != nil {
-			return nil, err
-		}
-
-		cert, err := helpers.ParseCertificatePEM(fileData)
-		if err != nil {
-			return nil, err
-		}
-		roots = append(roots, cert)
-	}
-
-	return &HTTPHandler{
-		Handler: &InfoHandler{
-			roots: roots,
-		},
-		Method: "GET",
+		Method: "POST",
 	}, nil
 }
 
 // Handle listens for incoming requests for CA information, and returns
 // a list containing information on each root certificate.
 func (h *InfoHandler) Handle(w http.ResponseWriter, r *http.Request) error {
-	var bundles []bundler.Bundle
 
-	for i := range h.roots {
-		bundles = append(bundles, bundler.Bundle{
-			Chain:     []*x509.Certificate{h.roots[i]},
-			Cert:      h.roots[i],
-			Issuer:    &h.roots[i].Issuer,
-			Subject:   &h.roots[i].Subject,
-			Expires:   &h.roots[i].NotAfter,
-			Hostnames: h.roots[i].DNSNames,
-			Status:    nil,
-		})
+	req := new(client.InfoReq)
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Warningf("failed to read request body: %v", err)
+		return errors.NewBadRequest(err)
+	}
+	err = json.Unmarshal(body, req)
+	if err != nil {
+		log.Warningf("failed to unmarshal request: %v", err)
+		return errors.NewBadRequest(err)
 	}
 
-	response := NewSuccessResponse(bundles)
+	cert, err := h.sign.Certificate(req.Label, req.Profile)
+	if err != nil {
+		return err
+	}
+	resp := client.InfoResp{
+		Certificate: bundler.PemBlockToString(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}),
+	}
+
+	response := NewSuccessResponse(resp)
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 	return enc.Encode(response)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/signer/local"
 )
 
 const (
@@ -159,7 +160,107 @@ func TestSign(t *testing.T) {
 		}
 
 	}
+}
 
+func newTestInfoHandler(t *testing.T) (h http.Handler) {
+	signer, err := local.NewSignerFromFile(testCaFile, testCaKeyFile, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, err = NewInfoHandler(signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+func TestNewInfoHandler(t *testing.T) {
+	newTestInfoHandler(t)
+}
+
+func newInfoServer(t *testing.T) *httptest.Server {
+	ts := httptest.NewServer(newTestInfoHandler(t))
+	return ts
+}
+
+func testInfoFile(t *testing.T, label, profile string) (resp *http.Response, body []byte) {
+	ts := newInfoServer(t)
+	defer ts.Close()
+	obj := map[string]string{}
+	obj["label"] = label
+	obj["profile"] = profile
+
+	blob, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = http.Post(ts.URL, "application/json", bytes.NewReader(blob))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+type infoTest struct {
+	Label              string
+	Profile            string
+	ExpectedHTTPStatus int
+	ExpectedSuccess    bool
+	ExpectedErrorCode  int
+}
+
+var infoTests = []infoTest{
+	{
+		"",
+		"",
+		http.StatusOK,
+		true,
+		0,
+	},
+	{
+		"badlabel",
+		"",
+		http.StatusBadRequest,
+		false,
+		http.StatusBadRequest,
+	},
+}
+
+func TestInfo(t *testing.T) {
+	for i, test := range infoTests {
+		resp, body := testInfoFile(t, test.Label, test.Profile)
+		if resp.StatusCode != test.ExpectedHTTPStatus {
+			t.Fatalf("Test %d: expected: %d, have %d", i, test.ExpectedHTTPStatus, resp.StatusCode)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, string(body))
+		}
+
+		message := new(Response)
+		err := json.Unmarshal(body, message)
+		if err != nil {
+			t.Fatalf("failed to read response body: %v", err)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, message)
+		}
+
+		if test.ExpectedSuccess != message.Success {
+			t.Fatalf("Test %d: expected: %v, have %v", i, test.ExpectedSuccess, message.Success)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, message)
+		}
+		if test.ExpectedSuccess == true {
+			continue
+		}
+
+		if test.ExpectedErrorCode != message.Errors[0].Code {
+			t.Fatalf("Test %d: expected: %v, have %v", i, test.ExpectedErrorCode, message.Errors[0].Code)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, message)
+		}
+
+	}
 }
 
 const (

--- a/api/client/api.go
+++ b/api/client/api.go
@@ -21,3 +21,14 @@ type Response struct {
 type SignResult struct {
 	Certificate []byte `json:"certificate"`
 }
+
+// InfoReq is the request struct for an info API request.
+type InfoReq struct {
+	Label   string `json:"label"`
+	Profile string `json:"profile"`
+}
+
+// InfoResp is the response for an Info API request.
+type InfoResp struct {
+	Certificate string `json:"certificate"`
+}

--- a/bundler/bundle.go
+++ b/bundler/bundle.go
@@ -56,7 +56,8 @@ func (c chain) MarshalJSON() ([]byte, error) {
 	return json.Marshal(string(ret))
 }
 
-func pemBlockToString(block *pem.Block) string {
+// PemBlockToString turns a pem.Block into the string encoded form.
+func PemBlockToString(block *pem.Block) string {
 	if block.Bytes == nil || block.Type == "" {
 		return ""
 	}
@@ -130,9 +131,9 @@ func (b *Bundle) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(map[string]interface{}{
 		"bundle":       chain(b.Chain),
-		"root":         pemBlockToString(&pem.Block{Type: "CERTIFICATE", Bytes: b.Root.Raw}),
-		"crt":          pemBlockToString(&pem.Block{Type: "CERTIFICATE", Bytes: b.Cert.Raw}),
-		"key":          pemBlockToString(&pem.Block{Type: typeString, Bytes: keyBytes}),
+		"root":         PemBlockToString(&pem.Block{Type: "CERTIFICATE", Bytes: b.Root.Raw}),
+		"crt":          PemBlockToString(&pem.Block{Type: "CERTIFICATE", Bytes: b.Cert.Raw}),
+		"key":          PemBlockToString(&pem.Block{Type: typeString, Bytes: keyBytes}),
 		"key_type":     keyType,
 		"key_size":     keyLength,
 		"issuer":       names(b.Issuer.Names),

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -29,14 +29,6 @@ var serverFlags = []string{"address", "port", "ca", "ca-key", "ca-bundle", "int-
 
 // registerHandlers instantiates various handlers and associate them to corresponding endpoints.
 func registerHandlers(c cli.Config) error {
-	log.Info("Setting up info endpoint")
-	infoHandler, err := api.NewInfoHandlerFromPEM([]string{c.CAFile})
-	if err != nil {
-		log.Warningf("endpoint '/api/v1/cfssl/info' is disabled: %v", err)
-	} else {
-		http.Handle("/api/v1/cfssl/info", infoHandler)
-	}
-
 	log.Info("Setting up signer endpoint")
 	s, err := sign.SignerFromConfig(c)
 	if err != nil {
@@ -44,6 +36,14 @@ func registerHandlers(c cli.Config) error {
 	} else {
 		signHandler := api.NewSignHandlerFromSigner(s)
 		http.Handle("/api/v1/cfssl/sign", signHandler)
+	}
+
+	log.Info("Setting up info endpoint")
+	infoHandler, err := api.NewInfoHandler(s)
+	if err != nil {
+		log.Warningf("endpoint '/api/v1/cfssl/info' is disabled: %v", err)
+	} else {
+		http.Handle("/api/v1/cfssl/info", infoHandler)
 	}
 
 	log.Info("Setting up new cert endpoint")

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -164,9 +164,12 @@ func (s *Signer) SigAlgo() x509.SignatureAlgorithm {
 }
 
 // Certificate returns the signer's certificate.
-func (s *Signer) Certificate() *x509.Certificate {
+func (s *Signer) Certificate(label, profile string) (*x509.Certificate, error) {
+	if label != "" {
+		return nil, cferr.NewBadRequestString("label specified for local operation")
+	}
 	cert := *s.ca
-	return &cert
+	return &cert, nil
 }
 
 // SetPolicy sets the signer's signature policy.

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -68,7 +68,7 @@ func (s *Subject) Name() pkix.Name {
 // A Signer contains a CA's certificate and private key for signing
 // certificates, a Signing policy to refer to and a SignatureAlgorithm.
 type Signer interface {
-	Certificate() *x509.Certificate
+	Certificate(label, profile string) (*x509.Certificate, error)
 	Policy() *config.Signing
 	SetPolicy(*config.Signing)
 	SigAlgo() x509.SignatureAlgorithm


### PR DESCRIPTION
This was issue #98.

- Send the info request to the appropriate signer, so it now works with
  both local and remote signers.

- Send the appropriate label through, although this parameter is
  currently ignored on the remote end.

- Add some unit tests.