### PR TITLE
Set pkcs11 user pin in environment

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"os"
 
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/helpers"
@@ -92,7 +93,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	if pkcs11.Enabled {
 		f.StringVar(&c.Module, "pkcs11-module", "", "PKCS #11 module")
 		f.StringVar(&c.Token, "pkcs11-token", "", "PKCS #11 token")
-		f.StringVar(&c.PIN, "pkcs11-pin", "", "PKCS #11 user PIN")
+		f.StringVar(&c.PIN, "pkcs11-pin", os.Getenv("USER_PIN"), "PKCS #11 user PIN")
 		f.StringVar(&c.PKCS11Label, "pkcs11-label", "", "PKCS #11 label")
 	}
 }


### PR DESCRIPTION
To hide the user pin from the process list, set it in the environment. That way, only users with access to `/proc/$(pidof cfssl)/environ` (typically root) can read the user pin. You can store the pin in a file accessible by root only and set the pin as follows:

    USER_PIN=$(cat /etc/cfssl/pin)
    $GOPATH/bin/cfssl ...

If USER_PIN is unset, the behavior is identical to the current one (i.e. you need to provide a pin on the command line).