### PR TITLE
Make scans run concurrently

### DIFF
--- a/api/scan/scan_test.go
+++ b/api/scan/scan_test.go
@@ -1,1 +1,66 @@
 package scan
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	handler = NewHandler()
+	ts      = httptest.NewServer(handler)
+)
+
+func TestBadRequest(t *testing.T) {
+	// Test request with no host
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+	resp, _ := http.DefaultClient.Do(req)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatal(resp.Status)
+	}
+
+	// Test request with non-existent host
+	data := req.URL.Query()
+	data.Add("host", "e.com")
+	req.URL.RawQuery = data.Encode()
+	resp, _ = http.DefaultClient.Do(req)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatal(resp.Status)
+	}
+}
+
+func TestScanRESTfulVerbs(t *testing.T) {
+	// GET should work
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+	data := req.URL.Query()
+	data.Add("host", "cloudflare.com")
+	req.URL.RawQuery = data.Encode()
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal(resp.Status)
+	}
+
+	// POST, PUT, DELETE, WHATEVER should return 400 errors
+	req, _ = http.NewRequest("POST", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+	req, _ = http.NewRequest("DELETE", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+	req, _ = http.NewRequest("PUT", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+	req, _ = http.NewRequest("WHATEVER", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -88,7 +88,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.BoolVar(&c.List, "list", false, "list possible scanners")
 	f.StringVar(&c.Family, "family", "", "scanner family regular expression")
 	f.StringVar(&c.Scanner, "scanner", "", "scanner regular expression")
-	f.DurationVar(&c.Timeout, "timeout", 0, "duration (ns, us, ms, s, m, h) to scan each host before timing out")
+	f.DurationVar(&c.Timeout, "timeout", 5*time.Minute, "duration (ns, us, ms, s, m, h) to scan each host before timing out")
 	f.StringVar(&c.Responses, "responses", "", "file to load OCSP responses from")
 	f.StringVar(&c.Path, "path", "/", "Path on which the server will listen")
 	f.StringVar(&c.Password, "password", "0", "Password for accessing PKCS #12 data passed to bundler")


### PR DESCRIPTION
Running scans sequentially takes too long, especially if any one scan
runs into network issues.

This change runs each scan in a separate goroutine, and returns
results/errors whenever an individual scan finishes.

Resolves #236