### PR TITLE
Disabling authentication for 'info'

### DIFF
--- a/signer/remote/remote.go
+++ b/signer/remote/remote.go
@@ -69,7 +69,9 @@ func (s *Signer) remoteOp(req interface{}, profile, target string) (cert []byte,
 			errors.New("failed to connect to remote"))
 	}
 
-	if p.Provider != nil {
+	// There's no server-side auth provider for the "info" method
+	// TODO: Revert this change once there is an AuthInfo provider.
+	if p.Provider != nil && target != "info" {
 		cert, err = server.AuthReq(jsonData, nil, p.Provider, target)
 	} else {
 		cert, err = server.Req(jsonData, target)


### PR DESCRIPTION
`remote.Certificate()` is broken right now when you use an authentication provider.  The API client tries to send an authenticated request to `/api/v1/cfssl/authinfo`, for which there's no corresponding API server.  This PR disables authentication for info requests (which aren't sensitive anyway), until such time as there's an API server to respond to authenticated requests.