### PR TITLE
Save bytes on OCSP responses.

### DIFF
--- a/ocsp/ocsp_test.go
+++ b/ocsp/ocsp_test.go
@@ -1,6 +1,7 @@
 package ocsp
 
 import (
+	"golang.org/x/crypto/ocsp"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -65,8 +66,48 @@ func TestNewSignerFromFile(t *testing.T) {
 	}
 }
 
-func TestSign(t *testing.T) {
+func setup(t *testing.T) (SignRequest, time.Duration) {
 	dur, _ := time.ParseDuration("1ms")
+	certPEM, err := ioutil.ReadFile(otherCertFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafCert, err := helpers.ParseCertificatePEM(certPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := SignRequest{
+		Certificate: leafCert,
+		Status:      "good",
+	}
+	return req, dur
+}
+
+func TestSignNoResponder(t *testing.T) {
+	req, dur := setup(t)
+	s, err := NewSignerFromFile(serverCertFile, serverCertFile, serverKeyFile, dur)
+	if err != nil {
+		t.Fatalf("Signer creation failed: %v", err)
+	}
+	respBytes, err := s.Sign(req)
+	if err != nil {
+		t.Fatal("Failed to sign with no responder cert")
+	}
+
+	resp, err := ocsp.ParseResponse(respBytes, nil)
+	if err != nil {
+		t.Fatal("Failed to fail on improper status code")
+	}
+	if resp.Certificate != nil {
+		t.Fatal("Response contain responder cert even though it was identical to issuer")
+	}
+}
+
+func TestSign(t *testing.T) {
+	req, dur := setup(t)
+
 	// expected case
 	s, err := NewSignerFromFile(serverCertFile, otherCertFile, serverKeyFile, dur)
 	if err != nil {
@@ -76,21 +117,6 @@ func TestSign(t *testing.T) {
 	_, err = s.Sign(SignRequest{})
 	if err == nil {
 		t.Fatal("Signed request with nil certificate")
-	}
-
-	certPEM, err := ioutil.ReadFile(otherCertFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cert, err := helpers.ParseCertificatePEM(certPEM)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	req := SignRequest{
-		Certificate: cert,
-		Status:      "good",
 	}
 
 	_, err = s.Sign(req)


### PR DESCRIPTION
When OCSP responder cert is the same as OCSP issuer, don't include the
certificate in the OCSP response, as it is unnecessary.