### PR TITLE
Add print-defaults commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ should carry out:
        serve            start the API server
        version          prints out the current version
        selfsign         generates a self-signed certificate
+       print-defaults	print default configurations
 
 Use "cfssl [command] -help" to find out more about a command.
 The version command takes no arguments.

--- a/cli/printdefault/defaults.go
+++ b/cli/printdefault/defaults.go
@@ -1,0 +1,49 @@
+package printdefaults
+
+var defaults = map[string]string{
+	"config": `{
+    "signing": {
+        "default": {
+            "expiry": "168h"
+        },
+        "profiles": {
+            "www": {
+                "expiry": "8760h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth"
+                ]
+            },
+            "client": {
+                "expiry": "8760h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "client auth"
+                ]
+            }
+        }
+    }
+}
+`,
+	"csr": `{
+    "CN": "example.net",
+    "hosts": [
+        "example.net",
+        "www.example.net"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "CA",
+            "ST": "San Francisco"
+        }
+    ]
+}
+`,
+}

--- a/cli/printdefault/printdefault.go
+++ b/cli/printdefault/printdefault.go
@@ -1,0 +1,48 @@
+package printdefaults
+
+import (
+	"fmt"
+
+	"github.com/cloudflare/cfssl/cli"
+)
+
+var printDefaultsUsage = `cfssl print-defaults -- print default configurations that can be used as a template
+
+Usage of print-defaults:
+        cfssl print-defaults TYPE
+
+If "list" is used as the TYPE, the list of supported types will be printed.
+`
+
+func printAvailable() {
+	fmt.Println("Default configurations are available for:")
+	for name := range defaults {
+		fmt.Println("\t" + name)
+	}
+}
+
+func printDefaults(args []string, c cli.Config) (err error) {
+	arg, args, err := cli.PopFirstArgument(args)
+	if err != nil {
+		return
+	}
+
+	if arg == "list" {
+		printAvailable()
+	} else {
+		if config, ok := defaults[arg]; !ok {
+			printAvailable()
+		} else {
+			fmt.Println(config)
+		}
+	}
+
+	return
+}
+
+// Command is exported for use by the CLI.
+var Command = &cli.Command{
+	UsageText: printDefaultsUsage,
+	Flags:     []string{},
+	Main:      printDefaults,
+}

--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudflare/cfssl/cli/info"
 	"github.com/cloudflare/cfssl/cli/ocspserve"
 	"github.com/cloudflare/cfssl/cli/ocspsign"
+	"github.com/cloudflare/cfssl/cli/printdefault"
 	"github.com/cloudflare/cfssl/cli/scan"
 	"github.com/cloudflare/cfssl/cli/selfsign"
 	"github.com/cloudflare/cfssl/cli/serve"
@@ -46,17 +47,18 @@ func main() {
 	flag.IntVar(&log.Level, "loglevel", log.LevelInfo, "Log level")
 	// Register commands.
 	cmds := map[string]*cli.Command{
-		"bundle":    bundle.Command,
-		"sign":      sign.Command,
-		"serve":     serve.Command,
-		"version":   version.Command,
-		"genkey":    genkey.Command,
-		"gencert":   gencert.Command,
-		"ocspsign":  ocspsign.Command,
-		"ocspserve": ocspserve.Command,
-		"selfsign":  selfsign.Command,
-		"scan":      scan.Command,
-		"info":      info.Command,
+		"bundle":         bundle.Command,
+		"sign":           sign.Command,
+		"serve":          serve.Command,
+		"version":        version.Command,
+		"genkey":         genkey.Command,
+		"gencert":        gencert.Command,
+		"ocspsign":       ocspsign.Command,
+		"ocspserve":      ocspserve.Command,
+		"selfsign":       selfsign.Command,
+		"scan":           scan.Command,
+		"info":           info.Command,
+		"print-defaults": printdefaults.Command,
 	}
 
 	// If the CLI returns an error, exit with an appropriate status


### PR DESCRIPTION
There are only two configs here, but it's a starting point for adding any other default configuration strings desired.