### PR TITLE
Minor cfssl improvements

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,7 @@ The requirements to build without Docker are:
 3. A properly configured GOPATH
 4. The default behaviour is to build with PKCS #11, which  requires the
    `gcc` compiler and the libtool development library and header files. On
-   Ubuntu, this is `libltdl-dev`.
+   Ubuntu, this is `libltdl-dev`. On Centos/RHEL, this is `libtool-ltdl-devel`.
 
 To build with PKCS #11 support, run:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation requires a
 properly set `GOPATH`.  The default behaviour is to build with PKCS
 \#11, which requires the `gcc` compiler and the libtool development
 library and header files. On Ubuntu, this is
-`libltdl-dev`. On Centos/RHEL, this is 'libtool' and 'libtool-ltdl'.
+`libltdl-dev`. On Centos/RHEL, this is `libtool-ltdl-devel`.
 If these are not installed, you can pass `-tags nopkcs11` to the below
 go get commands.
 

--- a/cli/gencert/gencert.go
+++ b/cli/gencert/gencert.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"github.com/cloudflare/cfssl/cli"
-	"github.com/cloudflare/cfssl/cli/genkey"
 	"github.com/cloudflare/cfssl/cli/sign"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/initca"
@@ -82,7 +81,7 @@ func gencertMain(args []string, c cli.Config) (err error) {
 		}
 
 		var key, csrBytes []byte
-		g := &csr.Generator{Validator: genkey.Validator}
+		g := &csr.Generator{Validator: func(*csr.CertificateRequest) error {return nil}}
 		csrBytes, key, err = g.ProcessRequest(&req)
 		if err != nil {
 			key = nil

--- a/cli/genkey/genkey.go
+++ b/cli/genkey/genkey.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/csr"
-	cferr "github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/initca"
 )
 
@@ -58,7 +57,7 @@ func genkeyMain(args []string, c cli.Config) (err error) {
 		}
 
 		var key, csrPEM []byte
-		g := &csr.Generator{Validator: Validator}
+		g := &csr.Generator{Validator: func(*csr.CertificateRequest) error {return nil}}
 		csrPEM, key, err = g.ProcessRequest(&req)
 		if err != nil {
 			key = nil
@@ -66,14 +65,6 @@ func genkeyMain(args []string, c cli.Config) (err error) {
 		}
 
 		cli.PrintCert(key, csrPEM, nil)
-	}
-	return nil
-}
-
-// Validator returns true if the csr has at least one host
-func Validator(req *csr.CertificateRequest) error {
-	if len(req.Hosts) == 0 {
-		return cferr.Wrap(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing hosts field"))
 	}
 	return nil
 }

--- a/cli/printdefault/defaults.go
+++ b/cli/printdefault/defaults.go
@@ -7,7 +7,7 @@ var defaults = map[string]string{
             "expiry": "168h"
         },
         "profiles": {
-            "www": {
+            "server": {
                 "expiry": "8760h",
                 "usages": [
                     "signing",

--- a/cli/selfsign/selfsign.go
+++ b/cli/selfsign/selfsign.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/cloudflare/cfssl/cli"
-	"github.com/cloudflare/cfssl/cli/genkey"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
@@ -61,7 +60,7 @@ func selfSignMain(args []string, c cli.Config) (err error) {
 	}
 
 	var key, csrPEM []byte
-	g := &csr.Generator{Validator: genkey.Validator}
+	g := &csr.Generator{Validator: func(*csr.CertificateRequest) error {return nil}}
 	csrPEM, key, err = g.ProcessRequest(&req)
 	if err != nil {
 		key = nil

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -49,7 +49,7 @@ type BasicKeyRequest struct {
 
 // NewBasicKeyRequest returns a default BasicKeyRequest.
 func NewBasicKeyRequest() *BasicKeyRequest {
-	return &BasicKeyRequest{"ecdsa", curveP256}
+	return &BasicKeyRequest{"rsa", 2048}
 }
 
 // Algo returns the requested key algorithm represented as a string.


### PR DESCRIPTION
- Fixed CentOS package name in README.md and BUILDING.md.
- If we have defaults at `cli/printdefault/defaults.go` - let's use them. Set default algo to rsa.
- Renamed `www` profile name to `server`. I suppose this is more proper name.
- Basically you can use `"hosts":[""]` json and it will pass validation. But if you would like to set hosts through `-hostname` option only when you omit `hosts` - this validation harms.

Don't have much experience with go. But I had an idea to validate "hosts" and "hostname" in proper way. Right now it is possible to pass `"hosts":["","",""]` or `-hostname=",,,,"`. Probably we have to fix `SplitHosts` and `OverrideHosts` functions. I've tried to implement something like this:

``` go
regexp.MustCompile("[ ,]+").Split(strings.TrimSpace(hostList),-1)
```

but it didn't work with ",     1 , 2 , 4  ,   5  ,   , dfdfdsfs  ,   , , ,  " strings
