### PR TITLE
Fix marshaling of OID

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -89,7 +89,7 @@ func (oid *OID) UnmarshalJSON(data []byte) (err error) {
 
 // MarshalJSON marshals an oid into a JSON string.
 func (oid OID) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%v"`, oid)), nil
+	return []byte(fmt.Sprintf(`"%v"`, asn1.ObjectIdentifier(oid))), nil
 }
 
 func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err error) {


### PR DESCRIPTION
In #238 I accidentally used %v with our custom oid, which lacks the correct String method. This PR casts to asn1.ObjectIdentifier to get the correct String method.