### PR TITLE
Additional configuration parameters for CA policies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,9 +3,13 @@ package config
 
 import (
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloudflare/cfssl/auth"
@@ -17,18 +21,44 @@ import (
 // A SigningProfile stores information that the CA needs to store
 // signature policy.
 type SigningProfile struct {
-	Usage        []string `json:"usages"`
-	IssuerURL    []string `json:"issuer_urls"`
-	OCSP         string   `json:"ocsp_url"`
-	CRL          string   `json:"crl_url"`
-	CA           bool     `json:"is_ca"`
-	ExpiryString string   `json:"expiry"`
-	AuthKeyName  string   `json:"auth_key"`
-	RemoteName   string   `json:"remote"`
+	Usage          []string `json:"usages"`
+	IssuerURL      []string `json:"issuer_urls"`
+	OCSP           string   `json:"ocsp_url"`
+	CRL            string   `json:"crl_url"`
+	CA             bool     `json:"is_ca"`
+	PolicyStrings  []string `json:"policies"`
+	OCSPNoCheck    bool     `json:"ocsp_no_check"`
+	ExpiryString   string   `json:"expiry"`
+	BackdateString string   `json:"backdate"`
+	AuthKeyName    string   `json:"auth_key"`
+	RemoteName     string   `json:"remote"`
 
+	Policies     []asn1.ObjectIdentifier
 	Expiry       time.Duration
+	Backdate     time.Duration
 	Provider     auth.Provider
 	RemoteServer string
+}
+
+func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err error) {
+	validOID, err := regexp.MatchString("\\d(\\.\\d+)*", oidString)
+	if err != nil {
+		return
+	}
+	if !validOID {
+		err = errors.New("Invalid OID")
+		return
+	}
+
+	segments := strings.Split(".", oidString)
+	oid = make(asn1.ObjectIdentifier, len(segments))
+	for i, intString := range segments {
+		oid[i], err = strconv.Atoi(intString)
+		if err != nil {
+			return
+		}
+	}
+	return
 }
 
 // populate is used to fill in the fields that are not in JSON
@@ -62,6 +92,25 @@ func (p *SigningProfile) populate(cfg *Config) error {
 
 		log.Debugf("expiry is valid")
 		p.Expiry = dur
+
+		if p.BackdateString != "" {
+			dur, err = time.ParseDuration(p.BackdateString)
+			if err != nil {
+				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+			}
+
+			p.Backdate = dur
+		}
+
+		if len(p.PolicyStrings) > 0 {
+			p.Policies = make([]asn1.ObjectIdentifier, len(p.PolicyStrings))
+			for i, oidString := range p.PolicyStrings {
+				p.Policies[i], err = parseObjectIdentifier(oidString)
+				if err != nil {
+					return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+				}
+			}
+		}
 	} else {
 		log.Debug("match remote in profile to remotes section")
 		if remote := cfg.Remotes[p.RemoteName]; remote != "" {
@@ -80,9 +129,9 @@ func (p *SigningProfile) populate(cfg *Config) error {
 			if key.Type == "standard" {
 				p.Provider, err = auth.New(key.Key, nil)
 				if err != nil {
-					log.Debugf("failed to create new stanard auth provider: %v", err)
+					log.Debugf("failed to create new standard auth provider: %v", err)
 					return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
-						errors.New("failed to create new stanard auth provider"))
+						errors.New("failed to create new standard auth provider"))
 				}
 			} else {
 				log.Debugf("unknown authentication type %v", key.Type)

--- a/config/config.go
+++ b/config/config.go
@@ -21,25 +21,23 @@ import (
 // A SigningProfile stores information that the CA needs to store
 // signature policy.
 type SigningProfile struct {
-	Usage           []string `json:"usages"`
-	IssuerURL       []string `json:"issuer_urls"`
-	OCSP            string   `json:"ocsp_url"`
-	CRL             string   `json:"crl_url"`
-	CA              bool     `json:"is_ca"`
-	PolicyStrings   []string `json:"policies"`
-	OCSPNoCheck     bool     `json:"ocsp_no_check"`
-	ExpiryString    string   `json:"expiry"`
-	BackdateString  string   `json:"backdate"`
-	AuthKeyName     string   `json:"auth_key"`
-	RemoteName      string   `json:"remote"`
-	NotBeforeString string   `json:"not_before"`
-	NotAfterString  string   `json:"not_after"`
+	Usage          []string  `json:"usages"`
+	IssuerURL      []string  `json:"issuer_urls"`
+	OCSP           string    `json:"ocsp_url"`
+	CRL            string    `json:"crl_url"`
+	CA             bool      `json:"is_ca"`
+	PolicyStrings  []string  `json:"policies"`
+	OCSPNoCheck    bool      `json:"ocsp_no_check"`
+	ExpiryString   string    `json:"expiry"`
+	BackdateString string    `json:"backdate"`
+	AuthKeyName    string    `json:"auth_key"`
+	RemoteName     string    `json:"remote"`
+	NotBefore      time.Time `json:"not_before"`
+	NotAfter       time.Time `json:"not_after"`
 
 	Policies     []asn1.ObjectIdentifier
 	Expiry       time.Duration
 	Backdate     time.Duration
-	NotBefore    time.Time
-	NotAfter     time.Time
 	Provider     auth.Provider
 	RemoteServer string
 }
@@ -106,24 +104,6 @@ func (p *SigningProfile) populate(cfg *Config) error {
 			}
 
 			p.Backdate = dur
-		}
-
-		if p.NotBeforeString != "" {
-			time, err := time.Parse(timeFormat, p.NotBeforeString)
-			if err != nil {
-				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
-			}
-
-			p.NotBefore = time
-		}
-
-		if p.NotAfterString != "" {
-			time, err := time.Parse(timeFormat, p.NotAfterString)
-			if err != nil {
-				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
-			}
-
-			p.NotAfter = time
 		}
 
 		if !p.NotBefore.IsZero() && !p.NotAfter.IsZero() && p.NotAfter.Before(p.NotBefore) {

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err err
 		return
 	}
 
-	segments := strings.Split(".", oidString)
+	segments := strings.Split(oidString, ".")
 	oid = make(asn1.ObjectIdentifier, len(segments))
 	for i, intString := range segments {
 		oid[i], err = strconv.Atoi(intString)

--- a/config/config.go
+++ b/config/config.go
@@ -21,21 +21,25 @@ import (
 // A SigningProfile stores information that the CA needs to store
 // signature policy.
 type SigningProfile struct {
-	Usage          []string `json:"usages"`
-	IssuerURL      []string `json:"issuer_urls"`
-	OCSP           string   `json:"ocsp_url"`
-	CRL            string   `json:"crl_url"`
-	CA             bool     `json:"is_ca"`
-	PolicyStrings  []string `json:"policies"`
-	OCSPNoCheck    bool     `json:"ocsp_no_check"`
-	ExpiryString   string   `json:"expiry"`
-	BackdateString string   `json:"backdate"`
-	AuthKeyName    string   `json:"auth_key"`
-	RemoteName     string   `json:"remote"`
+	Usage           []string `json:"usages"`
+	IssuerURL       []string `json:"issuer_urls"`
+	OCSP            string   `json:"ocsp_url"`
+	CRL             string   `json:"crl_url"`
+	CA              bool     `json:"is_ca"`
+	PolicyStrings   []string `json:"policies"`
+	OCSPNoCheck     bool     `json:"ocsp_no_check"`
+	ExpiryString    string   `json:"expiry"`
+	BackdateString  string   `json:"backdate"`
+	AuthKeyName     string   `json:"auth_key"`
+	RemoteName      string   `json:"remote"`
+	NotBeforeString string   `json:"not_before"`
+	NotAfterString  string   `json:"not_after"`
 
 	Policies     []asn1.ObjectIdentifier
 	Expiry       time.Duration
 	Backdate     time.Duration
+	NotBefore    time.Time
+	NotAfter     time.Time
 	Provider     auth.Provider
 	RemoteServer string
 }
@@ -60,6 +64,8 @@ func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err err
 	}
 	return
 }
+
+const timeFormat = "2006-01-02T15:04:05"
 
 // populate is used to fill in the fields that are not in JSON
 //
@@ -100,6 +106,28 @@ func (p *SigningProfile) populate(cfg *Config) error {
 			}
 
 			p.Backdate = dur
+		}
+
+		if p.NotBeforeString != "" {
+			time, err := time.Parse(timeFormat, p.NotBeforeString)
+			if err != nil {
+				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+			}
+
+			p.NotBefore = time
+		}
+
+		if p.NotAfterString != "" {
+			time, err := time.Parse(timeFormat, p.NotAfterString)
+			if err != nil {
+				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+			}
+
+			p.NotAfter = time
+		}
+
+		if !p.NotBefore.IsZero() && !p.NotAfter.IsZero() && p.NotAfter.Before(p.NotBefore) {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
 		}
 
 		if len(p.PolicyStrings) > 0 {


### PR DESCRIPTION
For Let's Encrypt, we require a few additional policy knobs to generate certificates with the profile we want.

* Specifying certificate policies (as OIDs)
* Specifying the OCSP No Check extension
* Specifying the amount of back-dating applied to a certificate

This PR adds those controls to config.SigningProfile, and adapts signer.FillTemplate() to put them into action.

As of this commit, the patch is untested, but builds and passes `go vet` and `golint`