### PR TITLE
Add an OSCP responder

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	List              bool
 	Family            string
 	Scanner           string
+	Responses         string
+	Path              string
 }
 
 // registerFlags defines all cfssl command flags and associates their values with variables.
@@ -80,6 +82,8 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.BoolVar(&c.List, "list", false, "list possible scanners")
 	f.StringVar(&c.Family, "family", "", "scanner family regular expression")
 	f.StringVar(&c.Scanner, "scanner", "", "scanner regular expression")
+	f.StringVar(&c.Responses, "responses", "", "file to load OCSP responses from")
+	f.StringVar(&c.Path, "path", "/", "Path on which the server will listen")
 
 	if pkcs11.Enabled {
 		f.StringVar(&c.Module, "pkcs11-module", "", "PKCS #11 module")

--- a/cli/ocspserve/oscpserve.go
+++ b/cli/ocspserve/oscpserve.go
@@ -1,0 +1,51 @@
+package ocspserve
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/cloudflare/cfssl/cli"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/ocsp"
+)
+
+// Usage text of 'cfssl serve'
+var ocspServerUsageText = `cfssl ocspserve -- set up an HTTP server that handles OCSP requests from a file (see RFC 5019)
+
+  Usage of ocspserve:
+          cfssl ocspserve [-address address] [-port port] [-responses file]
+
+  Flags:
+  `
+
+// Flags used by 'cfssl serve'
+var ocspServerFlags = []string{"address", "port", "responses"}
+
+// ocspServerMain is the command line entry point to the OCSP responder.
+// It sets up a new HTTP server that responds to OCSP requests.
+func ocspServerMain(args []string, c cli.Config) error {
+	// serve doesn't support arguments.
+	if len(args) > 0 {
+		return errors.New("argument is provided but not defined; please refer to the usage by flag -h")
+	}
+
+	if c.Responses == "" {
+		return errors.New("no response file provided, please set the -responses flag")
+	}
+
+	src, err := ocsp.NewSourceFromFile(c.Responses)
+	if err != nil {
+		return errors.New("unable to read response file")
+	}
+
+	log.Info("Registering OCSP responder handler")
+	http.Handle(c.Path, ocsp.Responder{Source: src})
+
+	addr := fmt.Sprintf("%s:%d", c.Address, c.Port)
+	log.Info("Now listening on ", addr)
+	return http.ListenAndServe(addr, nil)
+}
+
+// CLIServer assembles the definition of Command 'serve'
+var Command = &cli.Command{UsageText: ocspServerUsageText, Flags: ocspServerFlags, Main: ocspServerMain}

--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudflare/cfssl/cli/bundle"
 	"github.com/cloudflare/cfssl/cli/gencert"
 	"github.com/cloudflare/cfssl/cli/genkey"
+	"github.com/cloudflare/cfssl/cli/ocspserve"
 	"github.com/cloudflare/cfssl/cli/ocspsign"
 	"github.com/cloudflare/cfssl/cli/scan"
 	"github.com/cloudflare/cfssl/cli/selfsign"
@@ -43,15 +44,16 @@ func main() {
 	flag.IntVar(&log.Level, "loglevel", log.LevelInfo, "Log level")
 	// Register commands.
 	cmds := map[string]*cli.Command{
-		"bundle":   bundle.Command,
-		"sign":     sign.Command,
-		"serve":    serve.Command,
-		"version":  version.Command,
-		"genkey":   genkey.Command,
-		"gencert":  gencert.Command,
-		"ocspsign": ocspsign.Command,
-		"selfsign": selfsign.Command,
-		"scan":     scan.Command,
+		"bundle":    bundle.Command,
+		"sign":      sign.Command,
+		"serve":     serve.Command,
+		"version":   version.Command,
+		"genkey":    genkey.Command,
+		"gencert":   gencert.Command,
+		"ocspsign":  ocspsign.Command,
+		"ocspserve": ocspserve.Command,
+		"selfsign":  selfsign.Command,
+		"scan":      scan.Command,
 	}
 	// Register all command flags.
 	cli.Start(cmds)

--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -1,0 +1,141 @@
+package ocsp
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/cloudflare/cfssl/log"
+	"golang.org/x/crypto/ocsp"
+)
+
+var (
+	malformedRequestErrorResponse = []byte{0x30, 0x03, 0x0A, 0x01, 0x01}
+	internalErrorErrorResponse    = []byte{0x30, 0x03, 0x0A, 0x01, 0x02}
+	tryLaterErrorResponse         = []byte{0x30, 0x03, 0x0A, 0x01, 0x03}
+	sigRequredErrorResponse       = []byte{0x30, 0x03, 0x0A, 0x01, 0x05}
+	unauthorizedErrorResponse     = []byte{0x30, 0x03, 0x0A, 0x01, 0x06}
+)
+
+// Source represents the logical source of OCSP responses, i.e.,
+// the logic that actually chooses a response based on a request.  In
+// order to create an actual responder, wrap one of these in a Responder
+// object and pass it to http.Handle.
+type Source interface {
+	Response(*ocsp.Request) ([]byte, bool)
+}
+
+// An InMemorySource is a map from serialNumber -> der(response)
+type InMemorySource map[string][]byte
+
+// Response looks up an OCSP response to provide for a given request.
+// InMemorySource looks up a response purely based on serial number,
+// without regard to what issuer the request is asking for.
+func (src InMemorySource) Response(request *ocsp.Request) (response []byte, present bool) {
+	response, present = src[request.SerialNumber.String()]
+	return
+}
+
+// NewSourceFromFile reads the named file into an InMemorySource.
+// The file read by this function must contain whitespace-separated OCSP
+// responses. Each OCSP response must be in base64-encoded DER form (i.e.,
+// PEM without headers or whitespace).  Invalid responses are ignored.
+// This function pulls the entire file into an InMemorySource.
+func NewSourceFromFile(responseFile string) (Source, error) {
+	fileContents, err := ioutil.ReadFile(responseFile)
+	if err != nil {
+		return nil, err
+	}
+
+	responsesB64 := regexp.MustCompile("\\s").Split(string(fileContents), -1)
+	src := InMemorySource{}
+	for _, b64 := range responsesB64 {
+		der, tmpErr := base64.StdEncoding.DecodeString(b64)
+		if tmpErr != nil {
+			log.Errorf("Base64 decode error on: %s", b64)
+			continue
+		}
+
+		response, tmpErr := ocsp.ParseResponse(der, nil)
+		if tmpErr != nil {
+			log.Errorf("OCSP decode error on: %s", b64)
+			continue
+		}
+
+		src[response.SerialNumber.String()] = der
+	}
+
+	log.Infof("Read %d OCSP responses", len(src))
+	return src, nil
+}
+
+// A Responder object provides the HTTP logic to expose a
+// Source of OCSP responses.
+type Responder struct {
+	Source Source
+}
+
+// A Responder can process both GET and POST requests.  The mapping
+// from an OCSP request to an OCSP response is done by the Source;
+// the Responder simply decodes the request, and passes back whatever
+// response is provided by the source.
+func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	// Read response from request
+	var requestBody []byte
+	var err error
+	switch request.Method {
+	case "GET":
+		re := regexp.MustCompile("^.*/")
+		base64Request := re.ReplaceAllString(request.RequestURI, "")
+		base64Request, err = url.QueryUnescape(base64Request)
+		if err != nil {
+			return
+		}
+		requestBody, err = base64.StdEncoding.DecodeString(base64Request)
+		if err != nil {
+			return
+		}
+	case "POST":
+		requestBody, err = ioutil.ReadAll(request.Body)
+		if err != nil {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	default:
+		response.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	// TODO log request
+	b64Body := base64.StdEncoding.EncodeToString(requestBody)
+	log.Infof("Received OCSP request: %s", b64Body)
+
+	// All responses after this point will be OCSP.
+	// We could check for the content type of the request, but that
+	// seems unnecessariliy restrictive.
+	response.Header().Add("Content-Type", "application/ocsp-response")
+
+	// Parse response as an OCSP request
+	// XXX: This fails if the request contains the nonce extension.
+	//      We don't intend to support nonces anyway, but maybe we
+	//      should return unauthorizedRequest instead of malformed.
+	ocspRequest, err := ocsp.ParseRequest(requestBody)
+	if err != nil {
+		log.Errorf("Error decoding request body: %s", b64Body)
+		response.Write(malformedRequestErrorResponse)
+		return
+	}
+
+	// Look up OCSP response from source
+	ocspResponse, found := rs.Source.Response(ocspRequest)
+	if !found {
+		log.Errorf("No response found for request: %s", b64Body)
+		response.Write(unauthorizedErrorResponse)
+		return
+	}
+
+	// Write OCSP response to response
+	response.WriteHeader(http.StatusOK)
+	response.Write(ocspResponse)
+}


### PR DESCRIPTION
This PR adds a very basic OCSP responder to CFSSL. It comes in few major
parts:

A generic interface for an OCSP "source", which maps requests to
responses
An instance of this interface that reads responses from a flat file
An OCSP Responder struct that can respond for any source
A CLI command that assembles the whole thing together. (file -> source
-> responder -> http)