### PR TITLE
Make info -remote command safe

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -153,20 +153,25 @@ func (srv *Server) Info(jsonData []byte) (*InfoResp, error) {
 		return nil, err
 	}
 
-	cert := res["certificate"]
-	usages := res["usages"].([]interface{})
-	exp := res["expiry"]
+	info := new(InfoResp)
+
+	if val, ok := res["certificate"]; ok {
+		info.Certificate = val.(string)
+	}
+	var usages []interface{}
+	if val, ok := res["usages"]; ok {
+		usages = val.([]interface{})
+	}
+	if val, ok := res["expiry"]; ok {
+		info.ExpiryString = val.(string)
+	}
 
 	usageStrings := make([]string, len(usages))
 	for i, s := range usages {
 		usageStrings[i] = s.(string)
 	}
 
-	return &InfoResp{
-		Certificate:  cert.(string),
-		Usage:        usageStrings,
-		ExpiryString: exp.(string),
-	}, nil
+	return info, nil
 }
 
 func (srv *Server) getResultMap(jsonData []byte, target string) (result map[string]interface{}, err error) {

--- a/cli/info/info.go
+++ b/cli/info/info.go
@@ -38,6 +38,9 @@ func getInfoFromRemote(c cli.Config) (resp *client.InfoResp, err error) {
 
 	reqJSON, _ := json.Marshal(req)
 	resp, err = serv.Info(reqJSON)
+	if err != nil {
+		return
+	}
 
 	_, err = helpers.ParseCertificatePEM([]byte(resp.Certificate))
 	if err != nil {


### PR DESCRIPTION
The info command panics if there is an older cfssl at the other end or if an error is returned.