### PR TITLE
Add support for scanning server elliptic curve preferences.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ import (
 // mechanism.
 type CSRWhitelist struct {
 	Subject, PublicKeyAlgorithm, PublicKey, SignatureAlgorithm bool
-	DNSNames, IPAddresses bool
+	DNSNames, IPAddresses                                      bool
 }
 
 // A SigningProfile stores information that the CA needs to store
@@ -409,7 +409,7 @@ func LoadConfig(config []byte) (*Config, error) {
 	err := json.Unmarshal(config, &cfg)
 	if err != nil {
 		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
-			errors.New("failed to unmarshal configuration: " + err.Error()))
+			errors.New("failed to unmarshal configuration: "+err.Error()))
 	}
 
 	if cfg.Signing.Default == nil {

--- a/scan/tls_handshake.go
+++ b/scan/tls_handshake.go
@@ -10,6 +10,9 @@ import (
 	"github.com/cloudflare/cf-tls/tls"
 )
 
+// Sentinel for failures in sayHello. Should always be caught.
+var errHelloFailed = errors.New("Handshake failed in sayHello")
+
 // TLSHandshake contains scanners testing host cipher suite negotiation
 var TLSHandshake = &Family{
 	Description: "Scans for host's SSL/TLS version and cipher suite negotiation",
@@ -21,7 +24,31 @@ var TLSHandshake = &Family{
 	},
 }
 
-func sayHello(host string, ciphers []uint16, vers uint16) (cipherIndex int, err error) {
+func getCipherIndex(ciphers []uint16, serverCipher uint16) (cipherIndex int, err error) {
+	//func getCipherIndex(ciphers []uint16, serverCipher uint16) (cipherIndex int, err error) {
+	//	fmt.Println(serverCipher, ciphers)
+	var cipherID uint16
+	for cipherIndex, cipherID = range ciphers {
+		if serverCipher == cipherID {
+			return
+		}
+	}
+	err = fmt.Errorf("server negotiated ciphersuite we didn't send: %s", tls.CipherSuites[serverCipher])
+	return
+}
+
+func getCurveIndex(curves []tls.CurveID, serverCurve tls.CurveID) (curveIndex int, err error) {
+	var curveID tls.CurveID
+	for curveIndex, curveID = range curves {
+		if serverCurve == curveID {
+			return
+		}
+	}
+	err = fmt.Errorf("server negotiated elliptic curve we didn't send: %s", tls.Curves[serverCurve])
+	return
+}
+
+func sayHello(host string, ciphers []uint16, curves []tls.CurveID, vers uint16) (cipherIndex, curveIndex int, err error) {
 	tcpConn, err := net.Dial(Network, host)
 	if err != nil {
 		return
@@ -30,10 +57,12 @@ func sayHello(host string, ciphers []uint16, vers uint16) (cipherIndex int, err 
 	config.MinVersion = vers
 	config.MaxVersion = vers
 	config.CipherSuites = ciphers
+	config.CurvePreferences = curves
 	conn := tls.Client(tcpConn, config)
-	serverCipher, serverVersion, err := conn.SayHello()
+	serverCipher, serverCurveType, serverCurve, serverVersion, err := conn.SayHello()
 	conn.Close()
 	if err != nil {
+		err = errHelloFailed
 		return
 	}
 
@@ -42,13 +71,18 @@ func sayHello(host string, ciphers []uint16, vers uint16) (cipherIndex int, err 
 		return
 	}
 
-	var cipherID uint16
-	for cipherIndex, cipherID = range ciphers {
-		if serverCipher == cipherID {
-			return
+	cipherIndex, err = getCipherIndex(ciphers, serverCipher)
+
+	if tls.CipherSuites[serverCipher].EllipticCurve {
+		if curves == nil {
+			curves = allCurvesIDs()
 		}
+		if serverCurveType != 3 {
+			err = fmt.Errorf("server negotiated non-named ECDH parameters; we didn't analyze them. Server curve type: %d", serverCurveType)
+		}
+		curveIndex, err = getCurveIndex(curves, serverCurve)
 	}
-	err = fmt.Errorf("server negotiated ciphersuite we didn't send: %s", tls.CipherSuites[serverCipher])
+
 	return
 }
 
@@ -60,10 +94,29 @@ func allCiphersIDs() []uint16 {
 	return ciphers
 }
 
-// cipherVersions contains lists of host's supported cipher suites based on SSL/TLS Version
+func allCurvesIDs() []tls.CurveID {
+	curves := make([]tls.CurveID, 0, len(tls.Curves))
+	for curveID := range tls.Curves {
+		// No unassigned or explicit curves in the scan, per http://tools.ietf.org/html/rfc4492#section-5.4
+		if curveID == 0 || curveID == 65281 || curveID == 65282 {
+			continue
+		} else {
+			curves = append(curves, curveID)
+		}
+	}
+	return curves
+}
+
+type cipherDatum struct {
+	versionID uint16
+	curves    []tls.CurveID
+}
+
+// cipherVersions contains lists of host's supported cipher suites based on SSL/TLS Version.
+// If a cipher suite uses ECC, also contains a list of supported curves by SSL/TLS Version.
 type cipherVersions struct {
 	cipherID uint16
-	versions []uint16
+	data     []cipherDatum
 }
 
 type cipherVersionList []cipherVersions
@@ -71,11 +124,15 @@ type cipherVersionList []cipherVersions
 func (cvList cipherVersionList) String() string {
 	cvStrings := make([]string, len(cvList))
 	for i, c := range cvList {
-		versStrings := make([]string, len(c.versions))
-		for j, vers := range c.versions {
-			versStrings[j] = tls.Versions[vers]
+		versStrings := make([]string, len(c.data))
+		for j, d := range c.data {
+			curveStrings := make([]string, len(d.curves))
+			for k, c := range d.curves {
+				curveStrings[k] = tls.Curves[c]
+			}
+			versStrings[j] = fmt.Sprintf("%s: [ %s ]", tls.Versions[d.versionID], strings.Join(curveStrings, ","))
 		}
-		cvStrings[i] = fmt.Sprintf("%s\t%s", tls.CipherSuites[c.cipherID], strings.Join(versStrings, ", "))
+		cvStrings[i] = fmt.Sprintf("%s\t%s", tls.CipherSuites[c.cipherID], strings.Join(versStrings, ","))
 	}
 	return strings.Join(cvStrings, "\n")
 }
@@ -84,14 +141,44 @@ func (cvList cipherVersionList) MarshalJSON() ([]byte, error) {
 	b := new(bytes.Buffer)
 	cvStrs := make([]string, len(cvList))
 	for i, cv := range cvList {
-		versStrings := make([]string, len(cv.versions))
-		for j, vers := range cv.versions {
-			versStrings[j] = fmt.Sprintf("\"%s\"", tls.Versions[vers])
+		versStrings := make([]string, len(cv.data))
+		for j, d := range cv.data {
+			curveStrings := make([]string, len(d.curves))
+			if len(d.curves) > 0 {
+				for k, c := range d.curves {
+					curveStrings[k] = fmt.Sprintf("\"%s\"", tls.Curves[c])
+				}
+				versStrings[j] = fmt.Sprintf("{\"%s\":[%s]}", tls.Versions[d.versionID], strings.Join(curveStrings, ","))
+			} else {
+				versStrings[j] = fmt.Sprintf("\"%s\"", tls.Versions[d.versionID])
+			}
 		}
 		cvStrs[i] = fmt.Sprintf("{\"%s\":[%s]}", tls.CipherSuites[cv.cipherID].String(), strings.Join(versStrings, ","))
 	}
 	fmt.Fprintf(b, "[%s]", strings.Join(cvStrs, ","))
 	return b.Bytes(), nil
+}
+
+func doCurveScan(host string, vers, cipherID uint16, ciphers []uint16) (supportedCurves []tls.CurveID, err error) {
+	allCurves := allCurvesIDs()
+	curves := make([]tls.CurveID, len(allCurves))
+	copy(curves, allCurves)
+	for len(curves) > 0 {
+		var curveIndex int
+		_, curveIndex, err = sayHello(host, []uint16{cipherID}, curves, vers)
+		if err != nil {
+			// This case is expected, because eventually we ask only for curves the server doesn't support
+			if err == errHelloFailed {
+				err = nil
+				break
+			}
+			return
+		}
+		curveID := curves[curveIndex]
+		supportedCurves = append(supportedCurves, curveID)
+		curves = append(curves[:curveIndex], curves[curveIndex+1:]...)
+	}
+	return
 }
 
 // cipherSuiteScan returns, by TLS Version, the sort list of cipher suites
@@ -105,21 +192,35 @@ func cipherSuiteScan(host string) (grade Grade, output Output, err error) {
 		ciphers := make([]uint16, len(allCiphers))
 		copy(ciphers, allCiphers)
 		for len(ciphers) > 0 {
-			cipherIndex, err := sayHello(host, ciphers, vers)
+			var cipherIndex int
+			cipherIndex, _, err = sayHello(host, ciphers, nil, vers)
 			if err != nil {
-				break
+				if err == errHelloFailed {
+					err = nil
+					break
+				}
+				return
 			}
 			if vers == tls.VersionSSL30 {
 				grade = Warning
 			}
 			cipherID := ciphers[cipherIndex]
+
+			// If this is an EC cipher suite, do a second scan for curve support
+			var supportedCurves []tls.CurveID
+			if tls.CipherSuites[cipherID].EllipticCurve {
+				supportedCurves, err = doCurveScan(host, vers, cipherID, ciphers)
+				if len(supportedCurves) == 0 {
+					err = errors.New("couldn't negotiate any curves")
+				}
+			}
 			for i, c := range cvList {
 				if cipherID == c.cipherID {
-					cvList[i].versions = append(c.versions, vers)
+					cvList[i].data = append(c.data, cipherDatum{vers, supportedCurves})
 					goto exists
 				}
 			}
-			cvList = append(cvList, cipherVersions{cipherID, []uint16{vers}})
+			cvList = append(cvList, cipherVersions{cipherID, []cipherDatum{cipherDatum{vers, supportedCurves}}})
 		exists:
 			ciphers = append(ciphers[:cipherIndex], ciphers[cipherIndex+1:]...)
 		}

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -760,8 +760,8 @@ func TestWhitelistSign(t *testing.T) {
 			ExpiryString: "1h",
 			Expiry:       1 * time.Hour,
 			CA:           true,
-			CSRWhitelist:    &config.CSRWhitelist{
-				PublicKey: true,
+			CSRWhitelist: &config.CSRWhitelist{
+				PublicKey:          true,
 				PublicKeyAlgorithm: true,
 				SignatureAlgorithm: true,
 			},
@@ -786,7 +786,7 @@ func TestWhitelistSign(t *testing.T) {
 
 	name := cert.Subject
 	if name.CommonName != "" {
-		t.Fatalf("Expected empty certificate common name under policy without " +
+		t.Fatalf("Expected empty certificate common name under policy without "+
 			"Subject whitelist, got %v", name.CommonName)
 	}
 	// O is provided by the signing API request, not the CSR, so it's allowed to


### PR DESCRIPTION
This change adds support for scanning server curve choice preferences for the ECDH cipher suites, which is interesting in light of logjam (even though that only affects non-ED DH, it's nice to know what's happening in case something similar becomes interesting in the future). This fixes #221, although it's slightly more involved than @jacobhaven suggested. Specifically, the server curve preference is not declared until the ServerKeyExchange message, meaning that you have to go well past ServerHello to extract it.

The scan is performed using the same algorithm as for cipher suites, where the server's negotiated preference is dropped iteratively from the list of all possible choices until we've enumerated the server's preference list.

Update: the scan results now seem correct (assuming the right return is only `secp256r1` for all ECDH cipher suites CloudFlare supports - I can't tell from the published SSL config which curve(s) are used). The only remaining issue is that the handshake in cf-tls sometimes fails in specific conditions (assuming the scan results are correct).

NB - the buildbot always fails here because this code depends on unmerged changes to cf-tls. Is there a way to specify which branch it should build from?