### PR TITLE
Improved usage message.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -84,15 +84,18 @@ func Start(cmds map[string]*Command) {
 
 	registerFlags(&c, cfsslFlagSet)
 	// Initial parse of command line arguments. By convention, only -h/-help is supported.
-	flag.Parse()
 	if flag.Usage == nil {
 		flag.Usage = func() {
 			fmt.Fprintf(os.Stderr, usage)
 			for name := range cmds {
-				fmt.Fprintf(os.Stderr, "%s\n", name)
+				fmt.Fprintf(os.Stderr, "\t%s\n", name)
 			}
+			fmt.Fprintf(os.Stderr, "Top-level flags:\n")
+			flag.PrintDefaults()
 		}
 	}
+
+	flag.Parse()
 
 	if flag.NArg() < 1 {
 		fmt.Fprintf(os.Stderr, "No command is given.\n")
@@ -112,7 +115,7 @@ func Start(cmds map[string]*Command) {
 	// The usage of each individual command is re-written to mention
 	// flags defined and referenced only in that command.
 	cfsslFlagSet.Usage = func() {
-		fmt.Fprintf(os.Stderr, "%s", cmd.UsageText)
+		fmt.Fprintf(os.Stderr, "\t%s", cmd.UsageText)
 		for _, name := range cmd.Flags {
 			if f := cfsslFlagSet.Lookup(name); f != nil {
 				printDefaultValue(f)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -8,6 +8,11 @@ import (
 
 var cfsslFlagSet = flag.NewFlagSet("cfssl", flag.ExitOnError)
 
+// The testing style from this package is borrowed from the Go flag
+// library's methodology for testing this. We set flag.Usage to nil,
+// then replace it with a closure to ensure the usage function was
+// called appropriately.
+
 // 'cfssl -help' should be supported.
 func TestHelp(t *testing.T) {
 	called := false

--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -38,8 +38,8 @@ import (
 
 // main defines the cfssl usage and registers all defined commands and flags.
 func main() {
-	flag.Usage = nil
 	// Add command names to cfssl usage
+	flag.Usage = nil // this is set to nil for testabilty
 	flag.IntVar(&log.Level, "loglevel", log.LevelInfo, "Log level")
 	// Register commands.
 	cmds := map[string]*cli.Command{


### PR DESCRIPTION
This avoids panicking if with a top-level usage. Addresses #167.