### PR TITLE
Return with exit code 1 on error.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -101,7 +101,7 @@ func Start(cmds map[string]*Command) {
 	if flag.NArg() < 1 {
 		fmt.Fprintf(os.Stderr, "No command is given.\n")
 		flag.Usage()
-		return
+		os.Exit(1)
 	}
 
 	// Clip out the command name and args for the command
@@ -111,7 +111,7 @@ func Start(cmds map[string]*Command) {
 	if !found {
 		fmt.Fprintf(os.Stderr, "Command %s is not defined.\n", cmdName)
 		flag.Usage()
-		return
+		os.Exit(1)
 	}
 	// The usage of each individual command is re-written to mention
 	// flags defined and referenced only in that command.
@@ -137,6 +137,7 @@ func Start(cmds map[string]*Command) {
 
 	if err := cmd.Main(args, c); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -78,7 +78,7 @@ func PopFirstArgument(args []string) (string, []string, error) {
 }
 
 // Start is the entrance point of cfssl command line tools.
-func Start(cmds map[string]*Command) {
+func Start(cmds map[string]*Command) error {
 	// cfsslFlagSet is the flag sets for cfssl.
 	var cfsslFlagSet = flag.NewFlagSet("cfssl", flag.ExitOnError)
 	var c Config
@@ -101,7 +101,7 @@ func Start(cmds map[string]*Command) {
 	if flag.NArg() < 1 {
 		fmt.Fprintf(os.Stderr, "No command is given.\n")
 		flag.Usage()
-		os.Exit(1)
+		return errors.New("no command was given")
 	}
 
 	// Clip out the command name and args for the command
@@ -111,7 +111,7 @@ func Start(cmds map[string]*Command) {
 	if !found {
 		fmt.Fprintf(os.Stderr, "Command %s is not defined.\n", cmdName)
 		flag.Usage()
-		os.Exit(1)
+		return errors.New("undefined command")
 	}
 	// The usage of each individual command is re-written to mention
 	// flags defined and referenced only in that command.
@@ -132,13 +132,15 @@ func Start(cmds map[string]*Command) {
 	c.CFG, err = config.LoadFile(c.ConfigFile)
 	if c.ConfigFile != "" && err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load config file: %v", err)
-		os.Exit(1)
+		return errors.New("failed to load config file")
 	}
 
 	if err := cmd.Main(args, c); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }
 
 // ReadStdin reads from stdin if the file is "-"

--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/cli/bundle"
@@ -57,6 +58,11 @@ func main() {
 		"scan":      scan.Command,
 		"info":      info.Command,
 	}
-	// Register all command flags.
-	cli.Start(cmds)
+
+	// If the CLI returns an error, exit with an appropriate status
+	// code.
+	err := cli.Start(cmds)
+	if err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/cfssljson/cfssljson.go
+++ b/cmd/cfssljson/cfssljson.go
@@ -56,21 +56,21 @@ func main() {
 	fileData, err := readFile(*inFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read input: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	if *bare {
 		err = json.Unmarshal(fileData, &input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to parse input: %v\n", err)
-			return
+			os.Exit(1)
 		}
 	} else {
 		var response Response
 		err = json.Unmarshal(fileData, &response)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to parse input: %v\n", err)
-			return
+			os.Exit(1)
 		}
 
 		if !response.Success {
@@ -78,7 +78,7 @@ func main() {
 			for _, msg := range response.Errors {
 				fmt.Fprintf(os.Stderr, "\t%s\n", msg.Message)
 			}
-			return
+			os.Exit(1)
 		}
 
 		input = response.Result


### PR DESCRIPTION
Right now, if `cfssl` or `cfssljson` encounters an error, they don't return an error code. This ensures that they do.