### PR TITLE
Zi/refactor sha1 deprecation

### DIFF
--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -47,12 +47,11 @@ const (
 )
 
 const (
-	sha2Warning              = "The bundle contains certs signed with advanced hash functions such as SHA2,  which are problematic at certain operating systems, e.g. Windows XP SP2."
-	ecdsaWarning             = "The bundle contains ECDSA signatures, which are problematic at certain operating systems, e.g. Windows XP SP2, Android 2.2 and Android 2.3."
-	expiringWarningStub      = "The bundle is expiring within 30 days. "
-	untrustedWarningStub     = "The bundle may not be trusted by the following platform(s):"
-	ubiquityWarning          = "The bundle trust ubiquity is not guaranteed: No platform metadata found."
-	deprecateSHA1WarningStub = "Due to SHA-1 deprecation, the bundle may not be trusted by the following platform(s):"
+	sha2Warning          = "The bundle contains certs signed with advanced hash functions such as SHA2,  which are problematic at certain operating systems, e.g. Windows XP SP2."
+	ecdsaWarning         = "The bundle contains ECDSA signatures, which are problematic at certain operating systems, e.g. Windows XP SP2, Android 2.2 and Android 2.3."
+	expiringWarningStub  = "The bundle is expiring within 30 days. "
+	untrustedWarningStub = "The bundle may not be trusted by the following platform(s):"
+	ubiquityWarning      = "The bundle trust ubiquity is not guaranteed: No platform metadata found."
 )
 
 // A Bundler contains the certificate pools for producing certificate
@@ -656,11 +655,11 @@ func (b *Bundler) Bundle(certs []*x509.Certificate, key crypto.Signer, flavor Bu
 		messages = append(messages, untrustedMsg)
 	}
 	// Check if there is any platform that rejects the chain because of SHA1 deprecation.
-	deprecated := ubiquity.DeprecatedSHA1Platforms(matchingChains[0])
-	if len(deprecated) > 0 {
+	sha1Msgs := ubiquity.SHA1DeprecationMessages(matchingChains[0])
+	if len(sha1Msgs) > 0 {
 		log.Debug("Populate SHA1 deprecation warning.")
 		statusCode |= errors.BundleNotUbiquitousBit
-		messages = append(messages, deprecateSHA1Warning(deprecated))
+		messages = append(messages, sha1Msgs...)
 	}
 
 	bundle.Status = &BundleStatus{ExpiringSKIs: getSKIs(bundle.Chain, expiringCerts), Code: statusCode, Messages: messages, Untrusted: untrusted}
@@ -720,22 +719,6 @@ func untrustedPlatformsWarning(platforms []string) string {
 	}
 
 	msg := untrustedWarningStub
-	for i, platform := range platforms {
-		if i > 0 {
-			msg += ","
-		}
-		msg += " " + platform
-	}
-	msg += "."
-	return msg
-}
-
-// deprecateSHA1Warning generates a warning message with platform names which deprecates SHA1.
-func deprecateSHA1Warning(platforms []string) string {
-	if len(platforms) == 0 {
-		return ""
-	}
-	msg := deprecateSHA1WarningStub
 	for i, platform := range platforms {
 		if i > 0 {
 			msg += ","

--- a/bundler/bundler_sha1_deprecation_test.go
+++ b/bundler/bundler_sha1_deprecation_test.go
@@ -112,7 +112,7 @@ func TestSHA2Preferences(t *testing.T) {
 	b.IntermediatePool.AddCert(sha1Inter)
 	b.IntermediatePool.AddCert(sha2Inter)
 
-	bundle, err := b.BundleFromPEM(leafBytes, nil, Ubiquitous)
+	bundle, err := b.BundleFromPEMorDER(leafBytes, nil, Ubiquitous, "")
 	if err != nil {
 		t.Fatal("bundling failed: ", err)
 	}

--- a/bundler/bundler_sha1_deprecation_test.go
+++ b/bundler/bundler_sha1_deprecation_test.go
@@ -57,20 +57,27 @@ func TestChromeWarning(t *testing.T) {
 	}
 
 	fullChain := append(bundle.Chain, bundle.Root)
-	rejectingPlatforms := ubiquity.DeprecatedSHA1Platforms(fullChain)
-	deprecationMessage := deprecateSHA1Warning(rejectingPlatforms)
-	if deprecationMessage == "" {
+	sha1Msgs := ubiquity.SHA1DeprecationMessages(fullChain)
+	// Since the new SHA-1 cert is expired after 2015, it definitely trigger Chrome's deprecation policies.
+	if len(sha1Msgs) == 0 {
 		t.Fatal("SHA1 Deprecation Message should not be empty")
 	}
 	// check SHA1 deprecation warnings
-	foundMsg := false
-	for _, message := range bundle.Status.Messages {
-		if message == deprecationMessage {
-			foundMsg = true
+	var sha1MsgNotFound bool
+	for _, sha1Msg := range sha1Msgs {
+		foundMsg := false
+		for _, message := range bundle.Status.Messages {
+			if message == sha1Msg {
+				foundMsg = true
+			}
+		}
+		if !foundMsg {
+			sha1MsgNotFound = true
+			break
 		}
 	}
-	if !foundMsg {
-		t.Fatalf("Incorrect bundle status messages. Bundle status messages:%s, expected: %s\n", bundle.Status.Messages, deprecationMessage)
+	if sha1MsgNotFound {
+		t.Fatalf("Incorrect bundle status messages. Bundle status messages:%v, expected to contain: %v\n", bundle.Status.Messages, sha1Msgs)
 	}
 
 }

--- a/ubiquity/sha1.go
+++ b/ubiquity/sha1.go
@@ -1,0 +1,153 @@
+package ubiquity
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/cloudflare/cfssl/helpers"
+)
+
+// DeprecationSeverity encodes the severity of a deprecation policy
+type DeprecationSeverity int
+
+const (
+	// None indicates there is no deprecation
+	None DeprecationSeverity = iota
+	// Low indicates the deprecation policy won't affect user experience
+	Low
+	// Medium indicates the deprecation policy will affect user experience
+	// either in a minor way or for a limited scope of users.
+	Medium
+	// High indicates the deprecation policy will strongly affect user experience
+	High
+)
+
+// SHA1DeprecationPolicy encodes how a platform deprecates the support of SHA1
+type SHA1DeprecationPolicy struct {
+	// the name of platform
+	Platform string `json:"platform"`
+	// policy severity, policies of the same platform will only trigger the one of highest severity
+	Severity DeprecationSeverity `json:"severity"`
+	// a human readable message describing the deprecation effects
+	Description string `json:"description"`
+	// the date when the policy is effective. zero value means effective immediately
+	EffectiveDate time.Time `json:"effective_date"`
+	// the expiry deadline indicates the latest date which a end-entity
+	// certificate with SHA1 can be valid through.
+	ExpiryDeadline time.Time `json:"expiry_deadline"`
+	// the date beyond which SHA1 cert should not be issued.
+	NeverIssueAfter time.Time `json:"never_issue_after"`
+}
+
+// SHA1DeprecationPolicys ia a list of various SHA1DeprecationPolicy's
+// proposed by major browser producers
+var SHA1DeprecationPolicys = []SHA1DeprecationPolicy{
+	// Chrome:
+	//   if the leaf certificate expires between 01-01-2016 and 01-01-2017
+	//   and the chain (excluding root) contains SHA-1 cert, show "minor errors".
+	SHA1DeprecationPolicy{
+		Platform:       "Google Chrome",
+		Description:    "shows the SSL connection has minor problems",
+		Severity:       Medium,
+		ExpiryDeadline: time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC),
+	},
+	// Chrome:
+	//   if the leaf certificate expires after Jan. 1st 2017
+	//   and the chain (excluding root) contains SHA-1 cert, show "untrusted SSL".
+	SHA1DeprecationPolicy{
+		Platform:       "Google Chrome",
+		Description:    "shows the SSL connection is untrusted",
+		Severity:       High,
+		ExpiryDeadline: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC),
+	},
+	// Mozilla Firefox:
+	//   if the leaf certificate expires after Jan. 1st 2017, and
+	//   the chain (excluding root) contains SHA-1 cert, show a warning in the developer console.
+	SHA1DeprecationPolicy{
+		Platform:       "Mozilla Firefox",
+		Description:    "gives warning in the developer console",
+		Severity:       Low,
+		ExpiryDeadline: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC),
+	},
+	// Mozilla Firefox:
+	//   if a new certificate is issued after Jan. 1st 2016, and
+	//   it is a SHA-1 cert, reject it.
+	SHA1DeprecationPolicy{
+		Platform:        "Mozilla Firefox",
+		Description:     "shows the SSL connection is untrusted",
+		Severity:        Medium,
+		EffectiveDate:   time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NeverIssueAfter: time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC),
+	},
+	// Mozilla Firefox:
+	//   deprecate all valid SHA-1 cert chain on Jan. 1st 2017
+	SHA1DeprecationPolicy{
+		Platform:       "Mozilla Firefox",
+		Description:    "shows the SSL connection is untrusted",
+		Severity:       High,
+		EffectiveDate:  time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC),
+		ExpiryDeadline: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC),
+	},
+	// Microsoft Windows:
+	//   deprecate all valid SHA-1 cert chain on Jan. 1st 2017
+	SHA1DeprecationPolicy{
+		Platform:       "Microsoft Windows Vista and later",
+		Description:    "shows the SSL connection is untrusted",
+		Severity:       High,
+		EffectiveDate:  time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC),
+		ExpiryDeadline: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC),
+	},
+}
+
+// Flag returns whether the policy flags the cert chain as deprecated for matching its deprecation criteria
+func (p SHA1DeprecationPolicy) Flag(chain []*x509.Certificate) bool {
+	leaf := chain[0]
+	if time.Now().After(p.EffectiveDate) {
+
+		// Reject newly issued leaf certificate with SHA-1 after the specified deadline.
+		if !p.NeverIssueAfter.IsZero() && leaf.NotBefore.After(p.NeverIssueAfter) {
+			// Check hash algorithm of non-root leaf cert.
+			if len(chain) > 1 && helpers.HashAlgoString(leaf.SignatureAlgorithm) == "SHA1" {
+				return true
+			}
+		}
+
+		// Reject certificate chain with SHA-1 that are still valid after expiry deadline.
+		if !p.ExpiryDeadline.IsZero() && leaf.NotAfter.After(p.ExpiryDeadline) {
+			// Check hash algorithm of non-root certs.
+			for i, cert := range chain {
+				if i < len(chain)-1 {
+					if helpers.HashAlgoString(cert.SignatureAlgorithm) == "SHA1" {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// SHA1DeprecationMessages returns a list of human-readable messages. Each message describes
+// how one platform rejects the chain based on SHA1 deprecation policies.
+func SHA1DeprecationMessages(chain []*x509.Certificate) []string {
+	// record the most severe deprecation policy by each platform
+	selectedPolicies := map[string]SHA1DeprecationPolicy{}
+	for _, policy := range SHA1DeprecationPolicys {
+		if policy.Flag(chain) {
+			// only keep the policy with highest severity
+			if selectedPolicies[policy.Platform].Severity < policy.Severity {
+				selectedPolicies[policy.Platform] = policy
+			}
+		}
+	}
+	// build the message list
+	list := []string{}
+	for _, policy := range selectedPolicies {
+		if policy.Severity > None {
+			list = append(list, fmt.Sprintf("%s %s due to SHA-1 deprecation", policy.Platform, policy.Description))
+		}
+	}
+	return list
+}

--- a/ubiquity/testdata/ca.pem.metadata
+++ b/ubiquity/testdata/ca.pem.metadata
@@ -1,0 +1,15 @@
+[
+{
+	"name":"Browser Everywhere",
+	"weight": 0,
+	"hash_algo": "SHA2",
+	"key_algo": "ECDSA256"
+},
+{
+	"name":"Pineapple",
+	"weight": 1,
+	"hash_algo": "SHA2",
+	"key_algo": "ECDSA521",
+	"keystore": "pineapple.pem"
+}
+]

--- a/ubiquity/ubiquity_platform.go
+++ b/ubiquity/ubiquity_platform.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"path"
 	"path/filepath"
-	"time"
 
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"
@@ -36,55 +35,16 @@ func (s CertSet) Add(cert *x509.Certificate) {
 	s[SHA1RawPublicKey(cert)] = true
 }
 
-// CryptoDeprecationPolicy encodes how a platform plans to deprecate the support of a crypto hash/key algorithm.
-type CryptoDeprecationPolicy struct {
-	// The name of target algorithm to be deprecated.
-	Target string `json:"target"`
-	// The date when the policy is effective.
-	EffectiveDate time.Time `json:"effective_date"`
-	// The expiry deadline indicates the latest date which a end-entity certificate with the deprecating
-	// algorithm can be valid through.
-	ExpiryDeadline time.Time `json:"expiry_deadline"`
-}
-
 // A Platform contains ubiquity information on supported crypto algorithms and root certificate store name.
 type Platform struct {
-	Name            string                   `json:"name"`
-	Weight          int                      `json:"weight"`
-	HashAlgo        string                   `json:"hash_algo"`
-	KeyAlgo         string                   `json:"key_algo"`
-	KeyStoreFile    string                   `json:"keystore"`
-	HashDeprecation *CryptoDeprecationPolicy `json:"hash_algo_expiry"`
+	Name            string `json:"name"`
+	Weight          int    `json:"weight"`
+	HashAlgo        string `json:"hash_algo"`
+	KeyAlgo         string `json:"key_algo"`
+	KeyStoreFile    string `json:"keystore"`
 	KeyStore        CertSet
 	HashUbiquity    HashUbiquity
 	KeyAlgoUbiquity KeyAlgoUbiquity
-}
-
-// Deprecate returns whether the platform rejects the cert chain due to ceased support of a crypto hash algorithm.
-func (p Platform) Deprecate(chain []*x509.Certificate) bool {
-	if p.HashDeprecation == nil {
-		return false
-	}
-	now := time.Now()
-	leaf := chain[0]
-
-	// Currently we implement the logic that Chrome browsers use to stop supporting SHA-1. To our understanding,
-	// Microsoft and Mozilla use basically the same logic to cease support of SHA-1 as well.
-
-	if now.After(p.HashDeprecation.EffectiveDate) {
-		if leaf.NotAfter.After(p.HashDeprecation.ExpiryDeadline) {
-			// Check hash algorithm of non-root cert.
-			for i, cert := range chain {
-				if i < len(chain)-1 {
-					if helpers.HashAlgoString(cert.SignatureAlgorithm) == p.HashDeprecation.Target {
-						return true
-					}
-				}
-			}
-		}
-	}
-
-	return false
 }
 
 // Trust returns whether the platform has the root cert in the trusted store.
@@ -216,17 +176,6 @@ func UntrustedPlatforms(root *x509.Certificate) []string {
 	return ret
 }
 
-// DeprecatedSHA1Platforms returns a list of platforms which rejects the cert chain based on deprecation of SHA1.
-func DeprecatedSHA1Platforms(chain []*x509.Certificate) []string {
-	ret := []string{}
-	for _, platform := range Platforms {
-		if platform.Deprecate(chain) && platform.HashDeprecation.Target == "SHA1" {
-			ret = append(ret, platform.Name)
-		}
-	}
-	return ret
-}
-
 // CrossPlatformUbiquity returns a ubiquity score (persumably relecting the market share in percentage)
 // based on whether the given chain can be verified with the different platforms' root certificate stores.
 func CrossPlatformUbiquity(chain []*x509.Certificate) int {
@@ -241,7 +190,7 @@ func CrossPlatformUbiquity(chain []*x509.Certificate) int {
 	//	2. the chain satisfy the minimal constraints on hash function and key algorithm.
 	root := chain[len(chain)-1]
 	for _, platform := range Platforms {
-		if platform.Trust(root) && !platform.Deprecate(chain) {
+		if platform.Trust(root) {
 			switch {
 			case platform.HashUbiquity <= ChainHashUbiquity(chain) && platform.KeyAlgoUbiquity <= ChainKeyAlgoUbiquity(chain):
 				totalWeight += platform.Weight

--- a/ubiquity/ubiquity_test.go
+++ b/ubiquity/ubiquity_test.go
@@ -2,6 +2,7 @@ package ubiquity
 
 import (
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -10,13 +11,14 @@ import (
 )
 
 const (
-	rsa1024  = "testdata/rsa1024sha1.pem"
-	rsa2048  = "testdata/rsa2048sha2.pem"
-	rsa3072  = "testdata/rsa3072sha2.pem"
-	rsa4096  = "testdata/rsa4096sha2.pem"
-	ecdsa256 = "testdata/ecdsa256sha2.pem"
-	ecdsa384 = "testdata/ecdsa384sha2.pem"
-	ecdsa521 = "testdata/ecdsa521sha2.pem"
+	rsa1024    = "testdata/rsa1024sha1.pem"
+	rsa2048    = "testdata/rsa2048sha2.pem"
+	rsa3072    = "testdata/rsa3072sha2.pem"
+	rsa4096    = "testdata/rsa4096sha2.pem"
+	ecdsa256   = "testdata/ecdsa256sha2.pem"
+	ecdsa384   = "testdata/ecdsa384sha2.pem"
+	ecdsa521   = "testdata/ecdsa521sha2.pem"
+	caMetadata = "testdata/ca.pem.metadata"
 )
 
 var rsa1024Cert, rsa2048Cert, rsa3072Cert, rsa4096Cert, ecdsa256Cert, ecdsa384Cert, ecdsa521Cert *x509.Certificate
@@ -26,6 +28,7 @@ func readCert(filename string) *x509.Certificate {
 	cert, _ := helpers.ParseCertificatePEM(bytes)
 	return cert
 }
+
 func init() {
 	rsa1024Cert = readCert(rsa1024)
 	rsa2048Cert = readCert(rsa2048)
@@ -176,6 +179,55 @@ func TestChainKeyAlgoUbiquity(t *testing.T) {
 
 }
 
+func TestChainExpiryUbiquity(t *testing.T) {
+	// rsa1024Cert expires at year 2024
+	// rsa2048Cert expires at year 2019
+	// ecdsa256Cert expires at year 2019
+	chain1 := []*x509.Certificate{ecdsa256Cert, rsa2048Cert}
+	chain2 := []*x509.Certificate{ecdsa256Cert, rsa1024Cert}
+	if CompareExpiryUbiquity(chain1, chain2) >= 0 {
+		t.Fatal("Incorrect chain expiry ubiquity")
+	}
+
+	if CompareExpiryUbiquity(chain2, chain1) <= 0 {
+		t.Fatal("Incorrect chain expiry ubiquity")
+	}
+
+	if CompareExpiryUbiquity(chain1, chain1) != 0 {
+		t.Fatal("Incorrect chain expiry ubiquity")
+	}
+}
+
+func TestCompareChainExpiry(t *testing.T) {
+	// rsa1024Cert expires at 2024
+	// rsa2048Cert expires at 2019
+	// ecdsa256Cert expires at 2019
+	// both chain expires at year 2019.
+	chain1 := []*x509.Certificate{ecdsa256Cert, rsa2048Cert}
+	chain2 := []*x509.Certificate{ecdsa256Cert, rsa1024Cert}
+	if CompareChainExpiry(chain1, chain2) != 0 {
+		t.Fatal("Incorrect chain expiry")
+	}
+
+	if CompareExpiryUbiquity(chain1, chain1) != 0 {
+		t.Fatal("Incorrect chain expiry")
+	}
+}
+
+func TestCompareChainLength(t *testing.T) {
+	chain1 := []*x509.Certificate{ecdsa256Cert, rsa2048Cert}
+	chain2 := []*x509.Certificate{rsa1024Cert}
+	chain3 := []*x509.Certificate{rsa2048Cert}
+	// longer chain is ranked lower
+	if CompareChainLength(chain1, chain2) >= 0 {
+		t.Fatal("Incorrect chain length comparison")
+	}
+
+	if CompareChainLength(chain2, chain3) != 0 {
+		t.Fatal("Incorrect chain length comparison")
+	}
+}
+
 func TestPlatformKeyStoreUbiquity(t *testing.T) {
 	cert1 := rsa1024Cert
 	cert2 := rsa2048Cert
@@ -184,14 +236,17 @@ func TestPlatformKeyStoreUbiquity(t *testing.T) {
 	// "Macrosoft" has all three certs.
 	// "Godzilla" has two certs, cert1 and cert2.
 	// "Pinapple" has cert1.
+	// "Colorful" has no key store data, default to trust any cert
 	// All platforms support the same crypto suite.
 	platformA := Platform{Name: "MacroSoft", Weight: 100, HashAlgo: "SHA2", KeyAlgo: "ECDSA256", KeyStoreFile: "testdata/macrosoft.pem"}
 	platformB := Platform{Name: "Godzilla", Weight: 100, HashAlgo: "SHA2", KeyAlgo: "ECDSA256", KeyStoreFile: "testdata/godzilla.pem"}
 	platformC := Platform{Name: "Pineapple", Weight: 100, HashAlgo: "SHA2", KeyAlgo: "ECDSA256", KeyStoreFile: "testdata/pineapple.pem"}
+	platformD := Platform{Name: "Colorful", Weight: 100, HashAlgo: "SHA2", KeyAlgo: "ECDSA256", KeyStoreFile: ""}
 	platformA.ParseAndLoad()
 	platformB.ParseAndLoad()
 	platformC.ParseAndLoad()
-	Platforms = []Platform{platformA, platformB, platformC}
+	platformD.ParseAndLoad()
+	Platforms = []Platform{platformA, platformB, platformC, platformD}
 	// chain1 with root cert1 (RSA1024, SHA1), has the largest platform coverage.
 	// chain2 with root cert2 (RSA2048, SHA2), has the second largest coverage.
 	// chain3 with root cert3 (ECDSA256, SHA2), has the least coverage.
@@ -203,6 +258,50 @@ func TestPlatformKeyStoreUbiquity(t *testing.T) {
 	}
 	if CrossPlatformUbiquity(chain2) < CrossPlatformUbiquity(chain3) {
 		t.Fatal("Incorrect cross platform ubiquity")
+	}
+
+	if ComparePlatformUbiquity(chain1, chain2) < 0 {
+		t.Fatal("Incorrect cross platform ubiquity")
+	}
+
+	if ComparePlatformUbiquity(chain2, chain3) < 0 {
+		t.Fatal("Incorrect cross platform ubiquity")
+	}
+
+	// test UntrustedPlatforms()
+	u1 := UntrustedPlatforms(cert1)
+	if len(u1) != 0 {
+		t.Fatal("Incorrect UntrustedPlatforms")
+	}
+	u2 := UntrustedPlatforms(cert2)
+	if len(u2) != 1 {
+		t.Fatal("Incorrect UntrustedPlatforms")
+	}
+	u3 := UntrustedPlatforms(cert3)
+	if len(u3) != 2 {
+		t.Fatal("Incorrect UntrustedPlatforms")
+	}
+
+}
+
+func TestEmptyPlatformList(t *testing.T) {
+	Platforms = []Platform{}
+	cert := rsa1024Cert
+	chain := []*x509.Certificate{cert}
+	if CrossPlatformUbiquity(chain) != 0 {
+		t.Fatal("Incorrect cross platform ubiquity when Platforms is empty")
+	}
+	// test UntrustedPlatforms()
+	u1 := UntrustedPlatforms(cert)
+	if len(u1) != 0 {
+		t.Fatal("Incorrect UntrustedPlatforms when Platforms is empty")
+	}
+}
+
+func TestLoadPlatforms(t *testing.T) {
+	err := LoadPlatforms(caMetadata)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -215,9 +314,11 @@ func TestPlatformCryptoUbiquity(t *testing.T) {
 	platformA := Platform{Name: "TinySoft", Weight: 100, HashAlgo: "SHA1", KeyAlgo: "RSA", KeyStoreFile: "testdata/macrosoft.pem"}
 	platformB := Platform{Name: "SmallSoft", Weight: 100, HashAlgo: "SHA2", KeyAlgo: "RSA", KeyStoreFile: "testdata/macrosoft.pem"}
 	platformC := Platform{Name: "LargeSoft", Weight: 100, HashAlgo: "SHA2", KeyAlgo: "ECDSA256", KeyStoreFile: "testdata/macrosoft.pem"}
+	platformD := Platform{Name: "MediumSoft", Weight: 100, HashAlgo: "SHA2", KeyAlgo: "ECDSA384", KeyStoreFile: "testdata/macrosoft.pem"}
 	platformA.ParseAndLoad()
 	platformB.ParseAndLoad()
 	platformC.ParseAndLoad()
+	platformD.ParseAndLoad()
 	Platforms = []Platform{platformA, platformB, platformC}
 	// chain1 with root cert1 (RSA1024, SHA1), has the largest platform coverage.
 	// chain2 with root cert2 (RSA2048, SHA2), has the second largest coverage.
@@ -231,49 +332,13 @@ func TestPlatformCryptoUbiquity(t *testing.T) {
 	if CrossPlatformUbiquity(chain2) < CrossPlatformUbiquity(chain3) {
 		t.Fatal("Incorrect cross platform ubiquity")
 	}
-}
 
-func TestPlatformCryptoDeprecation(t *testing.T) {
-	cert1 := rsa1024Cert
-	cert2 := rsa2048Cert
-	pweight1 := 1
-	pweight2 := 10
-	pweight3 := 100
-	Jan1st2014 := time.Date(2014, time.January, 1, 0, 0, 0, 0, time.UTC)
-	Jan1st2100 := time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)
-	DeprecationPolicy2014 := &CryptoDeprecationPolicy{Target: "SHA1", EffectiveDate: Jan1st2014, ExpiryDeadline: Jan1st2014}
-	DeprecationPolicy2100 := &CryptoDeprecationPolicy{Target: "SHA2", EffectiveDate: Jan1st2100, ExpiryDeadline: Jan1st2014}
-	// All platforms have the same trust store but are with various crypto suite and deprecation policy.
-	// platformA supports SHA1 only and has no deprecation plan of SHA1.
-	// platformB supports SHA1/SHA2 and will deprecate SHA1 at year 2100.
-	// platformC supports SHA1/SHA2 and will deprecate SHA1 at year 2014.
-	platformA := Platform{Name: "TinySoft", Weight: pweight1, HashAlgo: "SHA1", KeyAlgo: "RSA", KeyStoreFile: "testdata/macrosoft.pem"}
-	platformB := Platform{Name: "SmallSoft", Weight: pweight2, HashAlgo: "SHA2", KeyAlgo: "RSA", KeyStoreFile: "testdata/macrosoft.pem", HashDeprecation: DeprecationPolicy2100}
-	platformC := Platform{Name: "LargeSoft", Weight: pweight3, HashAlgo: "SHA2", KeyAlgo: "RSA", KeyStoreFile: "testdata/macrosoft.pem", HashDeprecation: DeprecationPolicy2014}
-	platformA.ParseAndLoad()
-	platformB.ParseAndLoad()
-	platformC.ParseAndLoad()
-	Platforms = []Platform{platformA, platformB, platformC}
-	// chain1 is accepted by platform A, B and C. It's not rejected by platFormC because root cert is not subject to SHA1 deprecation.
-	chain1 := []*x509.Certificate{cert1}
-	// chain2 is accepted by platform A, B. It's rejected by platFormC because leaf cert is subject to SHA1 deprecation.
-	chain2 := []*x509.Certificate{cert1, cert1}
-	// chain3 is accepted by platformB and platFormC. It's rejected by platformA due to A's inablity to support SHA2.
-	chain3 := []*x509.Certificate{cert2, cert1}
-
-	if CrossPlatformUbiquity(chain1) != pweight1+pweight2+pweight3 {
-		t.Fatal("Incorrect cross platform ubiquity: ", CrossPlatformUbiquity(chain1))
-	}
-	if CrossPlatformUbiquity(chain2) != pweight1+pweight2 {
-		t.Fatal("Incorrect cross platform ubiquity: ", CrossPlatformUbiquity(chain2))
-	}
-	if CrossPlatformUbiquity(chain3) != pweight2+pweight3 {
-		t.Fatal("Incorrect cross platform ubiquity: ", CrossPlatformUbiquity(chain3))
+	if ComparePlatformUbiquity(chain1, chain2) < 0 {
+		t.Fatal("Incorrect cross platform ubiquity")
 	}
 
-	dplatforms := DeprecatedSHA1Platforms(chain2)
-	if len(dplatforms) != 1 || dplatforms[0] != "LargeSoft" {
-		t.Fatal("Incorrect deprecation checking: ", dplatforms)
+	if ComparePlatformUbiquity(chain1, chain2) < 0 {
+		t.Fatal("Incorrect cross platform ubiquity")
 	}
 }
 
@@ -327,6 +392,23 @@ func TestCompareSHA2Homogeneity(t *testing.T) {
 	}
 }
 
+func TestFilterTrivial(t *testing.T) {
+	var chain []*x509.Certificate
+	var chains [][]*x509.Certificate
+	ret := Filter(chains, CompareChainHashPriority)
+	if len(ret) != 0 {
+		t.Fatal("Incorrect filtering")
+	}
+
+	chain = []*x509.Certificate{rsa2048Cert}
+	chains = [][]*x509.Certificate{chain}
+
+	ret = Filter(chains, CompareChainHashPriority)
+	if len(ret) != 1 {
+		t.Fatal("Incorrect filtering")
+	}
+}
+
 func TestFilterChainHashPriority(t *testing.T) {
 	var chain1, chain2 []*x509.Certificate
 	chain1 = []*x509.Certificate{rsa2048Cert}  // SHA256
@@ -342,6 +424,7 @@ func TestFilterChainHashPriority(t *testing.T) {
 	if ret[0][0] != ecdsa384Cert {
 		t.Fatal("Incorrect chain hash priority filtering")
 	}
+
 }
 
 func TestFilterChainKeyAlgoPriority(t *testing.T) {
@@ -409,5 +492,157 @@ func TestFilterChainKeyAlgoUbiquity(t *testing.T) {
 	// check there is no reordering
 	if ret[0][0] != rsa2048Cert {
 		t.Fatal("Incorrect chain key algo priority filtering")
+	}
+}
+
+func TestFlagBySHA1DeprecationPolicy(t *testing.T) {
+	cert1 := rsa1024Cert
+	cert2 := rsa2048Cert
+	Jan1st2014 := time.Date(2014, time.January, 1, 0, 0, 0, 0, time.UTC)
+	Jan1st2100 := time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)
+	policy1 := SHA1DeprecationPolicy{
+		Description:    "SHA1 should be gone years ago",
+		ExpiryDeadline: Jan1st2014,
+	}
+	policy2 := SHA1DeprecationPolicy{
+		Description:    "SHA1 is perfect for another century",
+		ExpiryDeadline: Jan1st2100,
+	}
+	policy3 := SHA1DeprecationPolicy{
+		Description:    "effectively one century later, reject SHA1 expires on 2014",
+		EffectiveDate:  Jan1st2100,
+		ExpiryDeadline: Jan1st2014,
+	}
+	policy4 := SHA1DeprecationPolicy{
+		Description:     "no more new SHA1 cert",
+		NeverIssueAfter: Jan1st2014,
+	}
+	// chain1 is accepted univerally. It's not flagged because root cert is not subject to SHA1 deprecation.
+	chain1 := []*x509.Certificate{cert1}
+	if policy1.Flag(chain1) || policy2.Flag(chain1) || policy3.Flag(chain1) || policy4.Flag(chain1) {
+		t.Fatal("Incorrect SHA1 deprecation")
+	}
+
+	// chain2 is accepted by policy2 and policy3. It's flagged by policy1 and policy4
+	chain2 := []*x509.Certificate{cert1, cert1}
+	if !policy1.Flag(chain2) || policy2.Flag(chain2) || policy3.Flag(chain2) || !policy4.Flag(chain2) {
+		t.Fatal("Incorrect SHA1 deprecation")
+	}
+
+	// chain3 is accepted by universally since the leaf cert and the intermediate are signed by SHA-256
+	chain3 := []*x509.Certificate{cert2, cert2, cert1}
+	if policy1.Flag(chain3) || policy2.Flag(chain3) || policy3.Flag(chain3) || policy4.Flag(chain3) {
+		t.Fatal("Incorrect SHA1 deprecation")
+	}
+}
+
+func TestSHA1DeprecationMessages(t *testing.T) {
+	cert1 := rsa1024Cert
+	cert2 := rsa2048Cert
+	chain1 := []*x509.Certificate{cert1}
+	chain2 := []*x509.Certificate{cert1, cert1}
+	chain3 := []*x509.Certificate{cert2, cert1, cert1}
+	chain4 := []*x509.Certificate{cert2, cert2, cert1}
+	messages := []string{}
+
+	Jan1st2014 := time.Date(2014, time.January, 1, 0, 0, 0, 0, time.UTC)
+	Jan1st2100 := time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)
+	policy1 := SHA1DeprecationPolicy{
+		Platform:       "Browser A",
+		Description:    "minor warning",
+		Severity:       Low,
+		ExpiryDeadline: Jan1st2014,
+	}
+	policy2 := SHA1DeprecationPolicy{
+		Platform:       "Browser A",
+		Description:    "minor warning",
+		Severity:       Medium,
+		ExpiryDeadline: Jan1st2014,
+	}
+	policy3 := SHA1DeprecationPolicy{
+		Platform:        "Browser B",
+		Description:     "reject",
+		Severity:        High,
+		NeverIssueAfter: Jan1st2014,
+	}
+	policy4 := SHA1DeprecationPolicy{
+		Platform:        "Browser C",
+		Description:     "reject but not now",
+		Severity:        High,
+		NeverIssueAfter: Jan1st2014,
+		EffectiveDate:   Jan1st2100,
+	}
+
+	// The only policy has severity low
+	SHA1DeprecationPolicys = []SHA1DeprecationPolicy{policy1}
+	messages = SHA1DeprecationMessages(chain1)
+	// chain1 with only root is not subject to deprecation
+	if len(messages) != 0 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain2 has SHA-1 leaf cert, subject to deprecation
+	messages = SHA1DeprecationMessages(chain2)
+	if len(messages) != 1 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain3 has SHA-1 intermediate cert, subject to deprecation
+	messages = SHA1DeprecationMessages(chain3)
+	if len(messages) != 1 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain4 has no SHA-1 leaf or intermediate, not subject to deprecation
+	messages = SHA1DeprecationMessages(chain4)
+	if len(messages) != 0 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+
+	// A second policy that has higher severity , so it should takes effect and override lower one.
+	SHA1DeprecationPolicys = []SHA1DeprecationPolicy{policy1, policy2}
+	// chain1 only has root cert, not subject to deprecation policy
+	messages = SHA1DeprecationMessages(chain1)
+	if len(messages) != 0 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain2 has a SHA-1 leaf cert, will have a message from policy2
+	messages = SHA1DeprecationMessages(chain2)
+	if len(messages) != 1 ||
+		messages[0] != fmt.Sprintf("%s %s due to SHA-1 deprecation", policy2.Platform, policy2.Description) {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain3 has a SHA-1 intermediate cert, will have a message from policy2
+	messages = SHA1DeprecationMessages(chain3)
+	if len(messages) != 1 ||
+		messages[0] != fmt.Sprintf("%s %s due to SHA-1 deprecation", policy2.Platform, policy2.Description) {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain4 is not subject to any deprecation policy
+	messages = SHA1DeprecationMessages(chain4)
+	if len(messages) != 0 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+
+	// Add two policies. One tests for newly issued leaf certificate after a deadline, the other is the same,
+	// but takes effect at the 22nd century.
+	SHA1DeprecationPolicys = []SHA1DeprecationPolicy{policy1, policy2, policy3, policy4}
+	// chain1 only has root cert, not subject to any deprecation policy
+	messages = SHA1DeprecationMessages(chain1)
+	if len(messages) != 0 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain2 now is flagged by two policies: policy2 and policy3
+	messages = SHA1DeprecationMessages(chain2)
+	if len(messages) != 2 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain3 is not flagged by policy3 but policy2
+	messages = SHA1DeprecationMessages(chain3)
+	if len(messages) != 1 ||
+		messages[0] != fmt.Sprintf("%s %s due to SHA-1 deprecation", policy2.Platform, policy2.Description) {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
+	}
+	// chain4 is not subject to any deprecation policy
+	messages = SHA1DeprecationMessages(chain4)
+	if len(messages) != 0 {
+		t.Fatal("Incorrect SHA1 deprecation reporting")
 	}
 }


### PR DESCRIPTION
Rewrite/refactor SHA1 deprecation logic and improve test coverage.
- Revert the initial design of SHA1 deprecation policy being part of
  platform metadata because it makes metadata bloated. Instead, the
  platform metadata should only contain info on CA trust root stores
  and crypto support.
- Add a new type called SHA1Deprecated to handle SHA1
  deprecation warning.
- Add support to Firefox SHA1 deprecation policy in SHA1Deprecated.
- Make it explicit that ubiquity scoring doesn't take SHA1
  deprecation into account. Right now the weights of Chrome browsers
  in the metadata file is encoded as 0. So this is a safe change.
- Hardcode the list of platforms that would conditionally reject
  SHA1 certificate chain.
- Increase test coverage of package ubiquity
- Add a dynamic bundle test on prioritizing SHA-2 intermediates when the leaf cert is a SHA-2 cert.