### PR TITLE
Revamp pkcs11key

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,54 @@ pushd cli/serve && rice embed-go && popd
 
 Then building with `go build` will use the embedded resources.
 
+### Using a PKCS#11 hardware token / HSM
+
+For better security, you may want to store your private key in an HSM or
+smartcard. The interface to both of these categories of device is described by
+the PKCS#11 spec. If you need to do approximately one signing operation per
+second or fewer, the Yubikey NEO and NEO-n are inexpensive smartcard options:
+https://www.yubico.com/products/yubikey-hardware/yubikey-neo/. In general you
+are looking for a product that supports PIV (personal identity verification). If
+your signing needs are in the hundreds of signatures per second, you will need
+to purchase an expensive HSM (in the thousands to many thousands of USD).
+
+If you want to try out the PKCS#11 signing modes without a hardware token, you
+can use the [SoftHSM](https://github.com/opendnssec/SoftHSMv1#softhsm)
+implementation. Please note that using SoftHSM simply stores your private key in
+a file on disk and does not increase security.
+
+To get started with your PKCS#11 token you will need to initialize it with a
+private key, PIN, and token label. The instructions to do this will be specific
+to each hardware device, and you should follow the instructions provided by your
+vendor. You will also need to find the path to your 'module', a shared object
+file (.so). Having initialized your device, you can query it to check your token
+label with:
+
+    pkcs11-tool --module <module path> --list-token-slots
+
+You'll also want to check the label of the private key you imported (or
+generated). Run the following command and look for a 'Private Key Object':
+
+    pkcs11-tool --module <module path> --pin <pin> \
+      --list-token-slots --login --list-objects
+
+You now have all the information you need to use your PKCS#11 token with CFSSL.
+CFSSL supports PKCS#11 for certificate signing and OCSP signing. To create a
+Signer (for certificate signing), import `signer/universal` and call NewSigner
+with a Root object containing the module, pin, token label and private label
+from above, plus a path to your certificate. The structure of the Root object is
+documented in universal.go.
+
+The setup for an OCSP signer is slightly different. Import ocsp/pkcs11 and call
+NewPKCS11Signer with the appropriate configuration structure defined in
+`ocsp/config`.
+
+Alternately, you can construct a pkcs11key.Key or pkcs11key.Pool yourself, and
+pass it to ocsp.NewSigner (for OCSP) or local.NewSigner (for certificate
+signing). This will be necessary, for example, if you are using a single-session
+token like the Yubikey and need both OCSP signing and certificate signing at the
+same time.
+
 ### Additional Documentation
 
 Additional documentation can be found in the "doc/" directory:

--- a/crypto/pkcs11key/config.go
+++ b/crypto/pkcs11key/config.go
@@ -4,7 +4,6 @@ package pkcs11key
 // #11 key.
 type Config struct {
 	Module          string
-	SlotDescription string
 	TokenLabel      string
 	PIN             string
 	PrivateKeyLabel string

--- a/crypto/pkcs11key/config.go
+++ b/crypto/pkcs11key/config.go
@@ -1,0 +1,11 @@
+package pkcs11key
+
+// Config contains configuration information required to use a PKCS
+// #11 key.
+type Config struct {
+	Module          string
+	SlotDescription string
+	TokenLabel      string
+	PIN             string
+	PrivateKeyLabel string
+}

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -41,11 +41,11 @@ var hashPrefixes = map[crypto.Hash][]byte{
 // some smartcards like the Yubikey Neo do not support multiple simultaneous
 // sessions and will error out on creation of the second Key object.
 //
-// Note: If you instantiate multiple Keys, it is *highly* recommended that you
-// create all your Key objects serially, on your main thread, checking for
-// errors each time, and then farm them out for use by different goroutines. If
-// you fail to do this, your application may attempt to login repeatedly with
-// an incorrect PIN, locking the PKCS#11 token.
+// Note: If you instantiate multiple Keys without using Pool, it is *highly*
+// recommended that you create all your Key objects serially, on your main
+// thread, checking for errors each time, and then farm them out for use by
+// different goroutines. If you fail to do this, your application may attempt
+// to login repeatedly with an incorrect PIN, locking the PKCS#11 token.
 type Key struct {
 	// The PKCS#11 library to use
 	module *pkcs11.Ctx

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -1,6 +1,6 @@
 // +build !nopkcs11
 
-// Package Key implements crypto.Signer for PKCS #11 private
+// Package pkcs11key implements crypto.Signer for PKCS #11 private
 // keys. Currently, only RSA keys are supported.
 // See ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-11/v2-30/pkcs-11v2-30b-d6.pdf for
 // details of the Cryptoki PKCS#11 API.

--- a/crypto/pkcs11key/key_pool.go
+++ b/crypto/pkcs11key/key_pool.go
@@ -55,6 +55,9 @@ func (p *PKCS11KeyPool) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts)
 	return instance.Sign(rand, msg, opts)
 }
 
+// Public returns the public key of any one of the signers in the pool. Since
+// they were all created with the same arguments, the public key should be the
+// same for each one.
 func (p *PKCS11KeyPool) Public() crypto.PublicKey {
 	instance := p.get()
 	defer p.put(instance)

--- a/crypto/pkcs11key/key_pool.go
+++ b/crypto/pkcs11key/key_pool.go
@@ -7,17 +7,17 @@ import (
 	"fmt"
 )
 
-// PKCS11KeyPool is a pool of PKCS11Keys suitable for high performance parallel
+// Pool is a pool of PKCS11Keys suitable for high performance parallel
 // work. PKCS11Key on its own is suitable for multi-threaded use because it has
 // built-in locking, but one PKCS11Key can have at most one operation inflight
 // at a time. If you are using an HSM that supports multiple sessions, you may
-// want to use a PKCS11KeyPool instead, which contains multiple signers.
-// PKCS11KeyPool satisfies the Signer interface just as PKCS11Key does, and
+// want to use a Pool instead, which contains multiple signers.
+// Pool satisfies the Signer interface just as PKCS11Key does, and
 // farms out work to multiple sessions under the hood. This assumes you are
 // calling Sign from multiple goroutines (as would be common in an RPC or HTTP
 // environment). If you only call Sign from a single goroutine, you will only
 // ever get single-session performance.
-type PKCS11KeyPool struct {
+type Pool struct {
 	// This slice acts more or less like a concurrent stack. Keys are popped off
 	// the top for use, and then pushed back on when they are no longer in use.
 	signers    []*PKCS11Key
@@ -28,7 +28,7 @@ type PKCS11KeyPool struct {
 	cond    *sync.Cond
 }
 
-func (p *PKCS11KeyPool) get() *PKCS11Key {
+func (p *Pool) get() *PKCS11Key {
 	p.cond.L.Lock()
 	for len(p.signers) == 0 {
 		p.cond.Wait()
@@ -40,7 +40,7 @@ func (p *PKCS11KeyPool) get() *PKCS11Key {
 	return instance
 }
 
-func (p *PKCS11KeyPool) put(instance *PKCS11Key) {
+func (p *Pool) put(instance *PKCS11Key) {
 	p.cond.L.Lock()
 	p.signers = append(p.signers, instance)
 	p.cond.Signal()
@@ -49,7 +49,7 @@ func (p *PKCS11KeyPool) put(instance *PKCS11Key) {
 
 // Sign performs a signature using an available PKCS #11 key. If there is no key
 // available, it blocks until there is.
-func (p *PKCS11KeyPool) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) ([]byte, error) {
+func (p *Pool) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) ([]byte, error) {
 	instance := p.get()
 	defer p.put(instance)
 	return instance.Sign(rand, msg, opts)
@@ -58,14 +58,14 @@ func (p *PKCS11KeyPool) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts)
 // Public returns the public key of any one of the signers in the pool. Since
 // they were all created with the same arguments, the public key should be the
 // same for each one.
-func (p *PKCS11KeyPool) Public() crypto.PublicKey {
+func (p *Pool) Public() crypto.PublicKey {
 	instance := p.get()
 	defer p.put(instance)
 	return instance.Public()
 }
 
 // NewPool creates a pool of PKCS11Keys of size n.
-func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*PKCS11KeyPool, error) {
+func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*Pool, error) {
 	var err error
 	signers := make([]*PKCS11Key, n)
 	for i := 0; i < n; i++ {
@@ -81,7 +81,7 @@ func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*PKCS1
 	}
 
 	var mutex sync.Mutex
-	return &PKCS11KeyPool{
+	return &Pool{
 		signers: signers,
 		totalCount: len(signers),
 		cond: sync.NewCond(&mutex),
@@ -90,7 +90,7 @@ func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*PKCS1
 
 // Destroy calls destroy for each of the member keys, shutting down their
 // sessions.
-func (p *PKCS11KeyPool) Destroy() {
+func (p *Pool) Destroy() {
 	for i := 0; i < p.totalCount; i++ {
 		p.get().Destroy()
 	}

--- a/crypto/pkcs11key/key_pool.go
+++ b/crypto/pkcs11key/key_pool.go
@@ -1,0 +1,94 @@
+package pkcs11key
+
+import (
+	"sync"
+	"io"
+	"crypto"
+	"fmt"
+)
+
+// PKCS11KeyPool is a pool of PKCS11Keys suitable for high performance parallel
+// work. PKCS11Key on its own is suitable for multi-threaded use because it has
+// built-in locking, but one PKCS11Key can have at most one operation inflight
+// at a time. If you are using an HSM that supports multiple sessions, you may
+// want to use a PKCS11KeyPool instead, which contains multiple signers.
+// PKCS11KeyPool satisfies the Signer interface just as PKCS11Key does, and
+// farms out work to multiple sessions under the hood. This assumes you are
+// calling Sign from multiple goroutines (as would be common in an RPC or HTTP
+// environment). If you only call Sign from a single goroutine, you will only
+// ever get single-session performance.
+type PKCS11KeyPool struct {
+	// This slice acts more or less like a concurrent stack. Keys are popped off
+	// the top for use, and then pushed back on when they are no longer in use.
+	signers    []*PKCS11Key
+	// The initial length of signers, before any are popped off for use.
+	totalCount int
+	// This variable signals the condition that there are PKCS11Keys available to be
+	// used.
+	cond    *sync.Cond
+}
+
+func (p *PKCS11KeyPool) get() *PKCS11Key {
+	p.cond.L.Lock()
+	for len(p.signers) == 0 {
+		p.cond.Wait()
+	}
+
+	instance := p.signers[len(p.signers)-1]
+	p.signers = p.signers[:len(p.signers)-1]
+	p.cond.L.Unlock()
+	return instance
+}
+
+func (p *PKCS11KeyPool) put(instance *PKCS11Key) {
+	p.cond.L.Lock()
+	p.signers = append(p.signers, instance)
+	p.cond.Signal()
+	p.cond.L.Unlock()
+}
+
+// Sign performs a signature using an available PKCS #11 key. If there is no key
+// available, it blocks until there is.
+func (p *PKCS11KeyPool) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) ([]byte, error) {
+	instance := p.get()
+	defer p.put(instance)
+	return instance.Sign(rand, msg, opts)
+}
+
+func (p *PKCS11KeyPool) Public() crypto.PublicKey {
+	instance := p.get()
+	defer p.put(instance)
+	return instance.Public()
+}
+
+// NewPool creates a pool of PKCS11Keys of size n.
+func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*PKCS11KeyPool, error) {
+	var err error
+	signers := make([]*PKCS11Key, n)
+	for i := 0; i < n; i++ {
+		signers[i], err = New(modulePath, tokenLabel, pin, privateKeyLabel)
+		// If any of the signers fail, exit early. This could be, e.g., a bad PIN,
+		// and we want to make sure not to lock the token.
+		if err != nil {
+			for j := 0; j < i; j++ {
+				signers[j].Destroy()
+			}
+			return nil, fmt.Errorf("Problem making PKCS11Key: %s", err)
+		}
+	}
+
+	var mutex sync.Mutex
+	return &PKCS11KeyPool{
+		signers: signers,
+		totalCount: len(signers),
+		cond: sync.NewCond(&mutex),
+	}, nil
+}
+
+// Destroy calls destroy for each of the member keys, shutting down their
+// sessions.
+func (p *PKCS11KeyPool) Destroy() {
+	for i := 0; i < p.totalCount; i++ {
+		p.get().Destroy()
+	}
+}

--- a/crypto/pkcs11key/pkcs11key.go
+++ b/crypto/pkcs11key/pkcs11key.go
@@ -75,7 +75,7 @@ type PKCS11Key struct {
 	sessionMu sync.Mutex
 }
 
-var modules map[string]*pkcs11.Ctx = make(map[string]*pkcs11.Ctx);
+var modules = make(map[string]*pkcs11.Ctx);
 var modulesMu sync.Mutex;
 
 // initialize loads the given PKCS#11 module (shared library) if it is not

--- a/crypto/pkcs11key/pkcs11key.go
+++ b/crypto/pkcs11key/pkcs11key.go
@@ -219,14 +219,14 @@ func getPublicKey(module *pkcs11.Ctx, session pkcs11.SessionHandle, privateKeyHa
 
 // Destroy tears down a PKCS11Key by closing the session. It should be
 // called before the key gets GC'ed, to avoid leaving dangling sessions.
-// NOTE: We do not want to call module.Logout here. module.Logout applies
-// application-wide. So if there are multiple sessions active, the other ones
-// would be logged out as well, causing CKR_OBJECT_HANDLE_INVALID next
-// time they try to sign something. It's also unnecessary to log out explicitly:
-// module.CloseSession will log out once the last session in the application is
-// closed.
 func (ps *PKCS11Key) Destroy() {
 	if ps.session != nil {
+		// NOTE: We do not want to call module.Logout here. module.Logout applies
+		// application-wide. So if there are multiple sessions active, the other ones
+		// would be logged out as well, causing CKR_OBJECT_HANDLE_INVALID next
+		// time they try to sign something. It's also unnecessary to log out explicitly:
+		// module.CloseSession will log out once the last session in the application is
+		// closed.
 		ps.sessionMu.Lock()
 		ps.module.CloseSession(*ps.session)
 		ps.session = nil

--- a/crypto/pkcs11key/pkcs11key_bench_test.go
+++ b/crypto/pkcs11key/pkcs11key_bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkPKCS11(b *testing.B) {
 
 	// Login once to make sure the PIN works. This avoids repeatedly logging in
 	// with bad credentials, which would pin-lock the token.
-	firstKey, err := New(*module, "", *tokenLabel, *pin, *privateKeyLabel)
+	firstKey, err := New(*module, *tokenLabel, *pin, *privateKeyLabel)
 	if err != nil {
 		b.Fatal(err)
 		return
@@ -59,7 +59,7 @@ func BenchmarkPKCS11(b *testing.B) {
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		p, err := New(*module, "", *tokenLabel, *pin, *privateKeyLabel)
+		p, err := New(*module, *tokenLabel, *pin, *privateKeyLabel)
 		if err != nil {
 			b.Fatal(err)
 			return

--- a/crypto/pkcs11key/pkcs11key_bench_test.go
+++ b/crypto/pkcs11key/pkcs11key_bench_test.go
@@ -56,6 +56,12 @@ func BenchmarkPKCS11(b *testing.B) {
 	}
 	defer pool.Destroy()
 
+	instance := pool.get()
+	if instance.alwaysAuthenticate {
+		b.Log("WARNING: Token has CKA_ALWAYS_AUTHENTICATE attribute, which makes signing slow.")
+	}
+	pool.put(instance)
+
 	// Reset the benchmarking timer so we don't include setup time.
 	b.ResetTimer()
 

--- a/crypto/pkcs11key/pkcs11key_bench_test.go
+++ b/crypto/pkcs11key/pkcs11key_bench_test.go
@@ -58,6 +58,10 @@ func BenchmarkPKCS11(b *testing.B) {
 	// Reset the benchmarking timer so we don't include setup time.
 	b.ResetTimer()
 
+	// Start recording total time. Go's benchmarking code is interested in
+	// nanoseconds per op, but we're also interested in the total throughput.
+	start := time.Now()
+
 	b.RunParallel(func(pb *testing.PB) {
 		p, err := New(*module, *tokenLabel, *pin, *privateKeyLabel)
 		if err != nil {
@@ -74,6 +78,9 @@ func BenchmarkPKCS11(b *testing.B) {
 			}
 		}
 	})
+
+	elapsedTime := time.Now().Sub(start)
+	b.Logf("Time, count, ops / second: %s, %d, %g", elapsedTime, b.N, float64(b.N)*float64(time.Second)/float64(elapsedTime))
 }
 
 // Dummy test to avoid getting "warning: no tests found"

--- a/crypto/pkcs11key/pkcs11key_bench_test.go
+++ b/crypto/pkcs11key/pkcs11key_bench_test.go
@@ -1,0 +1,81 @@
+package pkcs11key
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"flag"
+	"math/big"
+	"testing"
+	"time"
+)
+
+var module = flag.String("module", "", "Path to PKCS11 module")
+var tokenLabel = flag.String("tokenLabel", "", "Token label")
+var pin = flag.String("pin", "", "PIN")
+var privateKeyLabel = flag.String("privateKeyLabel", "", "Private key label")
+
+// BenchmarkPKCS11 signs a certificate repeatedly using a PKCS11 token and
+// measures speed. To run (with SoftHSM):
+// go test -bench=. -benchtime 5s ./crypto/pkcs11key/ \
+//   -module /usr/lib/softhsm/libsofthsm.so -token-label "softhsm token" \
+//   -pin 1234 -private-key-label "my key" -cpu 4
+// You can adjust benchtime if you want to run for longer or shorter, and change
+// the number of CPUs to select the parallelism you want.
+func BenchmarkPKCS11(b *testing.B) {
+	if *module == "" || *tokenLabel == "" || *pin == "" || *privateKeyLabel == "" {
+		b.Fatal("Must pass all flags: module, tokenLabel, pin, and privateKeyLabel")
+		return
+	}
+
+	// A minimal, bogus certificate to be signed.
+	// Note: we choose a large N to make up for some of the missing fields in the
+	// bogus certificate, so we wind up something approximately the size of a real
+	// certificate.
+	N := big.NewInt(1)
+	N.Lsh(N, 6000)
+	template := x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		PublicKeyAlgorithm: x509.RSA,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now(),
+
+		PublicKey: &rsa.PublicKey{
+			N: N,
+			E: 1 << 17,
+		},
+	}
+
+	// Login once to make sure the PIN works. This avoids repeatedly logging in
+	// with bad credentials, which would pin-lock the token.
+	firstKey, err := New(*module, "", *tokenLabel, *pin, *privateKeyLabel)
+	if err != nil {
+		b.Fatal(err)
+		return
+	}
+	firstKey.Destroy()
+
+	// Reset the benchmarking timer so we don't include setup time.
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		p, err := New(*module, "", *tokenLabel, *pin, *privateKeyLabel)
+		if err != nil {
+			b.Fatal(err)
+			return
+		}
+		defer p.Destroy()
+
+		for pb.Next() {
+			_, err = x509.CreateCertificate(rand.Reader, &template, &template, template.PublicKey, p)
+			if err != nil {
+				b.Fatal(err)
+				return
+			}
+		}
+	})
+}
+
+// Dummy test to avoid getting "warning: no tests found"
+func TestNothing(t *testing.T) {
+}

--- a/helpers/pkcs11uri/pkcs11uri.go
+++ b/helpers/pkcs11uri/pkcs11uri.go
@@ -49,7 +49,6 @@ func ParsePKCS11URI(uri string) (*pkcs11key.Config, error) {
 	setIfPresent(pk11QAttr, "module-name", &c.Module)
 	setIfPresent(pk11QAttr, "module-path", &c.Module)
 	setIfPresent(pk11QAttr, "pin-value", &c.PIN)
-	setIfPresent(pk11PAttr, "slot-description", &c.SlotDescription)
 
 	var pinSourceURI string
 	setIfPresent(pk11QAttr, "pin-source", &pinSourceURI)

--- a/helpers/pkcs11uri/pkcs11uri.go
+++ b/helpers/pkcs11uri/pkcs11uri.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/cloudflare/cfssl/errors"
-	"github.com/cloudflare/cfssl/signer/pkcs11"
+	"github.com/cloudflare/cfssl/crypto/pkcs11key"
 )
 
 func setIfPresent(val url.Values, k string, target *string) {
@@ -27,13 +27,13 @@ var ErrInvalidURI = errors.New(errors.PrivateKeyError, errors.ParseFailed)
 // ParsePKCS11URI parses a PKCS #11 URI into a PKCS #11
 // configuration. Note that the module path will override the module
 // name if present.
-func ParsePKCS11URI(uri string) (*pkcs11.Config, error) {
+func ParsePKCS11URI(uri string) (*pkcs11key.Config, error) {
 	u, err := url.Parse(uri)
 	if err != nil || u.Scheme != "pkcs11" {
 		return nil, ErrInvalidURI
 	}
 
-	c := new(pkcs11.Config)
+	c := new(pkcs11key.Config)
 
 	pk11PAttr, err := url.ParseQuery(u.Opaque)
 	if err != nil {
@@ -44,11 +44,12 @@ func ParsePKCS11URI(uri string) (*pkcs11.Config, error) {
 	if err != nil {
 		return nil, ErrInvalidURI
 	}
-	setIfPresent(pk11PAttr, "token", &c.Token)
+	setIfPresent(pk11PAttr, "token", &c.TokenLabel)
+	setIfPresent(pk11PAttr, "object", &c.PrivateKeyLabel)
 	setIfPresent(pk11QAttr, "module-name", &c.Module)
 	setIfPresent(pk11QAttr, "module-path", &c.Module)
 	setIfPresent(pk11QAttr, "pin-value", &c.PIN)
-	setIfPresent(pk11PAttr, "slot-description", &c.Label)
+	setIfPresent(pk11PAttr, "slot-description", &c.SlotDescription)
 
 	var pinSourceURI string
 	setIfPresent(pk11QAttr, "pin-source", &pinSourceURI)

--- a/helpers/pkcs11uri/pkcs11uri_test.go
+++ b/helpers/pkcs11uri/pkcs11uri_test.go
@@ -65,13 +65,13 @@ var pkcs11UriCases = []pkcs11UriTest{
 			TokenLabel: "Software PKCS#11 softtoken",
 			PIN:        "the-pin",
 		}},
-	{"pkcs11:slot-description=Sun%20Metaslot",
+	{"pkcs11:token=Sun%20Token",
 		&pkcs11key.Config{
-			SlotDescription: "Sun Metaslot",
+			TokenLabel: "Sun Token",
 		}},
-	{"pkcs11:slot-description=test-label;token=test-token?pin-source=file:testdata/pin&module-name=test-module",
+	{"pkcs11:object=test-privkey;token=test-token?pin-source=file:testdata/pin&module-name=test-module",
 		&pkcs11key.Config{
-			SlotDescription: "test-label",
+			PrivateKeyLabel: "test-privkey",
 			TokenLabel:      "test-token",
 			PIN:             "123456",
 			Module:          "test-module",

--- a/helpers/pkcs11uri/pkcs11uri_test.go
+++ b/helpers/pkcs11uri/pkcs11uri_test.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cloudflare/cfssl/signer/pkcs11"
+	"github.com/cloudflare/cfssl/crypto/pkcs11key"
 )
 
 type pkcs11UriTest struct {
 	URI    string
-	Config *pkcs11.Config
+	Config *pkcs11key.Config
 }
 
-func cmpConfigs(a, b *pkcs11.Config) bool {
+func cmpConfigs(a, b *pkcs11key.Config) bool {
 	if a == nil {
 		if b == nil {
 			return true
@@ -25,12 +25,12 @@ func cmpConfigs(a, b *pkcs11.Config) bool {
 	}
 
 	return (a.Module == b.Module) &&
-		(a.Token == b.Token) &&
+		(a.TokenLabel == b.TokenLabel) &&
 		(a.PIN == b.PIN) &&
-		(a.Label == b.Label)
+		(a.PrivateKeyLabel == b.PrivateKeyLabel)
 }
 
-func diffConfigs(want, have *pkcs11.Config) {
+func diffConfigs(want, have *pkcs11key.Config) {
 	if have == nil && want != nil {
 		fmt.Printf("Expected config, have nil.")
 		return
@@ -45,9 +45,9 @@ func diffConfigs(want, have *pkcs11.Config) {
 	}
 
 	diff("Module", want.Module, have.Module)
-	diff("Token", want.Token, have.Token)
+	diff("TokenLabel", want.TokenLabel, have.TokenLabel)
 	diff("PIN", want.PIN, have.PIN)
-	diff("Label", want.Label, have.Label)
+	diff("PrivateKeyLabel", want.PrivateKeyLabel, have.PrivateKeyLabel)
 }
 
 /* Config from PKCS #11 signer
@@ -61,20 +61,20 @@ type Config struct {
 
 var pkcs11UriCases = []pkcs11UriTest{
 	{"pkcs11:token=Software%20PKCS%2311%20softtoken;manufacturer=Snake%20Oil,%20Inc.?pin-value=the-pin",
-		&pkcs11.Config{
-			Token: "Software PKCS#11 softtoken",
-			PIN:   "the-pin",
+		&pkcs11key.Config{
+			TokenLabel: "Software PKCS#11 softtoken",
+			PIN:        "the-pin",
 		}},
 	{"pkcs11:slot-description=Sun%20Metaslot",
-		&pkcs11.Config{
-			Label: "Sun Metaslot",
+		&pkcs11key.Config{
+			SlotDescription: "Sun Metaslot",
 		}},
 	{"pkcs11:slot-description=test-label;token=test-token?pin-source=file:testdata/pin&module-name=test-module",
-		&pkcs11.Config{
-			Label:  "test-label",
-			Token:  "test-token",
-			PIN:    "123456",
-			Module: "test-module",
+		&pkcs11key.Config{
+			SlotDescription: "test-label",
+			TokenLabel:      "test-token",
+			PIN:             "123456",
+			Module:          "test-module",
 		}},
 }
 

--- a/ocsp/config/config.go
+++ b/ocsp/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"time"
+	"github.com/cloudflare/cfssl/crypto/pkcs11key"
 )
 
 // Config contains configuration information required to set up an OCSP
@@ -14,15 +15,5 @@ type Config struct {
 	ResponderCertFile string
 	KeyFile string
 	Interval time.Duration
-	PKCS11 PKCS11Config
+	PKCS11 pkcs11key.Config
 }
-
-// PKCS11Config contains information specific to setting up a PKCS11 OCSP
-// signer.
-type PKCS11Config struct {
-	Module string
-	Token  string
-	PIN    string
-	Label  string
-}
-

--- a/ocsp/pkcs11/pkcs11.go
+++ b/ocsp/pkcs11/pkcs11.go
@@ -33,7 +33,6 @@ func NewPKCS11Signer(cfg ocspConfig.Config) (ocsp.Signer, error) {
 	PKCS11 := cfg.PKCS11
 	priv, err := pkcs11key.New(
 		PKCS11.Module,
-		PKCS11.SlotDescription,
 		PKCS11.TokenLabel,
 		PKCS11.PIN,
 		PKCS11.PrivateKeyLabel)

--- a/ocsp/pkcs11/pkcs11.go
+++ b/ocsp/pkcs11/pkcs11.go
@@ -31,8 +31,12 @@ func NewPKCS11Signer(cfg ocspConfig.Config) (ocsp.Signer, error) {
 	}
 
 	PKCS11 := cfg.PKCS11
-	priv, err := pkcs11key.New(PKCS11.Module, PKCS11.Token, PKCS11.PIN,
-		PKCS11.Label)
+	priv, err := pkcs11key.New(
+		PKCS11.Module,
+		PKCS11.SlotDescription,
+		PKCS11.TokenLabel,
+		PKCS11.PIN,
+		PKCS11.PrivateKeyLabel)
 	if err != nil {
 		return nil, errors.New(errors.PrivateKeyError, errors.ReadFailed)
 	}

--- a/signer/pkcs11/pkcs11.go
+++ b/signer/pkcs11/pkcs11.go
@@ -14,20 +14,11 @@ import (
 	"github.com/cloudflare/cfssl/signer/local"
 )
 
-// Config contains configuration information required to use a PKCS
-// #11 key.
-type Config struct {
-	Module string
-	Token  string
-	PIN    string
-	Label  string
-}
-
 // Enabled is set to true if PKCS #11 support is present.
 const Enabled = true
 
 // New returns a new PKCS #11 signer.
-func New(caCertFile string, policy *config.Signing, cfg *Config) (signer.Signer, error) {
+func New(caCertFile string, policy *config.Signing, cfg *pkcs11key.Config) (signer.Signer, error) {
 	if cfg == nil {
 		return nil, errors.New(errors.PrivateKeyError, errors.ReadFailed)
 	}
@@ -43,7 +34,7 @@ func New(caCertFile string, policy *config.Signing, cfg *Config) (signer.Signer,
 		return nil, err
 	}
 
-	priv, err := pkcs11key.New(cfg.Module, cfg.Token, cfg.PIN, cfg.Label)
+	priv, err := pkcs11key.New(cfg.Module, cfg.SlotDescription, cfg.TokenLabel, cfg.PIN, cfg.PrivateKeyLabel)
 	if err != nil {
 		return nil, errors.New(errors.PrivateKeyError, errors.ReadFailed)
 	}

--- a/signer/pkcs11/pkcs11.go
+++ b/signer/pkcs11/pkcs11.go
@@ -34,7 +34,7 @@ func New(caCertFile string, policy *config.Signing, cfg *pkcs11key.Config) (sign
 		return nil, err
 	}
 
-	priv, err := pkcs11key.New(cfg.Module, cfg.SlotDescription, cfg.TokenLabel, cfg.PIN, cfg.PrivateKeyLabel)
+	priv, err := pkcs11key.New(cfg.Module, cfg.TokenLabel, cfg.PIN, cfg.PrivateKeyLabel)
 	if err != nil {
 		return nil, errors.New(errors.PrivateKeyError, errors.ReadFailed)
 	}

--- a/signer/universal/universal.go
+++ b/signer/universal/universal.go
@@ -4,6 +4,7 @@ package universal
 import (
 	"github.com/cloudflare/cfssl/config"
 	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/crypto/pkcs11key"
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/local"
 	"github.com/cloudflare/cfssl/signer/pkcs11"
@@ -38,12 +39,12 @@ func fileBackedSigner(root *Root, policy *config.Signing) (signer.Signer, bool, 
 // options in the root.
 func pkcs11Signer(root *Root, policy *config.Signing) (signer.Signer, bool, error) {
 	module := root.Config["pkcs11-module"]
-	token := root.Config["pkcs11-token"]
-	label := root.Config["pkcs11-label"]
+	tokenLabel := root.Config["pkcs11-token-label"]
+	privateKeyLabel := root.Config["pkcs11-private-key-label"]
 	userPIN := root.Config["pkcs11-user-pin"]
 	certFile := root.Config["cert-file"]
 
-	if module == "" && token == "" && label == "" && userPIN == "" {
+	if module == "" && tokenLabel == "" && privateKeyLabel == "" && userPIN == "" {
 		return nil, false, nil
 	}
 
@@ -51,10 +52,10 @@ func pkcs11Signer(root *Root, policy *config.Signing) (signer.Signer, bool, erro
 		return nil, true, cferr.New(cferr.PrivateKeyError, cferr.Unavailable)
 	}
 
-	conf := pkcs11.Config{
+	conf := pkcs11key.Config{
 		Module: module,
-		Token:  token,
-		Label:  label,
+		TokenLabel:  tokenLabel,
+		PrivateKeyLabel:  privateKeyLabel,
 		PIN:    userPIN,
 	}
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/cfssl/issues/329
Fixes https://github.com/cloudflare/cfssl/issues/325
Fixes https://github.com/cloudflare/cfssl/issues/322
Incorporates https://github.com/cloudflare/cfssl/pull/321

pkcs11key used to log in and log out for each Sign request. This created a
performance problem, because logins are slow. It also created a concurrency
problem.

Logged in / logged out state is a property of a PKCS#11 application, not a
session. So it was possible for two Sign operations on separate threads to log
in at the same time, and for one Sign operation to finish and call Logout before
the other Sign operation called SignInit. This would result in a
CKR_OBJECT_HANDLE_INVALID error.

To fix both of these issues, I made the session a persistent property of a
PKCS11Key, and protected it with a mutex. Now each PKCS11Key maintains a single
session throughout its lifetime, increasing signing performance.

Also, some of the field names for PKCS11Key were incorrect, and there was no
provision to select by token label, only slot label. In general, token label is
more unique, and the better choice. This change incorporates the elements of
https://github.com/cloudflare/cfssl/pull/321 fixing that. That is, it renames
Token to SlotDescription, Label to PrivateKeyLabel, and adds a new field
TokenLabel. Note for people updating configs: In your configs, don't rename
Token to TokenLabel. The value you currently have in Token is actually a
SlotDescription, and should be named such. You should add a field named
TokenLabel, whose value you can find with pkcs11-tool --list-slots.

I also changed where the PKCS11Key Config object is defined, to make it more
straightforward to share between different components, and added object label
support to pkcs11uri, so private keys can be selected by label.