### PR TITLE
Add AuthRemote.

### DIFF
--- a/signer/remote/remote.go
+++ b/signer/remote/remote.go
@@ -82,8 +82,8 @@ func (s *Signer) remoteOp(req interface{}, profile, target string) (resp interfa
 	// There's no auth provider for the "info" method
 	if target == "info" {
 		resp, err = server.Info(jsonData)
-	} else if p.Provider != nil {
-		resp, err = server.AuthSign(jsonData, nil, p.Provider)
+	} else if p.RemoteProvider != nil {
+		resp, err = server.AuthSign(jsonData, nil, p.RemoteProvider)
 	} else {
 		resp, err = server.Sign(jsonData)
 	}


### PR DESCRIPTION
Previously, the AuthKeyName field in a signing profile acted as both the
authentication key that clients would use, and the authentication key
that the profile would use when sending a signing request to a remote
CFSSL. There wasn't any way to specify separate authentication keys.

This PR adds a field to the signing profile: AuthRemote. This pairs an
auth key name and a remote name; the names come from the same auth keys
and remote section of the config, and represent the configuration the
user will use.

As an internal implementation note, the RemoteServer field will now be
set if either the RemoteName or AuthRemote.RemoteName fields are
set.