### PR TITLE
Add a pkcs11key_stub for build tools.

### DIFF
--- a/crypto/pkcs11key/pkcs11key_stub.go
+++ b/crypto/pkcs11key/pkcs11key_stub.go
@@ -1,0 +1,6 @@
+// Package pkcs11key exists to satisfy Go build tools.
+// Some Go tools will complain "no buildable Go source files in ..." because
+// pkcs11key.go only builds when the pkcs11 tag is supplied. This empty file
+// exists only to suppress that error, which blocks completion in some tools
+// (specifically godep).
+package pkcs11key


### PR DESCRIPTION
In Boulder, we're using godep to vendorize dependencies. I'm working on a change to include the pkcs11 dependencies as well. This requires a patched version of godep to support tags (https://github.com/tools/godep/pull/117).

Unfortunately, godep gets confused and gives the error:

```
godep: no buildable Go source files in /home/jsha/go/packages/src/github.com/cloudflare/cfssl/crypto/pkcs11key
godep: error loading dependencies
```

This error is simply fixed by adding this file.