### PR TITLE
Fix remote signing bugs

### DIFF
--- a/api/sign/sign.go
+++ b/api/sign/sign.go
@@ -87,7 +87,7 @@ type jsonSignRequest struct {
 }
 
 func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
-	var sub *signer.Subject
+	sub := new(signer.Subject)
 	if js.Subject == nil {
 		sub = nil
 	} else {
@@ -294,8 +294,8 @@ func (h *AuthHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 		return errors.NewBadRequestString("invalid token")
 	}
 
-	if req.Hostname == "" {
-		return errors.NewBadRequestString("missing hostname parameter")
+	if req.Hostname == "" && len(req.Hosts) == 0 {
+		return errors.NewBadRequestString("missing hostnames")
 	}
 
 	if req.Request == "" {


### PR DESCRIPTION
Recent changes around hostname handling broke remote signing by creating a discontinuity in how the API client and server expressed lists of hostnames.

* Nil pointer dereference on subject copy
* Requests without `hostnames` rejected even when `hosts` was present

This PR fixes these two bugs.