### PR TITLE
Fix missing certificate PEM for API newcert

### DIFF
--- a/api/generator/generator.go
+++ b/api/generator/generator.go
@@ -234,8 +234,6 @@ func (cg *CertGeneratorHandler) Handle(w http.ResponseWriter, r *http.Request) e
 		return err
 	}
 
-	var certPEM []byte
-
 	var profile *config.SigningProfile
 	policy := cg.signer.Policy()
 	if policy != nil && policy.Profiles != nil && req.Profile != "" {
@@ -273,7 +271,7 @@ func (cg *CertGeneratorHandler) Handle(w http.ResponseWriter, r *http.Request) e
 	result := map[string]interface{}{
 		"private_key":         string(key),
 		"certificate_request": string(csr),
-		"certificate":         string(certPEM),
+		"certificate":         string(certBytes),
 		"sums": map[string]Sum{
 			"certificate_request": reqSum,
 			"certificate":         certSum,


### PR DESCRIPTION
When using the API, the certificate is missing due to some leftover refactor code I narrowed down to be this PR: https://github.com/cloudflare/cfssl/commit/ea6c2ed8b0884063ef450d74c34b44f148a84f5f

This fixes it by removing certPEM and using certBytes which is what is returned from the signer.