### PR TITLE
Add LogFatal level of logging that also calls `os.Exit(1)`

### DIFF
--- a/cmd/multirootca/ca.go
+++ b/cmd/multirootca/ca.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"net"
 	"net/http"
-	"os"
 
 	"github.com/cloudflare/cfssl/api/info"
 	"github.com/cloudflare/cfssl/cmd/multirootca/config"
@@ -46,14 +45,12 @@ func main() {
 	flag.Parse()
 
 	if *flagRootFile == "" {
-		log.Criticalf("no root file specified")
-		os.Exit(1)
+		log.Fatal("no root file specified")
 	}
 
 	roots, err := config.Parse(*flagRootFile)
 	if err != nil {
-		log.Criticalf("%v", err)
-		os.Exit(1)
+		log.Fatalf("%v", err)
 	}
 
 	for label, root := range roots {

--- a/log/log.go
+++ b/log/log.go
@@ -8,6 +8,7 @@ package log
 import (
 	"fmt"
 	golog "log"
+	"os"
 )
 
 // The following constants represent logging levels in increasing levels of seriousness.
@@ -17,6 +18,7 @@ const (
 	LevelWarning
 	LevelError
 	LevelCritical
+	LevelFatal
 )
 
 var levelPrefix = [...]string{
@@ -25,6 +27,7 @@ var levelPrefix = [...]string{
 	LevelWarning:  "[WARNING] ",
 	LevelError:    "[ERROR] ",
 	LevelCritical: "[CRITICAL] ",
+	LevelFatal:    "[FATAL] ",
 }
 
 // Level stores the current logging level.
@@ -40,6 +43,19 @@ func output(l int, v []interface{}) {
 	if l >= Level {
 		golog.Print(levelPrefix[l], fmt.Sprint(v...))
 	}
+}
+
+// Fatalf logs a formatted message at the "fatal" level and then exits. The
+// arguments are handled in the same manner as fmt.Printf.
+func Fatalf(format string, v ...interface{}) {
+	outputf(LevelFatal, format, v)
+	os.Exit(1)
+}
+
+// Fatal logs its arguments at the "fatal" level and then exits.
+func Fatal(v ...interface{}) {
+	output(LevelFatal, v)
+	os.Exit(1)
 }
 
 // Criticalf logs a formatted message at the "critical" level. The


### PR DESCRIPTION
I also updated instances where `log.Critical` was immediately followed by `os.Exit` (there may be other more complex instances that could use an update.)