### PR TITLE
ocsp: fix typo

### DIFF
--- a/cli/ocspserve/ocspserve.go
+++ b/cli/ocspserve/ocspserve.go
@@ -1,4 +1,4 @@
-// Package ocspserve implements the oscpserve function.
+// Package ocspserve implements the ocspserve function.
 package ocspserve
 
 import (


### PR DESCRIPTION
These should probably say `ocsp` :)