### PR TITLE
Add support for certificate policy qualifiers.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"regexp"
 	"strconv"
@@ -84,14 +85,7 @@ func (oid *OID) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (oid OID) MarshalJSON() ([]byte, error) {
-	ret := ""
-	for _, item := range asn1.ObjectIdentifier(oid) {
-		if ret != "" {
-			ret = ret + "."
-		}
-		ret = ret + strconv.Itoa(item)
-	}
-	return []byte("\"" + ret + "\""), nil
+	return []byte(fmt.Sprintf(`"%v"`, oid)), nil
 }
 
 func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err error) {

--- a/config/config.go
+++ b/config/config.go
@@ -34,9 +34,11 @@ type CSRWhitelist struct {
 	DNSNames, IPAddresses                                      bool
 }
 
+// OID is our own version of asn1's ObjectIdentifier, so we can define a custom
+// JSON marshal / unmarshal.
 type OID asn1.ObjectIdentifier
 
-// A flattening of the ASN.1 PolicyInformation structure from
+// CertificatePolicy is a flattening of the ASN.1 PolicyInformation structure from
 // https://tools.ietf.org/html/rfc3280.html#page-106.
 // Valid values of Type are "id-qt-unotice" and "id-qt-cps"
 type CertificatePolicy struct {
@@ -70,6 +72,7 @@ type SigningProfile struct {
 	CSRWhitelist *CSRWhitelist
 }
 
+// UnmarshalJSON unmarshals a JSON string into an OID.
 func (oid *OID) UnmarshalJSON(data []byte) (err error) {
 	if data[0] != '"' || data[len(data) - 1] != '"' {
 		return errors.New("OID JSON string not wrapped in quotes." + string(data))
@@ -84,6 +87,7 @@ func (oid *OID) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
+// MarshalJSON marshals an oid into a JSON string.
 func (oid OID) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%v"`, oid)), nil
 }

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -352,7 +352,7 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 }
 
 type policyQualifier struct {
-	PolicyQualifierId asn1.ObjectIdentifier
+	PolicyQualifierID asn1.ObjectIdentifier
 	Qualifier string `asn1:"tag:optional,ia5"`
 }
 type policyInformation struct {
@@ -364,10 +364,10 @@ var (
 	// Per https://tools.ietf.org/html/rfc3280.html#page-106, this represents:
 	// iso(1) identified-organization(3) dod(6) internet(1) security(5)
 	//   mechanisms(5) pkix(7) id-qt(2) id-qt-cps(1)
-	IDQTCertificationPracticeStatement = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
+	iDQTCertificationPracticeStatement = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
 	// iso(1) identified-organization(3) dod(6) internet(1) security(5)
 	//   mechanisms(5) pkix(7) id-qt(2) id-qt-unotice(2)
-	IDQTUserNotice = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
+	iDQTUserNotice = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
 )
 
 // addPolicies adds Certificate Policies and optional Policy Qualifiers to a
@@ -386,14 +386,14 @@ func addPolicies(template *x509.Certificate, policies []config.CertificatePolicy
 			case "id-qt-unotice":
 				pi.PolicyQualifiers = []policyQualifier{
 					policyQualifier{
-						PolicyQualifierId: IDQTUserNotice,
+						PolicyQualifierID: iDQTUserNotice,
 						Qualifier: policy.Qualifier,
 					},
 				}
 			case "id-qt-cps":
 				pi.PolicyQualifiers = []policyQualifier{
 					policyQualifier{
-						PolicyQualifierId: IDQTCertificationPracticeStatement,
+						PolicyQualifierID: iDQTCertificationPracticeStatement,
 						Qualifier: policy.Qualifier,
 					},
 				}

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -334,7 +334,10 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 		template.IssuingCertificateURL = profile.IssuerURL
 	}
 	if len(profile.Policies) != 0 {
-		template.PolicyIdentifiers = profile.Policies
+		err = addPolicies(template, profile.Policies)
+		if err != nil {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+		}
 	}
 	if profile.OCSPNoCheck {
 		ocspNoCheckExtension := pkix.Extension{
@@ -345,5 +348,73 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 		template.ExtraExtensions = append(template.ExtraExtensions, ocspNoCheckExtension)
 	}
 
+	return nil
+}
+
+type policyQualifier struct {
+	PolicyQualifierId asn1.ObjectIdentifier
+	Qualifier string `asn1:"tag:optional,ia5"`
+}
+type policyInformation struct {
+	PolicyIdentifier asn1.ObjectIdentifier
+	PolicyQualifiers []policyQualifier `asn1:"omitempty"`
+}
+
+var (
+	// Per https://tools.ietf.org/html/rfc3280.html#page-106, this represents:
+	// iso(1) identified-organization(3) dod(6) internet(1) security(5)
+	//   mechanisms(5) pkix(7) id-qt(2) id-qt-cps(1)
+	IDQTCertificationPracticeStatement = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
+	// iso(1) identified-organization(3) dod(6) internet(1) security(5)
+	//   mechanisms(5) pkix(7) id-qt(2) id-qt-unotice(2)
+	IDQTUserNotice = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
+)
+
+// addPolicies adds Certificate Policies and optional Policy Qualifiers to a
+// certificate, based on the input config. Go's x509 library allows setting
+// Certificate Policies easily, but does not support nested Policy Qualifiers
+// under those policies. So we need to construct the ASN.1 structure ourselves.
+func addPolicies(template *x509.Certificate, policies []config.CertificatePolicy) error {
+	asn1PolicyList := []policyInformation{}
+
+	for _, policy := range policies {
+		pi := policyInformation{
+			// The PolicyIdentifier is an OID assigned to a given issuer.
+			PolicyIdentifier: asn1.ObjectIdentifier(policy.ID),
+		}
+		switch policy.Type {
+			case "id-qt-unotice":
+				pi.PolicyQualifiers = []policyQualifier{
+					policyQualifier{
+						PolicyQualifierId: IDQTUserNotice,
+						Qualifier: policy.Qualifier,
+					},
+				}
+			case "id-qt-cps":
+				pi.PolicyQualifiers = []policyQualifier{
+					policyQualifier{
+						PolicyQualifierId: IDQTCertificationPracticeStatement,
+						Qualifier: policy.Qualifier,
+					},
+				}
+			case "":
+				// Empty qualifier type is fine: Include this Certificate Policy, but
+				// don't include a Policy Qualifier.
+			default:
+				return errors.New("Invalid qualifier type in Policies " + policy.Type)
+		}
+		asn1PolicyList = append(asn1PolicyList, pi)
+	}
+
+	asn1Bytes, err := asn1.Marshal(asn1PolicyList)
+	if err != nil {
+		return err
+	}
+
+	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
+		Id:       asn1.ObjectIdentifier{2, 5, 29, 32},
+		Critical: false,
+		Value:    asn1Bytes,
+	})
 	return nil
 }


### PR DESCRIPTION
Previously we could only add certificate policies, but not their related
qualifiers.

Fixes #230.