### PR TITLE
Improvement: Adds new cli flag 'int-dir' to bundle cmd

### DIFF
--- a/cli/bundle/bundle.go
+++ b/cli/bundle/bundle.go
@@ -15,18 +15,19 @@ var bundlerUsageText = `cfssl bundle -- create a certificate bundle that contain
 
 Usage of bundle:
 	- Bundle local certificate files
-        cfssl bundle -cert file [-ca-bundle file] [-int-bundle file] [-metadata file] [-key keyfile] [-flavor optimal|ubiquitous|force] [-password password]
+        cfssl bundle -cert file [-ca-bundle file] [-int-bundle file] [-int-dir dir] [-metadata file] [-key keyfile] [-flavor optimal|ubiquitous|force] [-password password]
 	- Bundle certificate from remote server.
-        cfssl bundle -domain domain_name [-ip ip_address] [-ca-bundle file] [-int-bundle file] [-metadata file]
+        cfssl bundle -domain domain_name [-ip ip_address] [-ca-bundle file] [-int-bundle file] [-int-dir dir] [-metadata file]
 
 Flags:
 `
 
 // flags used by 'cfssl bundle'
-var bundlerFlags = []string{"cert", "key", "ca-bundle", "int-bundle", "flavor", "metadata", "domain", "ip", "password"}
+var bundlerFlags = []string{"cert", "key", "ca-bundle", "int-bundle", "flavor", "int-dir", "metadata", "domain", "ip", "password"}
 
 // bundlerMain is the main CLI of bundler functionality.
 func bundlerMain(args []string, c cli.Config) (err error) {
+	bundler.IntermediateStash = c.IntDir
 	ubiquity.LoadPlatforms(c.Metadata)
 	flavor := bundler.BundleFlavor(c.Flavor)
 	// Initialize a bundler with CA bundle and intermediate bundle.

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -24,8 +24,8 @@ var serverUsageText = `cfssl serve -- set up a HTTP server handles CF SSL reques
 
 Usage of serve:
         cfssl serve [-address address] [-ca cert] [-ca-bundle bundle] \
-                    [-ca-key key] [-int-bundle bundle] [-port port] [-metadata file] \
-                    [-remote remote_host] [-config config] [-uselocal]
+                    [-ca-key key] [-int-bundle bundle] [-int-dir dir] [-port port] \
+                    [-metadata file] [-remote remote_host] [-config config] [-uselocal]
 
 Flags:
 `


### PR DESCRIPTION
The bundle command creates a special intermediate folder to store
the downloaded intermediate certificates.
The current implementation creates an 'intermediates' folder
at the current path, where cfssl is executed. This polutes the
file system with many unnecessary 'intermediates' folders.
This commit fixes the problem by adding a new flag 'int-dir' to
customize the intermediate folder path. The same flag is already
used for the HTTP server and inherits it's default value from
the config.