### PR TITLE
Add optional IP parameter to scan CLI and API

### DIFF
--- a/api/scan/scan.go
+++ b/api/scan/scan.go
@@ -18,22 +18,17 @@ func scanHandler(w http.ResponseWriter, r *http.Request) error {
 		return errors.NewBadRequest(err)
 	}
 
-	if len(r.Form["host"]) == 0 {
+	family := r.Form.Get("family")
+	scanner := r.Form.Get("scanner")
+	ip := r.Form.Get("ip")
+	host := r.Form.Get("host")
+	if host == "" {
 		log.Warningf("no host given")
 		return errors.NewBadRequestString("no host given")
 	}
-	host := r.Form["host"][0]
 
-	var family, scanner string
-	if len(r.Form["family"]) > 0 {
-		family = r.Form["family"][0]
-	}
 
-	if len(r.Form["scanner"]) > 0 {
-		scanner = r.Form["scanner"][0]
-	}
-
-	results, err := scan.Default.RunScans(host, family, scanner, 0)
+	results, err := scan.Default.RunScans(host, ip, family, scanner, 0)
 	if err != nil {
 		log.Warningf("%v", err)
 		return errors.NewBadRequest(err)

--- a/cli/scan/scan.go
+++ b/cli/scan/scan.go
@@ -10,14 +10,14 @@ import (
 
 var scanUsageText = `cfssl scan -- scan a host for issues
 Usage of scan:
-        cfssl scan [-family regexp] [-scanner regexp] [-timeout duration] HOST+
+        cfssl scan [-family regexp] [-scanner regexp] [-timeout duration] [-ip IPAddr] HOST+
         cfssl scan -list
 
 Arguments:
         HOST:    Host(s) to scan (including port)
 Flags:
 `
-var scanFlags = []string{"list", "family", "scanner", "timeout"}
+var scanFlags = []string{"list", "family", "scanner", "timeout", "ip"}
 
 func printJSON(v interface{}) {
 	b, err := json.MarshalIndent(v, "", "  ")
@@ -42,7 +42,7 @@ func scanMain(args []string, c cli.Config) (err error) {
 			fmt.Printf("Scanning %s...\n", host)
 
 			var results map[string]scan.FamilyResult
-			results, err = scan.Default.RunScans(host, c.Family, c.Scanner, c.Timeout)
+			results, err = scan.Default.RunScans(host, c.IP, c.Family, c.Scanner, c.Timeout)
 			if err != nil {
 				return
 			}

--- a/doc/api/endpoint_scan.txt
+++ b/doc/api/endpoint_scan.txt
@@ -9,6 +9,8 @@ Required parameters:
 
 Optional parameters:
 
+    * ip: IP Address to override DNS lookup of host
+
     The following parameters are used by the scanner to select which 
     scans to run.
 
@@ -303,6 +305,315 @@ Example:
                     "198.41.215.163": true,
                     "2400:cb00:2048:1::c629:d49d": true,
                     "2400:cb00:2048:1::c629:d59d": true
+                }
+            }
+        }
+    },
+    "success": true
+}
+
+    $ curl "${CFSSL_HOST}/api/v1/cfssl/scan?host=cloudflare.com&ip=2400:cb00:2048:1::c629:d49d" |python -m json.tool
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  3602    0  3602    0     0    337      0 --:--:--  0:00:10 --:--:--  1044
+{
+    "errors": [],
+    "messages": [],
+    "result": {
+        "Connectivity": {
+            "CloudFlareStatus": {
+                "grade": "Good",
+                "output": {
+                    "198.41.214.163": true,
+                    "198.41.215.163": true,
+                    "2400:cb00:2048:1::c629:d49d": true,
+                    "2400:cb00:2048:1::c629:d59d": true
+                }
+            },
+            "DNSLookup": {
+                "grade": "Good",
+                "output": [
+                    "2400:cb00:2048:1::c629:d59d",
+                    "2400:cb00:2048:1::c629:d49d",
+                    "198.41.215.163",
+                    "198.41.214.163"
+                ]
+            },
+            "TCPDial": {
+                "grade": "Good"
+            },
+            "TLSDial": {
+                "grade": "Good"
+            }
+        },
+        "PKI": {
+            "ChainExpiration": {
+                "grade": "Good",
+                "output": "2015-12-31T23:59:59Z"
+            },
+            "ChainValidation": {
+                "grade": "Warning",
+                "output": [
+                    " is signed by RSAWithSHA1",
+                    "Certificate for COMODO Extended Validation Secure Server CA is valid for too long",
+                    "COMODO Extended Validation Secure Server CA is signed by RSAWithSHA1"
+                ]
+            },
+            "MultipleCerts": {
+                "grade": "Good"
+            }
+        },
+        "TLSHandshake": {
+            "CertsByCiphers": {
+                "grade": "Good",
+                "output": {
+                    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": "SHA1WithRSA",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA": "SHA1WithRSA",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256": "SHA1WithRSA",
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": "SHA1WithRSA",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA": "SHA1WithRSA",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384": "SHA1WithRSA",
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384": "SHA1WithRSA",
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256": "SHA1WithRSA",
+                    "TLS_RSA_WITH_3DES_EDE_CBC_SHA": "SHA1WithRSA",
+                    "TLS_RSA_WITH_AES_128_CBC_SHA": "SHA1WithRSA",
+                    "TLS_RSA_WITH_AES_128_CBC_SHA256": "SHA1WithRSA",
+                    "TLS_RSA_WITH_AES_128_GCM_SHA256": "SHA1WithRSA",
+                    "TLS_RSA_WITH_AES_256_CBC_SHA": "SHA1WithRSA",
+                    "TLS_RSA_WITH_AES_256_CBC_SHA256": "SHA1WithRSA",
+                    "TLS_RSA_WITH_AES_256_GCM_SHA384": "SHA1WithRSA"
+                }
+            },
+            "CertsBySigAlgs": {
+                "grade": "Good",
+                "output": {
+                    "{DSA,SHA1}": "SHA1WithRSA",
+                    "{DSA,SHA224}": "SHA1WithRSA",
+                    "{DSA,SHA256}": "SHA1WithRSA",
+                    "{DSA,SHA384}": "SHA1WithRSA",
+                    "{DSA,SHA512}": "SHA1WithRSA",
+                    "{ECDSA,SHA1}": "SHA1WithRSA",
+                    "{ECDSA,SHA224}": "SHA1WithRSA",
+                    "{ECDSA,SHA256}": "SHA1WithRSA",
+                    "{ECDSA,SHA384}": "SHA1WithRSA",
+                    "{ECDSA,SHA512}": "SHA1WithRSA",
+                    "{RSA,SHA1}": "SHA1WithRSA",
+                    "{RSA,SHA224}": "SHA1WithRSA",
+                    "{RSA,SHA256}": "SHA1WithRSA",
+                    "{RSA,SHA384}": "SHA1WithRSA",
+                    "{RSA,SHA512}": "SHA1WithRSA"
+                }
+            },
+            "CipherSuite": {
+                "grade": "Good",
+                "output": [
+                    {
+                        "ECDHE-RSA-AES128-GCM-SHA256": [
+                            {
+                                "TLS 1.2": [
+                                    "secp256r1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ECDHE-RSA-AES128-SHA256": [
+                            {
+                                "TLS 1.2": [
+                                    "secp256r1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ECDHE-RSA-AES128-SHA": [
+                            {
+                                "TLS 1.2": [
+                                    "secp256r1"
+                                ]
+                            },
+                            {
+                                "TLS 1.1": [
+                                    "secp256r1"
+                                ]
+                            },
+                            {
+                                "TLS 1.0": [
+                                    "secp256r1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "AES128-GCM-SHA256": [
+                            "TLS 1.2"
+                        ]
+                    },
+                    {
+                        "AES128-SHA256": [
+                            "TLS 1.2"
+                        ]
+                    },
+                    {
+                        "AES128-SHA": [
+                            "TLS 1.2",
+                            "TLS 1.1",
+                            "TLS 1.0"
+                        ]
+                    },
+                    {
+                        "ECDHE-RSA-AES256-GCM-SHA384": [
+                            {
+                                "TLS 1.2": [
+                                    "secp256r1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ECDHE-RSA-AES256-SHA384": [
+                            {
+                                "TLS 1.2": [
+                                    "secp256r1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ECDHE-RSA-AES256-SHA": [
+                            {
+                                "TLS 1.2": [
+                                    "secp256r1"
+                                ]
+                            },
+                            {
+                                "TLS 1.1": [
+                                    "secp256r1"
+                                ]
+                            },
+                            {
+                                "TLS 1.0": [
+                                    "secp256r1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "AES256-GCM-SHA384": [
+                            "TLS 1.2"
+                        ]
+                    },
+                    {
+                        "AES256-SHA256": [
+                            "TLS 1.2"
+                        ]
+                    },
+                    {
+                        "AES256-SHA": [
+                            "TLS 1.2",
+                            "TLS 1.1",
+                            "TLS 1.0"
+                        ]
+                    },
+                    {
+                        "ECDHE-RSA-DES-CBC3-SHA": [
+                            {
+                                "TLS 1.2": [
+                                    "secp256r1"
+                                ]
+                            },
+                            {
+                                "TLS 1.1": [
+                                    "secp256r1"
+                                ]
+                            },
+                            {
+                                "TLS 1.0": [
+                                    "secp256r1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "DES-CBC3-SHA": [
+                            "TLS 1.2",
+                            "TLS 1.1",
+                            "TLS 1.0"
+                        ]
+                    }
+                ]
+            },
+            "SigAlgs": {
+                "grade": "Good",
+                "output": [
+                    {
+                        "hash": "SHA1",
+                        "signature": "RSA"
+                    },
+                    {
+                        "hash": "SHA1",
+                        "signature": "DSA"
+                    },
+                    {
+                        "hash": "SHA1",
+                        "signature": "ECDSA"
+                    },
+                    {
+                        "hash": "SHA224",
+                        "signature": "RSA"
+                    },
+                    {
+                        "hash": "SHA224",
+                        "signature": "DSA"
+                    },
+                    {
+                        "hash": "SHA224",
+                        "signature": "ECDSA"
+                    },
+                    {
+                        "hash": "SHA256",
+                        "signature": "RSA"
+                    },
+                    {
+                        "hash": "SHA256",
+                        "signature": "DSA"
+                    },
+                    {
+                        "hash": "SHA256",
+                        "signature": "ECDSA"
+                    },
+                    {
+                        "hash": "SHA384",
+                        "signature": "RSA"
+                    },
+                    {
+                        "hash": "SHA384",
+                        "signature": "DSA"
+                    },
+                    {
+                        "hash": "SHA384",
+                        "signature": "ECDSA"
+                    },
+                    {
+                        "hash": "SHA512",
+                        "signature": "RSA"
+                    },
+                    {
+                        "hash": "SHA512",
+                        "signature": "DSA"
+                    },
+                    {
+                        "hash": "SHA512",
+                        "signature": "ECDSA"
+                    }
+                ]
+            }
+        },
+        "TLSSession": {
+            "SessionResume": {
+                "grade": "Good",
+                "output": {
+                    "2400:cb00:2048:1::c629:d49d": true
                 }
             }
         }

--- a/scan/broad.go
+++ b/scan/broad.go
@@ -37,8 +37,8 @@ var (
 )
 
 // intermediateCAScan scans for new intermediate CAs not in the trust store.
-func intermediateCAScan(host string) (grade Grade, output Output, err error) {
-	cidr, port, _ := net.SplitHostPort(host)
+func intermediateCAScan(addr, hostname string) (grade Grade, output Output, err error) {
+	cidr, port, _ := net.SplitHostPort(addr)
 	_, ipnet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return Skipped, nil, nil

--- a/scan/connectivity.go
+++ b/scan/connectivity.go
@@ -35,13 +35,8 @@ var Connectivity = &Family{
 }
 
 // dnsLookupScan tests that DNS resolution of the host returns at least one address
-func dnsLookupScan(host string) (grade Grade, output Output, err error) {
-	host, _, err = net.SplitHostPort(host)
-	if err != nil {
-		return
-	}
-
-	addrs, err := net.LookupHost(host)
+func dnsLookupScan(addr, hostname string) (grade Grade, output Output, err error) {
+	addrs, err := net.LookupHost(hostname)
 	if err != nil {
 		return
 	}
@@ -102,14 +97,14 @@ func initOnCloudFlareScan() ([]*net.IPNet, error) {
 	return cfNets, nil
 }
 
-func onCloudFlareScan(host string) (grade Grade, output Output, err error) {
+func onCloudFlareScan(addr, hostname string) (grade Grade, output Output, err error) {
 	var cloudflareNets []*net.IPNet
 	if cloudflareNets, err = initOnCloudFlareScan(); err != nil {
 		grade = Skipped
 		return
 	}
 
-	_, addrs, err := dnsLookupScan(host)
+	_, addrs, err := dnsLookupScan(addr, hostname)
 	if err != nil {
 		return
 	}
@@ -135,8 +130,8 @@ func onCloudFlareScan(host string) (grade Grade, output Output, err error) {
 }
 
 // tcpDialScan tests that the host can be connected to through TCP.
-func tcpDialScan(host string) (grade Grade, output Output, err error) {
-	conn, err := Dialer.Dial(Network, host)
+func tcpDialScan(addr, hostname string) (grade Grade, output Output, err error) {
+	conn, err := Dialer.Dial(Network, addr)
 	if err != nil {
 		return
 	}
@@ -146,8 +141,8 @@ func tcpDialScan(host string) (grade Grade, output Output, err error) {
 }
 
 // tlsDialScan tests that the host can perform a TLS Handshake.
-func tlsDialScan(host string) (grade Grade, output Output, err error) {
-	conn, err := tls.DialWithDialer(Dialer, Network, host, defaultTLSConfig(host))
+func tlsDialScan(addr, hostname string) (grade Grade, output Output, err error) {
+	conn, err := tls.DialWithDialer(Dialer, Network, addr, defaultTLSConfig(hostname))
 	if err != nil {
 		return
 	}

--- a/scan/pki.go
+++ b/scan/pki.go
@@ -31,9 +31,9 @@ var PKI = &Family{
 }
 
 // getChain is a helper function that retreives the host's certificate chain.
-func getChain(host string, config *tls.Config) (chain []*x509.Certificate, err error) {
+func getChain(addr string, config *tls.Config) (chain []*x509.Certificate, err error) {
 	var conn *tls.Conn
-	conn, err = tls.DialWithDialer(Dialer, Network, host, config)
+	conn, err = tls.DialWithDialer(Dialer, Network, addr, config)
 	if err != nil {
 		return
 	}
@@ -45,7 +45,7 @@ func getChain(host string, config *tls.Config) (chain []*x509.Certificate, err e
 
 	chain = conn.ConnectionState().PeerCertificates
 	if len(chain) == 0 {
-		err = fmt.Errorf("%s returned empty certificate chain", host)
+		err = fmt.Errorf("%s returned empty certificate chain", addr)
 	}
 	return
 }
@@ -56,8 +56,8 @@ func (e expiration) String() string {
 	return time.Time(e).Format("Jan 2 15:04:05 2006 MST")
 }
 
-func chainExpiration(host string) (grade Grade, output Output, err error) {
-	chain, err := getChain(host, defaultTLSConfig(host))
+func chainExpiration(addr, hostname string) (grade Grade, output Output, err error) {
+	chain, err := getChain(addr, defaultTLSConfig(hostname))
 	if err != nil {
 		return
 	}
@@ -83,8 +83,8 @@ func chainExpiration(host string) (grade Grade, output Output, err error) {
 	return
 }
 
-func chainValidation(host string) (grade Grade, output Output, err error) {
-	chain, err := getChain(host, defaultTLSConfig(host))
+func chainValidation(addr, hostname string) (grade Grade, output Output, err error) {
+	chain, err := getChain(addr, defaultTLSConfig(hostname))
 	if err != nil {
 		return
 	}
@@ -139,15 +139,15 @@ func chainValidation(host string) (grade Grade, output Output, err error) {
 	return
 }
 
-func multipleCerts(host string) (grade Grade, output Output, err error) {
-	config := defaultTLSConfig(host)
+func multipleCerts(addr, hostname string) (grade Grade, output Output, err error) {
+	config := defaultTLSConfig(hostname)
 
-	firstChain, err := getChain(host, config)
+	firstChain, err := getChain(addr, config)
 	if err != nil {
 		return
 	}
 
-	grade, _, err = multiscan(host, func(addrport string) (g Grade, o Output, e error) {
+	grade, _, err = multiscan(addr, func(addrport string) (g Grade, o Output, e error) {
 		g = Good
 		chain, e1 := getChain(addrport, config)
 		if e1 != nil {

--- a/scan/scan_common_test.go
+++ b/scan/scan_common_test.go
@@ -7,8 +7,8 @@ import (
 
 var TestingScanner = &Scanner{
 	Description: "Tests common scan functions",
-	scan: func(host string) (Grade, Output, error) {
-		switch host {
+	scan: func(addr, hostname string) (Grade, Output, error) {
+		switch addr {
 		case "bad.example.com:443":
 			return Bad, "bad.com", nil
 		case "Warning.example.com:443":
@@ -39,27 +39,27 @@ func TestCommon(t *testing.T) {
 	var output Output
 	var err error
 
-	grade, output, err = TestingScanner.Scan("bad.example.com:443")
+	grade, output, err = TestingScanner.Scan("bad.example.com:443", "bad.example.com")
 	if grade != Bad || output.(string) != "bad.com" || err != nil {
 		t.FailNow()
 	}
 
-	grade, output, err = TestingScanner.Scan("Warning.example.com:443")
+	grade, output, err = TestingScanner.Scan("Warning.example.com:443", "Warning.example.com")
 	if grade != Warning || output.(string) != "Warning.com" || err != nil {
 		t.FailNow()
 	}
 
-	grade, output, err = TestingScanner.Scan("good.example.com:443")
+	grade, output, err = TestingScanner.Scan("good.example.com:443", "good.example.com")
 	if grade != Good || output.(string) != "good.com" || err != nil {
 		t.FailNow()
 	}
 
-	grade, output, err = TestingScanner.Scan("skipped.example.com:443/0")
+	grade, output, err = TestingScanner.Scan("skipped.example.com:443/0", "")
 	if grade != Skipped || output.(string) != "skipped" || err != nil {
 		t.FailNow()
 	}
 
-	_, _, err = TestingScanner.Scan("invalid")
+	_, _, err = TestingScanner.Scan("invalid", "invalid")
 	if err == nil {
 		t.FailNow()
 	}

--- a/scan/tls_session.go
+++ b/scan/tls_session.go
@@ -15,11 +15,11 @@ var TLSSession = &Family{
 }
 
 // SessionResumeScan tests that host is able to resume sessions across all addresses.
-func sessionResumeScan(host string) (grade Grade, output Output, err error) {
-	config := defaultTLSConfig(host)
+func sessionResumeScan(addr, hostname string) (grade Grade, output Output, err error) {
+	config := defaultTLSConfig(hostname)
 	config.ClientSessionCache = tls.NewLRUClientSessionCache(1)
 
-	conn, err := tls.DialWithDialer(Dialer, Network, host, config)
+	conn, err := tls.DialWithDialer(Dialer, Network, addr, config)
 	if err != nil {
 		return
 	}
@@ -27,7 +27,7 @@ func sessionResumeScan(host string) (grade Grade, output Output, err error) {
 		return
 	}
 
-	return multiscan(host, func(addrport string) (g Grade, o Output, e error) {
+	return multiscan(addr, func(addrport string) (g Grade, o Output, e error) {
 		var conn *tls.Conn
 		if conn, e = tls.DialWithDialer(Dialer, Network, addrport, config); e != nil {
 			return


### PR DESCRIPTION
This splits the `host` argument into `addr` (with optional fixed IP and Port) and `hostname`.

Note that none of these scans send HTTP requests, so there is no code to set the Host header (It will simply be `req.Host = hostname`).

The scans that don't make sense with a fixed address (i.e. DNS lookup) just use hostname