### PR TITLE
Remove unused Whitelist field from Subject struct

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -27,19 +27,11 @@ import (
 // MaxPathLen is the default path length for a new CA certificate.
 var MaxPathLen = 2
 
-// A Whitelist marks which fields should be set. As a bool's default
-// value is false, a whitelist should only keep those fields marked
-// true.
-type Whitelist struct {
-	CN, C, ST, L, O, OU bool
-}
-
 // Subject contains the information that should be used to override the
 // subject information when signing a certificate.
 type Subject struct {
-	CN        string
-	Names     []csr.Name `json:"names"`
-	Whitelist *Whitelist `json:"whitelist,omitempty"`
+	CN    string
+	Names []csr.Name `json:"names"`
 }
 
 // SignRequest stores a signature request, which contains the hostname,


### PR DESCRIPTION
The whitelisting of fields was replaced by a policy-level CSR whitelist with https://github.com/cloudflare/cfssl/commit/a05c5d2970952662f538c2dc15a6933b19d6566c