### PR TITLE
Add policy-level CSR whitelist.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -127,7 +127,7 @@ func Start(cmds map[string]*Command) {
 	var err error
 	c.CFG, err = config.LoadFile(c.ConfigFile)
 	if c.ConfigFile != "" && err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load config file\n")
+		fmt.Fprintf(os.Stderr, "Failed to load config file: %v", err)
 		os.Exit(1)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,16 +18,16 @@ import (
 	"github.com/cloudflare/cfssl/log"
 )
 
-// A CsrWhitelist stores booleans for fields in the CSR. If a CsrWhitelist is
+// A CSRWhitelist stores booleans for fields in the CSR. If a CSRWhitelist is
 // not present in a SigningProfile, all of these fields may be copied from the
-// CSR into the signed certificate. If a CsrWhitelist *is* present in a
-// SigningProfile, only those fields with a `true` value in the CsrWhitelist may
+// CSR into the signed certificate. If a CSRWhitelist *is* present in a
+// SigningProfile, only those fields with a `true` value in the CSRWhitelist may
 // be copied from the CSR to the signed certificate. Note that some of these
 // fields, like Subject, can be provided or partially provided through the API.
 // Since API clients are expected to be trusted, but CSRs are not, fields
 // provided through the API are not subject to whitelisting through this
 // mechanism.
-type CsrWhitelist struct {
+type CSRWhitelist struct {
 	Subject, PublicKeyAlgorithm, PublicKey, SignatureAlgorithm bool
 	DNSNames, IPAddresses bool
 }
@@ -55,7 +55,7 @@ type SigningProfile struct {
 	Provider     auth.Provider
 	RemoteServer string
 	UseSerialSeq bool
-	CsrWhitelist *CsrWhitelist
+	CSRWhitelist *CSRWhitelist
 }
 
 func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err error) {

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,20 @@ import (
 	"github.com/cloudflare/cfssl/log"
 )
 
+// A CsrWhitelist stores booleans for fields in the CSR. If a CsrWhitelist is
+// not present in a SigningProfile, all of these fields may be copied from the
+// CSR into the signed certificate. If a CsrWhitelist *is* present in a
+// SigningProfile, only those fields with a `true` value in the CsrWhitelist may
+// be copied from the CSR to the signed certificate. Note that some of these
+// fields, like Subject, can be provided or partially provided through the API.
+// Since API clients are expected to be trusted, but CSRs are not, fields
+// provided through the API are not subject to whitelisting through this
+// mechanism.
+type CsrWhitelist struct {
+	Subject, PublicKeyAlgorithm, PublicKey, SignatureAlgorithm bool
+	DNSNames, IPAddresses bool
+}
+
 // A SigningProfile stores information that the CA needs to store
 // signature policy.
 type SigningProfile struct {
@@ -41,6 +55,7 @@ type SigningProfile struct {
 	Provider     auth.Provider
 	RemoteServer string
 	UseSerialSeq bool
+	CsrWhitelist *CsrWhitelist
 }
 
 func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err error) {
@@ -393,7 +408,8 @@ func LoadConfig(config []byte) (*Config, error) {
 	var cfg = &Config{}
 	err := json.Unmarshal(config, &cfg)
 	if err != nil {
-		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("failed to unmarshal configuration"))
+		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+			errors.New("failed to unmarshal configuration: " + err.Error()))
 	}
 
 	if cfg.Signing.Default == nil {

--- a/doc/api.txt
+++ b/doc/api.txt
@@ -71,13 +71,6 @@ The subject contains:
           * 'ST': the state or province
         * CN: the certificate's Common Name.
 
-	* whitelist: if not null, this structure contains a set of
-        boolean fields indicating which fields should be accepted from
-        the client CSR. These fields are CN, C, L, O, OU, and ST. Any
-        fields not explicitly set to true will not be copied from the
-        CSR. However, if the whitelist is null, it will not be
-        checked.
-
 Result: { "certificate": "-----BEGIN CERTIFICATE..." }
 
 2.2 BUNDLING

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -197,25 +197,25 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 	safeTemplate := x509.Certificate{}
 	// If the profile contains no explicit whitelist, assume that all fields
 	// should be copied from the CSR.
-	if profile.CsrWhitelist == nil {
+	if profile.CSRWhitelist == nil {
 		safeTemplate = *csrTemplate
 	} else {
-		if profile.CsrWhitelist.Subject {
+		if profile.CSRWhitelist.Subject {
 			safeTemplate.Subject = csrTemplate.Subject
 		}
-		if profile.CsrWhitelist.PublicKeyAlgorithm {
+		if profile.CSRWhitelist.PublicKeyAlgorithm {
 			safeTemplate.PublicKeyAlgorithm = csrTemplate.PublicKeyAlgorithm
 		}
-		if profile.CsrWhitelist.PublicKey {
+		if profile.CSRWhitelist.PublicKey {
 			safeTemplate.PublicKey = csrTemplate.PublicKey
 		}
-		if profile.CsrWhitelist.SignatureAlgorithm {
+		if profile.CSRWhitelist.SignatureAlgorithm {
 			safeTemplate.SignatureAlgorithm = csrTemplate.SignatureAlgorithm
 		}
-		if profile.CsrWhitelist.DNSNames {
+		if profile.CSRWhitelist.DNSNames {
 			safeTemplate.DNSNames = csrTemplate.DNSNames
 		}
-		if profile.CsrWhitelist.IPAddresses {
+		if profile.CSRWhitelist.IPAddresses {
 			safeTemplate.IPAddresses = csrTemplate.IPAddresses
 		}
 	}

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -122,36 +122,6 @@ func replaceSliceIfEmpty(replaced, newContents *[]string) {
 	}
 }
 
-func whitelistString(keep bool, field *string) {
-	if !keep {
-		*field = ""
-	}
-}
-
-func whitelistStringSlice(keep bool, field *[]string) {
-	if !keep {
-		*field = []string{}
-	}
-}
-
-// whitelistRequest checks the request for a whitelist. If one isn't
-// present, the name is untouched. If it is present, only those fields
-// which are explictly permitted are kept.
-func whitelistRequest(s *signer.Subject, name pkix.Name) pkix.Name {
-	if s == nil || s.Whitelist == nil {
-		return name
-	}
-
-	whitelistString(s.Whitelist.CN, &name.CommonName)
-	whitelistStringSlice(s.Whitelist.C, &name.Country)
-	whitelistStringSlice(s.Whitelist.ST, &name.Province)
-	whitelistStringSlice(s.Whitelist.L, &name.Locality)
-	whitelistStringSlice(s.Whitelist.O, &name.Organization)
-	whitelistStringSlice(s.Whitelist.OU, &name.OrganizationalUnit)
-
-	return name
-}
-
 // PopulateSubjectFromCSR has functionality similar to Name, except
 // it fills the fields of the resulting pkix.Name with req's if the
 // subject's corresponding fields are empty
@@ -161,10 +131,6 @@ func PopulateSubjectFromCSR(s *signer.Subject, req pkix.Name) pkix.Name {
 		return req
 	}
 
-	req = whitelistRequest(s, req)
-	if len(s.Names) == 0 {
-		return req
-	}
 	name := s.Name()
 
 	if name.CommonName == "" {
@@ -222,15 +188,42 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 			cferr.BadRequest, errors.New("not a certificate or csr"))
 	}
 
-	template, err := signer.ParseCertificateRequest(s, block.Bytes)
+	csrTemplate, err := signer.ParseCertificateRequest(s, block.Bytes)
 	if err != nil {
 		return nil, err
 	}
 
-	OverrideHosts(template, req.Hosts)
-	template.Subject = PopulateSubjectFromCSR(req.Subject, template.Subject)
+	// Copy out only the fields from the CSR authorized by policy.
+	safeTemplate := x509.Certificate{}
+	// If the profile contains no explicit whitelist, assume that all fields
+	// should be copied from the CSR.
+	if profile.CsrWhitelist == nil {
+		safeTemplate = *csrTemplate
+	} else {
+		if profile.CsrWhitelist.Subject {
+			safeTemplate.Subject = csrTemplate.Subject
+		}
+		if profile.CsrWhitelist.PublicKeyAlgorithm {
+			safeTemplate.PublicKeyAlgorithm = csrTemplate.PublicKeyAlgorithm
+		}
+		if profile.CsrWhitelist.PublicKey {
+			safeTemplate.PublicKey = csrTemplate.PublicKey
+		}
+		if profile.CsrWhitelist.SignatureAlgorithm {
+			safeTemplate.SignatureAlgorithm = csrTemplate.SignatureAlgorithm
+		}
+		if profile.CsrWhitelist.DNSNames {
+			safeTemplate.DNSNames = csrTemplate.DNSNames
+		}
+		if profile.CsrWhitelist.IPAddresses {
+			safeTemplate.IPAddresses = csrTemplate.IPAddresses
+		}
+	}
 
-	return s.sign(template, profile, serialSeq)
+	OverrideHosts(&safeTemplate, req.Hosts)
+	safeTemplate.Subject = PopulateSubjectFromCSR(req.Subject, safeTemplate.Subject)
+
+	return s.sign(&safeTemplate, profile, serialSeq)
 }
 
 // SigAlgo returns the RSA signer's signature algorithm.

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -760,7 +760,7 @@ func TestWhitelistSign(t *testing.T) {
 			ExpiryString: "1h",
 			Expiry:       1 * time.Hour,
 			CA:           true,
-			CsrWhitelist:    &config.CsrWhitelist{
+			CSRWhitelist:    &config.CSRWhitelist{
 				PublicKey: true,
 				PublicKeyAlgorithm: true,
 				SignatureAlgorithm: true,

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -668,70 +668,23 @@ func TestOverwriteHosts(t *testing.T) {
 
 }
 
-func TestWhitelist(t *testing.T) {
-	name := csr.CertificateRequest{
-		Names: []csr.Name{
-			{
-				C:  "C",
-				ST: "ST",
-				L:  "L",
-				O:  "O",
-				OU: "OU",
-			},
-		},
-		CN: "something dot com",
+func expectOneValueOf(t *testing.T, s []string, e, n string) {
+	if len(s) != 1 {
+		t.Fatalf("Expected %s to have a single value, but it has %d values", n, len(s))
 	}
 
-	subject := &signer.Subject{
-		Whitelist: &signer.Whitelist{
-			C: true,
-			O: true,
-		},
-	}
-
-	out := whitelistRequest(subject, name.Name())
-	if out.CommonName != "" {
-		t.Fatal("Common name should not have been whitelisted.")
-	}
-
-	if len(out.Country) != 0 && out.Country[0] != "C" {
-		t.Fatalf("Expected country to be whitelisted and preserved, but have %v", out.Country)
-	}
-
-	if len(out.Province) != 0 {
-		t.Fatalf("Expected province to not have been whitelisted, but have %v", out.Province)
-	}
-
-	if len(out.Locality) != 0 {
-		t.Fatalf("Expected locality to not have been whitelisted, but have %v", out.Locality)
-	}
-
-	if len(out.Organization) != 0 && out.Organization[0] != "O" {
-		t.Fatalf("Expected organization to be whitelisted and preserved, but have %v", out.Organization)
-	}
-
-	if len(out.OrganizationalUnit) != 0 {
-		t.Fatalf("Expected organizational unit to not have been whitelisted, but have %v", out.OrganizationalUnit)
+	if s[0] != e {
+		t.Fatalf("Expected %s to be '%s', but it is '%s'", n, e, s[0])
 	}
 }
 
-func TestWhitelistSign(t *testing.T) {
-	expectOneValueOf := func(s []string, e, n string) {
-		if len(s) != 1 {
-			t.Fatalf("Expected %s to have a single value, but it has %d values", n, len(s))
-		}
-
-		if s[0] != e {
-			t.Fatalf("Expected %s to be '%s', but it is '%s'", n, e, s[0])
-		}
+func expectEmpty(t *testing.T, s []string, n string) {
+	if len(s) != 0 {
+		t.Fatalf("Expected no values in %s, but have %d values: %v", n, len(s), s)
 	}
+}
 
-	expectEmpty := func(s []string, n string) {
-		if len(s) != 0 {
-			t.Fatalf("Expected no values in %s, but have %d values", n, len(s))
-		}
-	}
-
+func TestNoWhitelistSign(t *testing.T) {
 	csrPEM, err := ioutil.ReadFile(fullSubjectCSR)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -741,13 +694,20 @@ func TestWhitelistSign(t *testing.T) {
 		Names: []csr.Name{
 			{O: "sam certificate authority"},
 		},
-		Whitelist: &signer.Whitelist{
-			OU: true,
-		},
 		CN: "localhost",
 	}
 
 	s := newCustomSigner(t, testECDSACaFile, testECDSACaKeyFile)
+	// No policy CSR whitelist: the normal set of CSR fields get passed through to
+	// certificate.
+	s.policy = &config.Signing{
+		Default: &config.SigningProfile{
+			Usage:        []string{"cert sign", "crl sign"},
+			ExpiryString: "1h",
+			Expiry:       1 * time.Hour,
+			CA:           true,
+		},
+	}
 
 	request := signer.SignRequest{
 		Hosts:   []string{"127.0.0.1", "localhost"},
@@ -770,9 +730,80 @@ func TestWhitelistSign(t *testing.T) {
 		t.Fatalf("Expected certificate common name to be 'localhost' but have '%v'", name.CommonName)
 	}
 
-	expectOneValueOf(name.Organization, "sam certificate authority", "O")
-	expectOneValueOf(name.OrganizationalUnit, "WWW", "OU")
-	expectEmpty(name.Province, "ST")
-	expectEmpty(name.Locality, "L")
-	expectEmpty(name.Country, "C")
+	// CSR has: Subject: C=US, O=CloudFlare, OU=WWW, L=Ithaca, ST=New York
+	// Expect all to be passed through.
+	expectOneValueOf(t, name.Organization, "sam certificate authority", "O")
+	expectOneValueOf(t, name.OrganizationalUnit, "WWW", "OU")
+	expectOneValueOf(t, name.Province, "New York", "ST")
+	expectOneValueOf(t, name.Locality, "Ithaca", "L")
+	expectOneValueOf(t, name.Country, "US", "C")
+}
+
+func TestWhitelistSign(t *testing.T) {
+	csrPEM, err := ioutil.ReadFile(fullSubjectCSR)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	req := &signer.Subject{
+		Names: []csr.Name{
+			{O: "sam certificate authority"},
+		},
+	}
+
+	s := newCustomSigner(t, testECDSACaFile, testECDSACaKeyFile)
+	// Whitelist only key-related fields. Subject, DNSNames, etc shouldn't get
+	// passed through from CSR.
+	s.policy = &config.Signing{
+		Default: &config.SigningProfile{
+			Usage:        []string{"cert sign", "crl sign"},
+			ExpiryString: "1h",
+			Expiry:       1 * time.Hour,
+			CA:           true,
+			CsrWhitelist:    &config.CsrWhitelist{
+				PublicKey: true,
+				PublicKeyAlgorithm: true,
+				SignatureAlgorithm: true,
+			},
+		},
+	}
+
+	request := signer.SignRequest{
+		Hosts:   []string{"127.0.0.1", "localhost"},
+		Request: string(csrPEM),
+		Subject: req,
+	}
+
+	certPEM, err := s.Sign(request)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	cert, err := helpers.ParseCertificatePEM(certPEM)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	name := cert.Subject
+	if name.CommonName != "" {
+		t.Fatalf("Expected empty certificate common name under policy without " +
+			"Subject whitelist, got %v", name.CommonName)
+	}
+	// O is provided by the signing API request, not the CSR, so it's allowed to
+	// be copied into the certificate.
+	expectOneValueOf(t, name.Organization, "sam certificate authority", "O")
+	expectEmpty(t, name.OrganizationalUnit, "OU")
+	expectEmpty(t, name.Province, "ST")
+	expectEmpty(t, name.Locality, "L")
+	expectEmpty(t, name.Country, "C")
+	if cert.PublicKeyAlgorithm != x509.RSA {
+		t.Fatalf("Expected public key algorithm to be RSA")
+	}
+
+	// Signature algorithm is allowed to be copied from CSR, but is overridden by
+	// DefaultSigAlgo.
+	if cert.SignatureAlgorithm != x509.ECDSAWithSHA256 {
+		t.Fatalf("Expected public key algorithm to be ECDSAWithSHA256, got %v",
+			cert.SignatureAlgorithm)
+	}
 }


### PR DESCRIPTION
For public CA use, Let's Encrypt / Boulder would like to be able to explicitly
distrust certain fields from the untrusted input CSR. More specifically, we'd
like a whitelist of fields that can be copied from the CSR, so that any fields
added in the future will be excluded rather than included.

This change builds on / replaces @kisom's earlier change that provides a whitelist on the
Subject field, passed by the API call.