### PR TITLE
Add info endpoint to return public keys.

### DIFF
--- a/cmd/multirootca/api.go
+++ b/cmd/multirootca/api.go
@@ -193,3 +193,17 @@ func dumpMetrics(w http.ResponseWriter, req *http.Request) {
 
 	w.Write(out)
 }
+
+// info returns a JSON-encoded map of labels to certificates.
+func info(w http.ResponseWriter, req *http.Request) {
+	incRequests()
+
+	// publics is defined in ca.go; it contains a mapping of
+	// labels to certificates.
+	res := api.NewSuccessResponse(publics)
+	jenc := json.NewEncoder(w)
+	err := jenc.Encode(res)
+	if err != nil {
+		log.Errorf("error writing response to info endpoint: %v", err)
+	}
+}


### PR DESCRIPTION
Right now, clients do not have a means to access the public certificates for the signers in the multiroot CA. This PR adds an endpoint that returns a json encoded list of API certificates to the client.