### PR TITLE
scan: Fix supportedSKXSignatureAlgorithms not being reset to default.

### DIFF
--- a/scan/tls_handshake.go
+++ b/scan/tls_handshake.go
@@ -74,6 +74,7 @@ func sayHello(host string, ciphers []uint16, curves []tls.CurveID, vers uint16, 
 		sigAlgs = tls.AllSignatureAndHashAlgorithms
 	}
 	tls.SetSupportedSKXSignatureAlgorithms(sigAlgs)
+	defer tls.ResetSupportedSKXSignatureAlgorithms()
 
 	conn := tls.Client(tcpConn, config)
 	serverCipher, serverCurveType, serverCurve, serverVersion, err := conn.SayHello()


### PR DESCRIPTION
This will remove the `unknown hash function` seen after having set sigAlgs that we don't actually support.