### PR TITLE
Fix OCSP responder for GET requests.

### DIFF
--- a/ocsp/responder_test.go
+++ b/ocsp/responder_test.go
@@ -1,0 +1,52 @@
+package ocsp
+
+import (
+	"testing"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	goocsp "golang.org/x/crypto/ocsp"
+)
+
+type testSource struct{}
+
+func (ts testSource) Response(r *goocsp.Request) ([]byte, bool) {
+	return []byte("hi"), true
+}
+
+type testCase struct {
+	method, path string
+	expected int
+}
+
+func TestOCSP(t *testing.T) {
+	cases := []testCase{
+		testCase{"OPTIONS", "/", http.StatusMethodNotAllowed},
+		testCase{"GET", "/", http.StatusBadRequest},
+		// Bad URL encoding
+		testCase{"GET", "%ZZFQwUjBQME4wTDAJBgUrDgMCGgUABBQ55F6w46hhx%2Fo6OXOHa%2BYfe32YhgQU%2B3hPEvlgFYMsnxd%2FNBmzLjbqQYkCEwD6Wh0MaVKu9gJ3By9DI%2F%2Fxsd4%3D", http.StatusBadRequest},
+		// Bad URL encoding
+		testCase{"GET", "%%FQwUjBQME4wTDAJBgUrDgMCGgUABBQ55F6w46hhx%2Fo6OXOHa%2BYfe32YhgQU%2B3hPEvlgFYMsnxd%2FNBmzLjbqQYkCEwD6Wh0MaVKu9gJ3By9DI%2F%2Fxsd4%3D", http.StatusBadRequest},
+		// Bad base64 encoding
+		testCase{"GET", "==MFQwUjBQME4wTDAJBgUrDgMCGgUABBQ55F6w46hhx%2Fo6OXOHa%2BYfe32YhgQU%2B3hPEvlgFYMsnxd%2FNBmzLjbqQYkCEwD6Wh0MaVKu9gJ3By9DI%2F%2Fxsd4%3D", http.StatusBadRequest},
+		// Bad OCSP DER encoding
+		testCase{"GET", "AAAMFQwUjBQME4wTDAJBgUrDgMCGgUABBQ55F6w46hhx%2Fo6OXOHa%2BYfe32YhgQU%2B3hPEvlgFYMsnxd%2FNBmzLjbqQYkCEwD6Wh0MaVKu9gJ3By9DI%2F%2Fxsd4%3D", http.StatusBadRequest},
+		// Good encoding all around, including a double slash
+		testCase{"GET", "MFQwUjBQME4wTDAJBgUrDgMCGgUABBQ55F6w46hhx%2Fo6OXOHa%2BYfe32YhgQU%2B3hPEvlgFYMsnxd%2FNBmzLjbqQYkCEwD6Wh0MaVKu9gJ3By9DI%2F%2Fxsd4%3D", http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		rw := httptest.NewRecorder()
+		responder := Responder{testSource{}}
+
+		responder.ServeHTTP(rw, &http.Request{
+			Method: tc.method,
+			URL: &url.URL{
+				Path: tc.path,
+			},
+		})
+		if rw.Code != tc.expected {
+			t.Errorf("Incorrect response code: got %d, wanted %d", rw.Code, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
Previously, the OCSP responder would drop everything up to the first '/'.
Also, it has to cope with spaces output by URL decoding.
Added a test.

Fixes letsencrypt/boulder#884

Note: Don't merge just yet. We're going to try a new workflow for reviewing Boulder-related PRs. First we'll do a PR on our own fork: https://github.com/letsencrypt/cfssl/pull/1, and once another Boulder dev has reviewed and merged over there, I'll ping this PR to get merged into CFSSL.