### PR TITLE
Improve tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.4
+  - 1.4
 before_install:
   # CFSSL consists of multiple Go packages, which refer to each other by
   # their absolute GitHub path, e.g. github.com/cloudflare/crypto/pkcs11key.
@@ -21,12 +21,7 @@ before_script:
   - go get github.com/modocache/gover
   - go get -v github.com/GeertJohan/fgt
 script:
-  - go get github.com/cloudflare/cfssl/...
-  - go test github.com/cloudflare/cfssl/...
-  - go vet github.com/cloudflare/cfssl/...
-  - fgt golint github.com/cloudflare/cfssl/...
-  - go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -i sh -c {}
-  - gover . coverprofile.txt
+  - ./test.sh
 notifications:
   email:
     recipients:

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -o errexit
+cd $(dirname $0)
+ls $GOPATH/src/github.com/cloudflare/cfssl
+
+go vet ./...
+if ! which fgt > /dev/null ; then
+  echo "Please install fgt from https://github.com/GeertJohan/fgt."
+  exit 1
+fi
+if ! which golint > /dev/null ; then
+  echo "Please install golint from github.com/golang/lint/golint."
+  exit 1
+fi
+fgt golint ./...
+go test ./...
+go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -i sh -c {}
+gover . coverprofile.txt


### PR DESCRIPTION
Pull out a test.sh that includes golint and go vet.
Don't `go get` cfssl: It should already be checked out as part of Travis' setup.
This step was overwriting user-specific repos.