### PR TITLE
Fix bundler tests that utilize expiring real-world certificates

### DIFF
--- a/bundler/bundle_from_pem_test.go
+++ b/bundler/bundle_from_pem_test.go
@@ -83,7 +83,7 @@ func TestBundleFromPEM(t *testing.T) {
 	}
 }
 
-// GoDaddy intermeidate cert valid until year 2034
+// GoDaddy intermediate cert valid until year 2034
 var GoDaddyRootCert = []byte(`-----BEGIN CERTIFICATE-----
 MIIEADCCAuigAwIBAgIBADANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEh
 MB8GA1UEChMYVGhlIEdvIERhZGR5IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBE
@@ -109,7 +109,7 @@ dEr/VxqHD3VILs9RaRegAhJhldXRQLIQTO7ErBBDpqWeCtWVYpoNz4iCxTIM5Cuf
 ReYNnyicsbkqWletNw+vHX/bvZ8=
 -----END CERTIFICATE-----`)
 
-// GoDaddy intermeidate cert valid until year 2026
+// GoDaddy intermediate cert valid until year 2026
 var GoDaddyIntermediateCert = []byte(`-----BEGIN CERTIFICATE-----
 MIIE3jCCA8agAwIBAgICAwEwDQYJKoZIhvcNAQEFBQAwYzELMAkGA1UEBhMCVVMx
 ITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28g

--- a/bundler/bundler_sha1_deprecation_test.go
+++ b/bundler/bundler_sha1_deprecation_test.go
@@ -97,7 +97,7 @@ func TestSHA2Preferences(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// create a intermediate signer from SHA-1 intermedate cert/key
+	// create a intermediate signer from SHA-1 intermediate cert/key
 	sha2InterSigner := makeCASigner(sha1InterBytes, interKeyBytes, x509.SHA256WithRSA, t)
 	// sign a leaf cert
 	leafBytes := signCSRFile(sha2InterSigner, leafCSR, t)


### PR DESCRIPTION
- Replace those tests with ones using certificate generated on the fly