### PR TITLE
Added ocspsign API endpoint. Support for ocspResponse in cfssljson

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The bundle output form should follow the example
 #### Generating certificate signing request and private key
 
 ```
-cfssl genkey csrjson
+cfssl genkey csr.json
 ```
 
 To generate a private key and corresponding certificate request, specify
@@ -219,7 +219,7 @@ the key request as a JSON file. This file should follow the form
 #### Generating self-signed root CA certificate and private key
 
 ```
-cfssl genkey -initca csrjson | cfssljson -bare ca
+cfssl genkey -initca csr.json | cfssljson -bare ca
 ```
 
 To generate a self-signed root CA certificate, specify the key request as
@@ -230,7 +230,7 @@ certificate.
 #### Generating a remote-issued certificate and private key.
 
 ```
-cfssl gencert -remote=remote_server [-hostname=comma,separated,hostnames] csrjson
+cfssl gencert -remote=remote_server [-hostname=comma,separated,hostnames] csr.json
 ```
 
 This is calls genkey, but has a remote CFSSL server sign and issue
@@ -239,11 +239,23 @@ a certificate. You may use `-hostname` to override certificate SANs.
 #### Generating a local-issued certificate and private key.
 
 ```
-cfssl gencert -ca cert -ca-key key [-hostname=comma,separated,hostnames] csrjson
+cfssl gencert -ca cert -ca-key key [-hostname=comma,separated,hostnames] csr.json
 ```
 
 This is generates and issues a certificate and private key from a local CA
 via a JSON request. You may use `-hostname` to override certificate SANs.
+
+
+#### Updating a OCSP responses file with a newly issued certificate
+
+```
+cfssl ocspsign -ca cert -responder key -responder-key key -cert cert \
+ | cfssljson -bare -stdout >> responses
+```
+
+This will generate a OCSP response for the `cert` and add it to the
+`responses` file. You can then pass `responses` to `ocspserve` to start a
+OCSP server.
 
 ### Starting the API Server
 
@@ -332,7 +344,12 @@ filenames in the following way:
 * if there is a "csr" (or if not, if there's a "certificate_request") field,
   the file "basename.csr" will be produced.
 * if there is a "bundle" field, the file "basename-bundle.pem" will
-  be producd.
+  be produced.
+* if there is a "ocspResponse" field, the file "basename-response.der" will
+  be produced.
+
+Instead of saving to a file, you can pass `-stdout` to output the encoded
+contents.
 
 ### Static Builds
 

--- a/api/ocsp/ocspsign.go
+++ b/api/ocsp/ocspsign.go
@@ -1,0 +1,95 @@
+// Package ocsp implements the HTTP handler for the ocsp commands.
+package ocsp
+
+import (
+	"net/http"
+
+	"encoding/base64"
+	"encoding/json"
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/ocsp"
+	"io/ioutil"
+	"time"
+)
+
+// A Handler accepts requests with a certficate parameter
+// (which should be PEM-encoded) and returns a signed ocsp
+// response.
+type Handler struct {
+	signer ocsp.Signer
+}
+
+// NewHandler returns a new http.Handler that handles a ocspsign request.
+func NewHandler(s ocsp.Signer) http.Handler {
+	return &api.HTTPHandler{
+		Handler: &Handler{
+			signer: s,
+		},
+		Methods: []string{"POST"},
+	}
+}
+
+// This type is meant to be unmarshalled from JSON
+type jsonSignRequest struct {
+	Certificate string `json:"certificate"`
+	Status      string `json:"status"`
+	Reason      int    `json:"reason,omitempty"`
+	RevokedAt   string `json:"revoked_at,omitempty"`
+}
+
+// Handle responds to requests for a ocsp signature. It creates and signs
+// a ocsp response for the provided certificate and status. If the status
+// is revoked then it also adds reason and revoked_at. The response is
+// base64 encoded.
+func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	// Default the status to good so it matches the cli
+	req := &jsonSignRequest{
+		Status: "good",
+	}
+	err = json.Unmarshal(body, req)
+	if err != nil {
+		return errors.NewBadRequestString("Unable to parse sign request")
+	}
+
+	cert, err := helpers.ParseCertificatePEM([]byte(req.Certificate))
+	if err != nil {
+		log.Error("Error from ParseCertificatePEM", err)
+		return errors.NewBadRequestString("Malformed certificate")
+	}
+
+	signReq := ocsp.SignRequest{
+		Certificate: cert,
+		Status:      req.Status,
+	}
+	// We need to convert the time from being a string to a time.Time
+	if req.Status == "revoked" {
+		signReq.Reason = req.Reason
+		// "now" is accepted and the default on the cli so default that here
+		if req.RevokedAt == "" || req.RevokedAt == "now" {
+			signReq.RevokedAt = time.Now()
+		} else {
+			signReq.RevokedAt, err = time.Parse("2006-01-02", req.RevokedAt)
+			if err != nil {
+				return errors.NewBadRequestString("Malformed revocation time")
+			}
+		}
+	}
+
+	resp, err := h.signer.Sign(signReq)
+	if err != nil {
+		return err
+	}
+
+	b64Resp := base64.StdEncoding.EncodeToString(resp)
+	result := map[string]string{"ocspResponse": b64Resp}
+	return api.SendResponse(w, result)
+}

--- a/api/ocsp/ocspsign_test.go
+++ b/api/ocsp/ocspsign_test.go
@@ -1,0 +1,232 @@
+package ocsp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"encoding/base64"
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/ocsp"
+	goocsp "golang.org/x/crypto/ocsp"
+	"time"
+)
+
+const (
+	testCaFile       = "../../ocsp/testdata/ca.pem"
+	testRespCertFile = "../../ocsp/testdata/server.crt"
+	testKeyFile      = "../../ocsp/testdata/server.key"
+	testCertFile     = "../../ocsp/testdata/cert.pem"
+)
+
+func newTestHandler(t *testing.T) http.Handler {
+	// arbitrary duration
+	dur, _ := time.ParseDuration("1ms")
+	s, err := ocsp.NewSignerFromFile(testCaFile, testRespCertFile, testKeyFile, dur)
+	if err != nil {
+		t.Fatalf("Signer creation failed %v", err)
+	}
+	return NewHandler(s)
+}
+
+func TestNewHandler(t *testing.T) {
+	newTestHandler(t)
+}
+
+func newSignServer(t *testing.T) *httptest.Server {
+	ts := httptest.NewServer(newTestHandler(t))
+	return ts
+}
+
+func testSignFile(t *testing.T, certFile, status string, reason int, revokedAt string) (resp *http.Response, body []byte) {
+	ts := newSignServer(t)
+	defer ts.Close()
+
+	obj := map[string]interface{}{}
+	if certFile != "" {
+		c, err := ioutil.ReadFile(certFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		obj["certificate"] = string(c)
+	}
+	if status != "" {
+		obj["status"] = status
+	}
+	obj["reason"] = reason
+	if revokedAt != "" {
+		obj["revoked_at"] = revokedAt
+	}
+
+	blob, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = http.Post(ts.URL, "application/json", bytes.NewReader(blob))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+type signTest struct {
+	CertificateFile    string
+	Status             string
+	Reason             int
+	RevokedAt          string
+	ExpectedHTTPStatus int
+	ExpectedSuccess    bool
+	ExpectedErrorCode  int
+}
+
+var signTests = []signTest{
+	{
+		CertificateFile:    testCertFile,
+		ExpectedHTTPStatus: http.StatusOK,
+		ExpectedSuccess:    true,
+		ExpectedErrorCode:  0,
+	},
+	{
+		CertificateFile:    testCertFile,
+		Status:             "revoked",
+		Reason:             1,
+		ExpectedHTTPStatus: http.StatusOK,
+		ExpectedSuccess:    true,
+		ExpectedErrorCode:  0,
+	},
+	{
+		CertificateFile:    testCertFile,
+		Status:             "revoked",
+		RevokedAt:          "now",
+		ExpectedHTTPStatus: http.StatusOK,
+		ExpectedSuccess:    true,
+		ExpectedErrorCode:  0,
+	},
+	{
+		CertificateFile:    testCertFile,
+		Status:             "revoked",
+		RevokedAt:          "2015-08-15",
+		ExpectedHTTPStatus: http.StatusOK,
+		ExpectedSuccess:    true,
+		ExpectedErrorCode:  0,
+	},
+	{
+		CertificateFile:    testCertFile,
+		Status:             "revoked",
+		RevokedAt:          "a",
+		ExpectedHTTPStatus: http.StatusBadRequest,
+		ExpectedSuccess:    false,
+		ExpectedErrorCode:  http.StatusBadRequest,
+	},
+	{
+		CertificateFile:    "",
+		Status:             "",
+		ExpectedHTTPStatus: http.StatusBadRequest,
+		ExpectedSuccess:    false,
+		ExpectedErrorCode:  http.StatusBadRequest,
+	},
+	{
+		CertificateFile:    testCertFile,
+		Status:             "_",
+		ExpectedHTTPStatus: http.StatusBadRequest,
+		ExpectedSuccess:    false,
+		ExpectedErrorCode:  8200,
+	},
+}
+
+func TestSign(t *testing.T) {
+	for i, test := range signTests {
+		resp, body := testSignFile(t, test.CertificateFile, test.Status, test.Reason, test.RevokedAt)
+		if resp.StatusCode != test.ExpectedHTTPStatus {
+			t.Logf("Test %d: expected: %d, have %d", i, test.ExpectedHTTPStatus, resp.StatusCode)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, string(body))
+		}
+
+		message := new(api.Response)
+		err := json.Unmarshal(body, message)
+		if err != nil {
+			t.Logf("failed to read response body: %v", err)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, message)
+		}
+
+		if test.ExpectedSuccess != message.Success {
+			t.Logf("Test %d: expected: %v, have %v", i, test.ExpectedSuccess, message.Success)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, message)
+		}
+		if !test.ExpectedSuccess {
+			if test.ExpectedErrorCode != message.Errors[0].Code {
+				t.Fatalf("Test %d: expected: %v, have %v", i, test.ExpectedErrorCode, message.Errors[0].Code)
+				t.Fatal(resp.Status, test.ExpectedHTTPStatus, message)
+			}
+			continue
+		}
+
+		result, ok := message.Result.(map[string]interface{})
+		if !ok {
+			t.Logf("failed to read result")
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, string(body))
+		}
+		b64Resp, ok := result["ocspResponse"].(string)
+		if !ok {
+			t.Logf("failed to find ocspResponse")
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, string(body))
+		}
+
+		der, err := base64.StdEncoding.DecodeString(b64Resp)
+		if err != nil {
+			t.Logf("failed to decode base64")
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, b64Resp)
+		}
+
+		ocspResp, err := goocsp.ParseResponse(der, nil)
+		if err != nil {
+			t.Logf("failed to parse ocsp response: %v", err)
+			t.Fatal(resp.Status, test.ExpectedHTTPStatus, b64Resp)
+		}
+
+		//should default to good
+		if test.Status == "" {
+			test.Status = "good"
+		}
+		intStatus := ocsp.StatusCode[test.Status]
+		if ocspResp.Status != intStatus {
+			t.Fatalf("Test %d incorrect status: expected: %v, have %v", i, intStatus, ocspResp.Status)
+			t.Fatal(ocspResp.Status, intStatus, ocspResp)
+		}
+
+		if test.Status == "revoked" {
+			if ocspResp.RevocationReason != test.Reason {
+				t.Fatalf("Test %d incorrect reason: expected: %v, have %v", i, test.Reason, ocspResp.RevocationReason)
+				t.Fatal(ocspResp.RevocationReason, test.Reason, ocspResp)
+			}
+
+			var r time.Time
+			if test.RevokedAt == "" || test.RevokedAt == "now" {
+				r = time.Now()
+			} else {
+				r, _ = time.Parse("2006-01-02", test.RevokedAt)
+			}
+
+			if ocspResp.RevokedAt.Year() != r.Year() {
+				t.Fatalf("Test %d incorrect revokedAt: expected: %v, have %v", i, test.RevokedAt, ocspResp.RevokedAt)
+				t.Fatal(ocspResp.RevokedAt, test.RevokedAt, ocspResp)
+			}
+			if ocspResp.RevokedAt.Month() != r.Month() {
+				t.Fatalf("Test %d incorrect revokedAt: expected: %v, have %v", i, test.RevokedAt, ocspResp.RevokedAt)
+				t.Fatal(ocspResp.RevokedAt, test.RevokedAt, ocspResp)
+			}
+			if ocspResp.RevokedAt.Day() != r.Day() {
+				t.Fatalf("Test %d incorrect revokedAt: expected: %v, have %v", i, test.RevokedAt, ocspResp.RevokedAt)
+				t.Fatal(ocspResp.RevokedAt, test.RevokedAt, ocspResp)
+			}
+		}
+	}
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -25,13 +25,13 @@ Use "cfssl [command] -help" to find out more about a command.
 
 import (
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 
+	"encoding/base64"
 	"github.com/cloudflare/cfssl/config"
 )
 
@@ -174,11 +174,11 @@ func PrintCert(key, csrBytes, cert []byte) {
 }
 
 // PrintOCSPResponse outputs an OCSP response to stdout
+// ocspResponse is base64 encoded
 func PrintOCSPResponse(resp []byte) {
-	pemResponse := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: resp})
+	b64Resp := base64.StdEncoding.EncodeToString(resp)
 
-	out := map[string]string{}
-	out["ocspResponse"] = string(pemResponse)
+	out := map[string]string{"ocspResponse": b64Resp}
 	jsonOut, err := json.Marshal(out)
 	if err != nil {
 		return

--- a/cli/config.go
+++ b/cli/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	PIN               string
 	PKCS11Label       string
 	ResponderFile     string
+	ResponderKeyFile  string
 	Status            string
 	Reason            int
 	RevokedAt         string
@@ -80,6 +81,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.Label, "label", "", "key label to use in remote CFSSL server")
 	f.StringVar(&c.AuthKey, "authkey", "", "key to authenticate requests to remote CFSSL server")
 	f.StringVar(&c.ResponderFile, "responder", "", "Certificate for OCSP responder")
+	f.StringVar(&c.ResponderKeyFile, "responder-key", "", "private key for OCSP responder certificate")
 	f.StringVar(&c.Status, "status", "good", "Status of the certificate: good, revoked, unknown")
 	f.IntVar(&c.Reason, "reason", 0, "Reason code for revocation")
 	f.StringVar(&c.RevokedAt, "revoked-at", "now", "Date of revocation (YYYY-MM-DD)")

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -38,6 +38,7 @@ func TestServe(t *testing.T) {
 	expected[v1APIPath("newcert")] = http.StatusNotFound
 	expected[v1APIPath("info")] = http.StatusNotFound
 	expected[v1APIPath("bundle")] = http.StatusNotFound
+	expected[v1APIPath("ocspsign")] = http.StatusNotFound
 
 	// Enabled endpoints should return '405 Method Not Allowed'
 	expected[v1APIPath("init_ca")] = http.StatusMethodNotAllowed

--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -20,7 +20,9 @@ import (
 	"golang.org/x/crypto/ocsp"
 )
 
-var statusCode = map[string]int{
+// StatusCode is a map between string statuses sent by cli/api
+// to ocsp int statuses
+var StatusCode = map[string]int{
 	"good":    ocsp.Good,
 	"revoked": ocsp.Revoked,
 	"unknown": ocsp.Unknown,
@@ -122,7 +124,7 @@ func (s StandardSigner) Sign(req SignRequest) ([]byte, error) {
 	thisUpdate := time.Now().Round(time.Hour)
 	nextUpdate := thisUpdate.Add(s.interval)
 
-	status, ok := statusCode[req.Status]
+	status, ok := StatusCode[req.Status]
 	if !ok {
 		return nil, cferr.New(cferr.OCSPError, cferr.InvalidStatus)
 	}

--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -52,6 +52,10 @@ func NewSourceFromFile(responseFile string) (Source, error) {
 	responsesB64 := regexp.MustCompile("\\s").Split(string(fileContents), -1)
 	src := InMemorySource{}
 	for _, b64 := range responsesB64 {
+		// if the line/space is empty just skip
+		if b64 == "" {
+			continue
+		}
 		der, tmpErr := base64.StdEncoding.DecodeString(b64)
 		if tmpErr != nil {
 			log.Errorf("Base64 decode error on: %s", b64)


### PR DESCRIPTION
This is only my second PR so I'm not very familiar with the codebase as a whole but this PR does:
* Added `ocspsign` API endpoint to sign ocsp responses
* Added support for `ocspResponse` in cfssljson
* cfssljson can also now output to stdout using `-stdout`
* `ocspserve` will not silently ignore trailing whitespace (or double spaces) in the responses file
* Updated README with example for creating a OCSP responses file from `ocspsign` cli.

I don't know if this is okay but I'm getting an error from openssl when parsing the OCSP responses from `ocspsign`:
```
# cfssl ocspsign -ca ca.crt -responder resp.crt -responder-key resp.key -cert test.crt | cfssljson -bare ocsp
# openssl ocsp -text -respin ocsp-response.der
OCSP Response Data:
    OCSP Response Status: successful (0x0)
Error parsing response
140127808935840:error:0D0680A8:asn1 encoding routines:ASN1_CHECK_TLEN:wrong tag:tasn_dec.c:1342:
140127808935840:error:0D06C03A:asn1 encoding routines:ASN1_D2I_EX_PRIMITIVE:nested asn1 error:tasn_dec.c:854:
140127808935840:error:0D08303A:asn1 encoding routines:ASN1_TEMPLATE_NOEXP_D2I:nested asn1 error:tasn_dec.c:774:Field=producedAt, Type=OCSP_RESPDATA
140127808935840:error:0D08303A:asn1 encoding routines:ASN1_TEMPLATE_NOEXP_D2I:nested asn1 error:tasn_dec.c:774:Field=tbsResponseData, Type=OCSP_BASICRESP
140127808935840:error:0D0C706E:asn1 encoding routines:ASN1_item_unpack:decode error:asn_pack.c:189:
    Response Type: Basic OCSP Response
```
Should I file that as a new bug or is that expected?