### PR TITLE
Replace SerialSeq with ClientProvidesSerialNumbers.

### DIFF
--- a/api/sign/sign.go
+++ b/api/sign/sign.go
@@ -4,6 +4,7 @@ package sign
 import (
 	"encoding/json"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 
 	"github.com/cloudflare/cfssl/api"
@@ -85,7 +86,7 @@ type jsonSignRequest struct {
 	Subject   *signer.Subject `json:"subject,omitempty"`
 	Profile   string          `json:"profile"`
 	Label     string          `json:"label"`
-	SerialSeq string          `json:"serial_sequence,omitempty"`
+	Serial    *big.Int        `json:"serial,omitempty"`
 }
 
 func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
@@ -104,7 +105,7 @@ func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
 			Request:   js.Request,
 			Profile:   js.Profile,
 			Label:     js.Label,
-			SerialSeq: js.SerialSeq,
+			Serial:    js.Serial,
 		}
 	}
 
@@ -114,7 +115,7 @@ func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
 		Request:   js.Request,
 		Profile:   js.Profile,
 		Label:     js.Label,
-		SerialSeq: js.SerialSeq,
+		Serial:    js.Serial,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -75,9 +75,10 @@ type SigningProfile struct {
 	Backdate      time.Duration
 	Provider      auth.Provider
 	RemoteServer  string
-	UseSerialSeq  bool
 	CSRWhitelist  *CSRWhitelist
 	NameWhitelist *regexp.Regexp
+
+	ClientProvidesSerialNumbers bool
 }
 
 // UnmarshalJSON unmarshals a JSON string into an OID.

--- a/errors/error.go
+++ b/errors/error.go
@@ -88,8 +88,10 @@ const (
 	// BadRequest indicates that the certificate request is invalid.
 	BadRequest // Code 13XX
 
-	// SerialSeqParseError -- SerialSeq failed to parse as hex digits
-	SerialSeqParseError // Code 14XX
+	// MissingSerial indicates that the profile specified
+	// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
+	// number.
+	MissingSerial // Code 14XX
 )
 
 const (
@@ -215,6 +217,8 @@ func New(category Category, reason Reason) *Error {
 			msg = "Unable to verify certificate"
 		case BadRequest:
 			msg = "Invalid certificate request"
+		case MissingSerial:
+			msg = "Missing serial number in request"
 		default:
 			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category CertificateError.",
 				reason))

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -151,20 +151,20 @@ func testSign(t *testing.T) {
 	badcert := *cert
 	badcert.PublicKey = nil
 	profl := config.SigningProfile{Usage: []string{"Certificates", "Rule"}}
-	_, err = signer.sign(&badcert, &profl, "")
+	_, err = signer.sign(&badcert, &profl)
 
 	if err == nil {
 		t.Fatal("Improper input failed to raise an error")
 	}
 
 	// nil profile
-	_, err = signer.sign(cert, &profl, "")
+	_, err = signer.sign(cert, &profl)
 	if err == nil {
 		t.Fatal("Nil profile failed to raise an error")
 	}
 
 	// empty profile
-	_, err = signer.sign(cert, &config.SigningProfile{}, "")
+	_, err = signer.sign(cert, &config.SigningProfile{})
 	if err == nil {
 		t.Fatal("Empty profile failed to raise an error")
 	}
@@ -172,7 +172,7 @@ func testSign(t *testing.T) {
 	// empty expiry
 	prof := signer.policy.Default
 	prof.Expiry = 0
-	_, err = signer.sign(cert, prof, "")
+	_, err = signer.sign(cert, prof)
 	if err != nil {
 		t.Fatal("nil expiry raised an error")
 	}
@@ -182,7 +182,7 @@ func testSign(t *testing.T) {
 	prof.CRL = "stuff"
 	prof.OCSP = "stuff"
 	prof.IssuerURL = []string{"stuff"}
-	_, err = signer.sign(cert, prof, "")
+	_, err = signer.sign(cert, prof)
 	if err != nil {
 		t.Fatal("non nil urls raised an error")
 	}
@@ -192,12 +192,12 @@ func testSign(t *testing.T) {
 	prof = signer.policy.Default
 	prof.CA = false
 	nilca.ca = nil
-	_, err = nilca.sign(cert, prof, "")
+	_, err = nilca.sign(cert, prof)
 	if err == nil {
 		t.Fatal("nil ca with isca false raised an error")
 	}
 	prof.CA = true
-	_, err = nilca.sign(cert, prof, "")
+	_, err = nilca.sign(cert, prof)
 	if err != nil {
 		t.Fatal("nil ca with CA true raised an error")
 	}


### PR DESCRIPTION
For Boulder, we're moving to a new serial number generation scheme with an 8-bit datacenter prefix and 136 bits of randomness: https://github.com/letsencrypt/boulder/pull/823. So we don't need the `SerialSeq` feature anymore (and I strongly suspect no-one else uses it). But we do need the ability to specify a serial number when we call into CFSSL.