### PR TITLE
Look up PKCS#11 keys by key label, regardless of slot

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -38,9 +38,10 @@ type Config struct {
 	Label             string
 	AuthKey           string
 	Module            string
-	Token             string
+	SlotDescription   string
+	TokenLabel        string
 	PIN               string
-	PKCS11Label       string
+	PrivateKeyLabel   string
 	ResponderFile     string
 	ResponderKeyFile  string
 	Status            string
@@ -96,10 +97,11 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.Usage, "usage", "dev", "usage of private key")
 
 	if pkcs11.Enabled {
-		f.StringVar(&c.Module, "pkcs11-module", "", "PKCS #11 module")
-		f.StringVar(&c.Token, "pkcs11-token", "", "PKCS #11 token")
-		f.StringVar(&c.PIN, "pkcs11-pin", os.Getenv("USER_PIN"), "PKCS #11 user PIN")
-		f.StringVar(&c.PKCS11Label, "pkcs11-label", "", "PKCS #11 label")
+		f.StringVar(&c.Module, "pkcs11-module", "", "PKCS#11 module")
+		f.StringVar(&c.SlotDescription, "pkcs11-slot", "", "PKCS#11 slot description")
+		f.StringVar(&c.TokenLabel, "pkcs11-token", "", "PKCS#11 token label")
+		f.StringVar(&c.PIN, "pkcs11-pin", os.Getenv("USER_PIN"), "PKCS#11 user PIN")
+		f.StringVar(&c.PrivateKeyLabel, "pkcs11-label", "", "PKCS#11 private key label")
 	}
 }
 
@@ -109,8 +111,9 @@ func RootFromConfig(c *Config) universal.Root {
 	return universal.Root{
 		Config: map[string]string{
 			"pkcs11-module":   c.Module,
-			"pkcs11-token":    c.Token,
-			"pkcs11-label":    c.PKCS11Label,
+			"pkcs11-slot":     c.SlotDescription,
+			"pkcs11-token":    c.TokenLabel,
+			"pkcs11-label":    c.PrivateKeyLabel,
 			"pkcs11-user-pin": c.PIN,
 			"cert-file":       c.CAFile,
 			"key-file":        c.CAKeyFile,

--- a/crypto/pkcs11key/pkcs11key.go
+++ b/crypto/pkcs11key/pkcs11key.go
@@ -140,9 +140,8 @@ func (ps *PKCS11Key) openSession() (pkcs11.SessionHandle, pkcs11.ObjectHandle, e
 	}
 	for _, slot := range slots {
 		// If ps.slotDescription is provided, we will only check matching slots
-		slotInfo, err2 := ps.module.GetSlotInfo(slot)
-		if err2 != nil {
-			err = err2
+		slotInfo, err := ps.module.GetSlotInfo(slot)
+		if err != nil {
 			continue
 		}
 		if ps.slotDescription != "" && slotInfo.SlotDescription != ps.slotDescription {
@@ -170,9 +169,8 @@ func (ps *PKCS11Key) openSession() (pkcs11.SessionHandle, pkcs11.ObjectHandle, e
 			ps.closeSession(session)
 			continue
 		}
-		objs, _, err2 := ps.module.FindObjects(session, 2)
+		objs, _, err := ps.module.FindObjects(session, 2)
 		if err != nil {
-			err = err2
 			ps.closeSession(session)
 			continue
 		}

--- a/crypto/pkcs11key/pkcs11key.go
+++ b/crypto/pkcs11key/pkcs11key.go
@@ -8,7 +8,6 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"errors"
-	"fmt"
 	"io"
 	"math/big"
 
@@ -141,24 +140,20 @@ func (ps *PKCS11Key) openSession() (session pkcs11.SessionHandle, keyHandle pkcs
 		slotInfo, err2 := ps.module.GetSlotInfo(slot)
 		if err2 != nil {
 			err = err2
-			fmt.Printf(">>> [%u] Couldn't get slot description\n", slot)
 			continue
 		}
 		if ps.slotDescription != "" && slotInfo.SlotDescription != ps.slotDescription {
-			fmt.Printf(">>> [%u] slotDescription didn't match [%s] != [%s]\n", slot, slotInfo.SlotDescription, ps.slotDescription)
 			continue
 		}
 
 		// Open session
 		session, err = ps.module.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION)
 		if err != nil {
-			fmt.Printf(">>> [%u] Couldn't open session [%v]\n", slot, err)
 			continue
 		}
 
 		// Login
 		if err = ps.module.Login(session, pkcs11.CKU_USER, ps.pin); err != nil {
-			fmt.Printf(">>> [%u] Couldn't log in with pin [%s] [%v]\n", slot, ps.pin, err)
 			ps.closeSession(session)
 			continue
 		}
@@ -169,19 +164,16 @@ func (ps *PKCS11Key) openSession() (session pkcs11.SessionHandle, keyHandle pkcs
 			pkcs11.NewAttribute(pkcs11.CKA_LABEL, ps.privateKeyLabel),
 		}
 		if err = ps.module.FindObjectsInit(session, template); err != nil {
-			fmt.Printf(">>> [%u] Couldn't FindObjectsInit\n", slot)
 			ps.closeSession(session)
 			continue
 		}
 		objs, _, err2 := ps.module.FindObjects(session, 2)
 		if err != nil {
 			err = err2
-			fmt.Printf(">>> [%u] Couldn't FindObjects\n", slot)
 			ps.closeSession(session)
 			continue
 		}
 		if err = ps.module.FindObjectsFinal(session); err != nil {
-			fmt.Printf(">>> [%u] Couldn't FindObjectsFinal\n", slot)
 			ps.closeSession(session)
 			continue
 		}

--- a/helpers/pkcs11uri/pkcs11uri.go
+++ b/helpers/pkcs11uri/pkcs11uri.go
@@ -44,11 +44,12 @@ func ParsePKCS11URI(uri string) (*pkcs11.Config, error) {
 	if err != nil {
 		return nil, ErrInvalidURI
 	}
-	setIfPresent(pk11PAttr, "token", &c.Token)
+	setIfPresent(pk11PAttr, "slot-description", &c.SlotDescription)
+	setIfPresent(pk11PAttr, "token", &c.TokenLabel)
 	setIfPresent(pk11QAttr, "module-name", &c.Module)
 	setIfPresent(pk11QAttr, "module-path", &c.Module)
 	setIfPresent(pk11QAttr, "pin-value", &c.PIN)
-	setIfPresent(pk11PAttr, "slot-description", &c.Label)
+	setIfPresent(pk11PAttr, "object", &c.PrivateKeyLabel)
 
 	var pinSourceURI string
 	setIfPresent(pk11QAttr, "pin-source", &pinSourceURI)

--- a/helpers/pkcs11uri/pkcs11uri_test.go
+++ b/helpers/pkcs11uri/pkcs11uri_test.go
@@ -25,9 +25,10 @@ func cmpConfigs(a, b *pkcs11.Config) bool {
 	}
 
 	return (a.Module == b.Module) &&
-		(a.Token == b.Token) &&
+		(a.TokenLabel == b.TokenLabel) &&
+		(a.SlotDescription == b.SlotDescription) &&
 		(a.PIN == b.PIN) &&
-		(a.Label == b.Label)
+		(a.PrivateKeyLabel == b.PrivateKeyLabel)
 }
 
 func diffConfigs(want, have *pkcs11.Config) {
@@ -45,9 +46,10 @@ func diffConfigs(want, have *pkcs11.Config) {
 	}
 
 	diff("Module", want.Module, have.Module)
-	diff("Token", want.Token, have.Token)
+	diff("SlotDescription", want.SlotDescription, have.SlotDescription)
+	diff("TokenLabel", want.TokenLabel, have.TokenLabel)
 	diff("PIN", want.PIN, have.PIN)
-	diff("Label", want.Label, have.Label)
+	diff("PrivateKeyLabel", want.PrivateKeyLabel, have.PrivateKeyLabel)
 }
 
 /* Config from PKCS #11 signer
@@ -62,19 +64,27 @@ type Config struct {
 var pkcs11UriCases = []pkcs11UriTest{
 	{"pkcs11:token=Software%20PKCS%2311%20softtoken;manufacturer=Snake%20Oil,%20Inc.?pin-value=the-pin",
 		&pkcs11.Config{
-			Token: "Software PKCS#11 softtoken",
-			PIN:   "the-pin",
+			TokenLabel: "Software PKCS#11 softtoken",
+			PIN:        "the-pin",
 		}},
 	{"pkcs11:slot-description=Sun%20Metaslot",
 		&pkcs11.Config{
-			Label: "Sun Metaslot",
+			SlotDescription: "Sun Metaslot",
 		}},
 	{"pkcs11:slot-description=test-label;token=test-token?pin-source=file:testdata/pin&module-name=test-module",
 		&pkcs11.Config{
-			Label:  "test-label",
-			Token:  "test-token",
-			PIN:    "123456",
-			Module: "test-module",
+			SlotDescription: "test-label",
+			TokenLabel:      "test-token",
+			PIN:             "123456",
+			Module:          "test-module",
+		}},
+	{"pkcs11:slot-description=test-label;object=test-label2;token=test-token?pin-source=file:testdata/pin&module-name=test-module",
+		&pkcs11.Config{
+			SlotDescription: "test-label",
+			TokenLabel:      "test-token",
+			PIN:             "123456",
+			Module:          "test-module",
+			PrivateKeyLabel: "test-label2",
 		}},
 }
 

--- a/ocsp/config/config.go
+++ b/ocsp/config/config.go
@@ -10,11 +10,11 @@ import (
 // signer. If PKCS11.Module is non-empty, PKCS11 signing will be used.
 // Otherwise signing from a key file will be used.
 type Config struct {
-	CACertFile string
+	CACertFile        string
 	ResponderCertFile string
-	KeyFile string
-	Interval time.Duration
-	PKCS11 PKCS11Config
+	KeyFile           string
+	Interval          time.Duration
+	PKCS11            PKCS11Config
 }
 
 // PKCS11Config contains information specific to setting up a PKCS11 OCSP
@@ -25,4 +25,3 @@ type PKCS11Config struct {
 	PIN    string
 	Label  string
 }
-

--- a/ocsp/config/config.go
+++ b/ocsp/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 // signer.
 type PKCS11Config struct {
 	Module string
+	Slot   string
 	Token  string
 	PIN    string
 	Label  string

--- a/ocsp/pkcs11/pkcs11.go
+++ b/ocsp/pkcs11/pkcs11.go
@@ -5,13 +5,13 @@
 package pkcs11
 
 import (
-	"io/ioutil"
 	"github.com/cloudflare/cfssl/crypto/pkcs11key"
 	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/ocsp"
 	ocspConfig "github.com/cloudflare/cfssl/ocsp/config"
+	"io/ioutil"
 )
 
 // Enabled is set to true if PKCS #11 support is present.
@@ -31,8 +31,8 @@ func NewPKCS11Signer(cfg ocspConfig.Config) (ocsp.Signer, error) {
 	}
 
 	PKCS11 := cfg.PKCS11
-	priv, err := pkcs11key.New(PKCS11.Module, PKCS11.Token, PKCS11.PIN,
-		PKCS11.Label)
+	priv, err := pkcs11key.New(PKCS11.Module, PKCS11.Slot, PKCS11.Token,
+		PKCS11.PIN, PKCS11.Label)
 	if err != nil {
 		return nil, errors.New(errors.PrivateKeyError, errors.ReadFailed)
 	}

--- a/signer/pkcs11/pkcs11.go
+++ b/signer/pkcs11/pkcs11.go
@@ -18,6 +18,7 @@ import (
 // #11 key.
 type Config struct {
 	Module string
+	Slot   string
 	Token  string
 	PIN    string
 	Label  string
@@ -43,7 +44,7 @@ func New(caCertFile string, policy *config.Signing, cfg *Config) (signer.Signer,
 		return nil, err
 	}
 
-	priv, err := pkcs11key.New(cfg.Module, cfg.Token, cfg.PIN, cfg.Label)
+	priv, err := pkcs11key.New(cfg.Module, cfg.Slot, cfg.Token, cfg.PIN, cfg.Label)
 	if err != nil {
 		return nil, errors.New(errors.PrivateKeyError, errors.ReadFailed)
 	}

--- a/signer/pkcs11/pkcs11.go
+++ b/signer/pkcs11/pkcs11.go
@@ -44,7 +44,7 @@ func New(caCertFile string, policy *config.Signing, cfg *Config) (signer.Signer,
 		return nil, err
 	}
 
-	priv, err := pkcs11key.New(cfg.Module, cfg.Slot, cfg.Token, cfg.PIN, cfg.Label)
+	priv, err := pkcs11key.New(cfg.Module, cfg.SlotDescription, cfg.TokenLabel, cfg.PIN, cfg.PrivateKeyLabel)
 	if err != nil {
 		return nil, errors.New(errors.PrivateKeyError, errors.ReadFailed)
 	}

--- a/signer/pkcs11/pkcs11.go
+++ b/signer/pkcs11/pkcs11.go
@@ -17,11 +17,11 @@ import (
 // Config contains configuration information required to use a PKCS
 // #11 key.
 type Config struct {
-	Module string
-	Slot   string
-	Token  string
-	PIN    string
-	Label  string
+	Module          string
+	SlotDescription string
+	TokenLabel      string
+	PIN             string
+	PrivateKeyLabel string
 }
 
 // Enabled is set to true if PKCS #11 support is present.

--- a/signer/universal/universal.go
+++ b/signer/universal/universal.go
@@ -38,12 +38,13 @@ func fileBackedSigner(root *Root, policy *config.Signing) (signer.Signer, bool, 
 // options in the root.
 func pkcs11Signer(root *Root, policy *config.Signing) (signer.Signer, bool, error) {
 	module := root.Config["pkcs11-module"]
-	token := root.Config["pkcs11-token"]
-	label := root.Config["pkcs11-label"]
+	slotDescription := root.Config["pkcs11-slot"]
+	tokenLabel := root.Config["pkcs11-token"]
+	privateKeyLabel := root.Config["pkcs11-label"]
 	userPIN := root.Config["pkcs11-user-pin"]
 	certFile := root.Config["cert-file"]
 
-	if module == "" && token == "" && label == "" && userPIN == "" {
+	if module == "" && slotDescription == "" && tokenLabel == "" && privateKeyLabel == "" && userPIN == "" {
 		return nil, false, nil
 	}
 
@@ -52,10 +53,11 @@ func pkcs11Signer(root *Root, policy *config.Signing) (signer.Signer, bool, erro
 	}
 
 	conf := pkcs11.Config{
-		Module: module,
-		Token:  token,
-		Label:  label,
-		PIN:    userPIN,
+		Module:          module,
+		SlotDescription: slotDescription,
+		TokenLabel:      tokenLabel,
+		PrivateKeyLabel: privateKeyLabel,
+		PIN:             userPIN,
 	}
 
 	s, err := pkcs11.New(certFile, policy, &conf)


### PR DESCRIPTION
In some PKCS#11 modules, slots are not distinguished by name, but it is possible to assign distinct names to private keys.  This PR updates the PKCS#11 key object handle this situation better:

* Each time the key is used, we search for it across all slots
* The slot description is used to filter slots in this search