### PR TITLE
Add support for multiple remotes in API client

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -15,7 +15,6 @@ var (
 
 func TestNewServer(t *testing.T) {
 	s := NewServer("1.1.1.1:::123456789")
-
 	if s != nil {
 		t.Fatalf("fatal error, server created with too many colons %v", s)
 	}
@@ -55,5 +54,18 @@ func TestSign(t *testing.T) {
 	sign, _ := s.Sign([]byte{5, 5, 5, 5})
 	if sign != nil {
 		t.Fatalf("%v", sign)
+	}
+}
+
+func TestNewServerGroup(t *testing.T) {
+	s := NewServer("cfssl1.local:8888, cfssl2.local:8888")
+
+	ogl, ok := s.(*orderedListGroup)
+	if !ok {
+		t.Fatalf("expected NewServer to return an ordered group list with a list of servers, instead got a %T = %+v", ogl, ogl)
+	}
+
+	if len(ogl.remotes) != 2 {
+		t.Fatalf("expected the remote to have two servers, but it has %d", len(ogl.remotes))
 	}
 }

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -69,3 +69,28 @@ func TestNewServerGroup(t *testing.T) {
 		t.Fatalf("expected the remote to have two servers, but it has %d", len(ogl.remotes))
 	}
 }
+
+func TestNewOGLGroup(t *testing.T) {
+	strategy := StrategyFromString("ordered_list")
+	if strategy == StrategyInvalid {
+		t.Fatal("expected StrategyOrderedList as selected strategy but have StrategyInvalid")
+	}
+
+	if strategy != StrategyOrderedList {
+		t.Fatalf("expected StrategyOrderedList (%d) but have %d", StrategyOrderedList, strategy)
+	}
+
+	rem, err := NewGroup([]string{"ca1.local,", "ca2.local"}, strategy)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	ogl, ok := rem.(*orderedListGroup)
+	if !ok {
+		t.Fatalf("expected to get an orderedListGroup but got %T", rem)
+	}
+
+	if len(ogl.remotes) != 2 {
+		t.Fatalf("expected two remotes in the ordered group list but have %d", len(ogl.remotes))
+	}
+}

--- a/api/client/group.go
+++ b/api/client/group.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/cloudflare/cfssl/auth"
+	"github.com/cloudflare/cfssl/info"
+)
+
+type Strategy int
+
+const (
+	StrategyInvalid = iota
+	StrategyOrderedList
+)
+
+var strategyStrings = map[string]Strategy{
+	"ordered_list": StrategyOrderedList,
+}
+
+// StrategyFromString takes a string describing a
+func StrategyFromString(s string) Strategy {
+	s := strings.TrimSpace(strings.ToLower(s))
+	strategy, ok := strategyStrings[s]
+	if !ok {
+		return StrategyInvalid
+	}
+	return strategy
+}
+
+type Group interface {
+	AuthSign(req, id []byte, provider auth.Provider) ([]byte, error)
+	Sign(jsonData []byte) ([]byte, error)
+	Info(jsonData []byte) (*info.Resp, error)
+}
+
+func NewGroup(remotes []string, strategy Strategy) (Group, error) {
+	var servers = make([]*Server, len(remotes))
+	for i := range remotes {
+		servers[i] = NewServer(remotes[i])
+	}
+
+	switch strategy {
+	case StrategyOrderedList:
+		return newOrdererdListGroup(servers)
+	default:
+		return nil, errors.New("unrecognised strategy")
+	}
+}
+
+type orderedListGroup struct {
+	remotes []*Server
+}
+
+func newOrdererdListGroup(remotes []*Server) (Group, error) {
+	return &orderedListGroup{
+		remotes: remotes,
+	}, nil
+}
+
+func (g *orderedListGroup) AuthSign(req, id []byte, provider auth.Provider) (resp []byte, err error) {
+	for i := range g.remotes {
+		resp, err = g.remotes[i].AuthSign(req, id, provider)
+		if err == nil {
+			return resp, nil
+		}
+	}
+
+	return nil, err
+}
+
+func (g *orderedListGroup) Sign(jsonData []byte) (resp []byte, err error) {
+	for i := range g.remotes {
+		resp, err = g.remotes[i].Sign(jsonData)
+		if err == nil {
+			return resp, nil
+		}
+	}
+
+	return nil, err
+}
+
+func (g *orderedListGroup) Info(jsonData []byte) (resp *info.Resp, err error) {
+	for i := range g.remotes {
+		resp, err = g.remotes[i].Info(jsonData)
+		if err == nil {
+			return resp, nil
+		}
+	}
+
+	return nil, err
+}

--- a/signer/remote/remote.go
+++ b/signer/remote/remote.go
@@ -83,9 +83,9 @@ func (s *Signer) remoteOp(req interface{}, profile, target string) (resp interfa
 	if target == "info" {
 		resp, err = server.Info(jsonData)
 	} else if p.Provider != nil {
-		resp, err = server.AuthReq(jsonData, nil, p.Provider, target)
+		resp, err = server.AuthSign(jsonData, nil, p.Provider)
 	} else {
-		resp, err = server.Req(jsonData, target)
+		resp, err = server.Sign(jsonData)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR enables support for groups of CFSSL remote instances in the API client. Groups of servers are indistinguishable from the client's perspective from a single server. Groups are constructed from a specific strategy using the `NewGroup` function, or by passing a comma-separated list to `NewServer` to construct an ordered list of remotes. The change to `NewServer` provides a non-invasive mechanism for supporting a group of remotes using the strategy that we intend to use first.

The only strategy supported now is an ordered list, in which the list of hosts are attempted in sequence until one succeeds or none do with the goal of improving availability. Potentially as a part of CFSSL v1.2, a round-robin strategy should be implemented to provide load-balancing.