### PR TITLE
Allow containerized build under SELinux

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+BUILD_DIR=$(cd "$(dirname $0)"; cd ..; pwd)
+
+relabel() {
+  chcon -R -t "${1}" "${BUILD_DIR}"
+}
+
 if [ -z "$1" ]; then
     OS_PLATFORM_ARG=(-os="darwin linux windows")
 else
@@ -16,6 +22,15 @@ fi
 # Build Docker image unless we opt out of it
 if [[ -z "$SKIP_BUILD" ]]; then
     docker build -t cfssl-build -f Dockerfile.build .
+fi
+
+# Temporarily change SELinux context of build directory
+if [[ "$(command getenforce 2>&1)" == "Enforcing" ]]; then
+  USER_CONTEXT="$(getfattr --only-values -n security.selinux "${BUILD_DIR}" | awk -F':' '{ print $3 }')"
+  CONTAINER_CONTEXT="svirt_sandbox_file_t"
+
+  trap "relabel '${USER_CONTEXT}'" EXIT
+  relabel "${CONTAINER_CONTEXT}"
 fi
 
 # Get rid of existing binaries


### PR DESCRIPTION
Under the default SELinux policy, Docker containers can only access files
labeled svirt_sandbox_file_t (with optional MCS tags). The -Z option (new in 1.7)
relabels files in a volume mount to be accessible by the running container.

Ref: http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/

And some relevant audit output:

```
----
time->Mon Jul 20 19:12:08 2015
type=AVC msg=audit(1437444728.970:5451): avc:  denied  { read } for  pid=15910 comm="go" name="cfssl.go" dev="dm-3" ino=4723277 scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=1
----
time->Mon Jul 20 19:12:08 2015
type=AVC msg=audit(1437444728.970:5452): avc:  denied  { open } for  pid=15910 comm="go" path="/go/src/github.com/cloudflare/cfssl/cmd/cfssl/cfssl.go" dev="dm-3" ino=4723277 scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=1
----
time->Mon Jul 20 19:12:11 2015
type=AVC msg=audit(1437444731.824:5458): avc:  denied  { remove_name } for  pid=15985 comm="go" name="cfssl_darwin-386" dev="dm-3" ino=10100992 scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=dir permissive=1
----
time->Mon Jul 20 19:12:11 2015
type=AVC msg=audit(1437444731.824:5459): avc:  denied  { unlink } for  pid=15985 comm="go" name="cfssl_darwin-386" dev="dm-3" ino=10100992 scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=system_u:object_r:user_home_t:s0 tclass=file permissive=1
----
time->Mon Jul 20 19:12:09 2015
type=AVC msg=audit(1437444729.699:5453): avc:  denied  { write } for  pid=15966 comm="go" name="cfssl" dev="dm-3" ino=10101018 scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=dir permissive=1
----
time->Mon Jul 20 19:12:09 2015
type=AVC msg=audit(1437444729.699:5454): avc:  denied  { add_name } for  pid=15966 comm="go" name="cfssl_darwin-386" scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=dir permissive=1
----
time->Mon Jul 20 19:12:09 2015
type=AVC msg=audit(1437444729.699:5455): avc:  denied  { create } for  pid=15966 comm="go" name="cfssl_darwin-386" scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=system_u:object_r:user_home_t:s0 tclass=file permissive=1
----
time->Mon Jul 20 19:12:09 2015
type=AVC msg=audit(1437444729.699:5456): avc:  denied  { write open } for  pid=15966 comm="go" path="/go/src/github.com/cloudflare/cfssl/cfssl_darwin-386" dev="dm-3" ino=10100992 scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=system_u:object_r:user_home_t:s0 tclass=file permissive=1
----
time->Mon Jul 20 19:12:11 2015
type=AVC msg=audit(1437444731.815:5457): avc:  denied  { read } for  pid=15985 comm="go" name="cfssl_darwin-386" dev="dm-3" ino=10100992 scontext=system_u:system_r:svirt_lxc_net_t:s0:c697,c888 tcontext=system_u:object_r:user_home_t:s0 tclass=file permissive=1
```