### PR TITLE
Zi/api sign polish

### DIFF
--- a/api/sign/sign.go
+++ b/api/sign/sign.go
@@ -140,9 +140,6 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	signReq := jsonReqToTrue(req)
-	if signReq.Hosts == nil {
-		return errors.NewBadRequestString("missing parameter 'hostname' or 'hosts'")
-	}
 
 	if req.Request == "" {
 		return errors.NewBadRequestString("missing parameter 'certificate_request'")
@@ -279,9 +276,6 @@ func (h *AuthHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	signReq := jsonReqToTrue(req)
-	if signReq.Hosts == nil {
-		return errors.NewBadRequestString("missing parameter 'hostname' or 'hosts'")
-	}
 
 	if signReq.Request == "" {
 		return errors.NewBadRequestString("missing parameter 'certificate_request'")

--- a/api/sign/sign_test.go
+++ b/api/sign/sign_test.go
@@ -319,9 +319,9 @@ var signTests = []signTest{
 	{
 		Hosts:              nil,
 		CSRFile:            testCSRFile,
-		ExpectedHTTPStatus: http.StatusBadRequest,
-		ExpectedSuccess:    false,
-		ExpectedErrorCode:  http.StatusBadRequest,
+		ExpectedHTTPStatus: http.StatusOK,
+		ExpectedSuccess:    true,
+		ExpectedErrorCode:  0,
 	},
 	{
 		Hosts:              []string{testDomainName},

--- a/cmd/multirootca/api.go
+++ b/cmd/multirootca/api.go
@@ -146,6 +146,10 @@ func dispatchRequest(w http.ResponseWriter, req *http.Request) {
 
 	if policy.Profiles != nil && sigRequest.Profile != "" {
 		profile = policy.Profiles[sigRequest.Profile]
+		if profile == nil {
+			fail(w, req, http.StatusBadRequest, 1, "invalid profile", "failed to look up profile with name: "+sigRequest.Profile)
+			return
+		}
 	}
 
 	if profile == nil {


### PR DESCRIPTION
The "Hosts" field of sign request is optional, fix the logic of api sign.
Also, add a small change to better report the failed lookup of profile.