### PR TITLE
Remove old PolicyStrings field.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,7 +61,6 @@ type SigningProfile struct {
 	OCSP                string    `json:"ocsp_url"`
 	CRL                 string    `json:"crl_url"`
 	CA                  bool      `json:"is_ca"`
-	PolicyStrings       []string  `json:"policies"`
 	OCSPNoCheck         bool      `json:"ocsp_no_check"`
 	ExpiryString        string    `json:"expiry"`
 	BackdateString      string    `json:"backdate"`


### PR DESCRIPTION
This was superseded by CertificatePolicies.

Looks like this was accidentally restored in a42b0f13. It causes a conflict when loading JSON because there are two fields named `policies`.