### PR TITLE
Run Travis for PRs only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,16 @@ before_install:
   - mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/cloudflare
   - test ! -d $GOPATH/src/github.com/cloudflare/cfssl && ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/cloudflare/cfssl || true
 
+# Only build pull requests, pushes to the master branch, and branches
+# starting with `test-`. This is a convenient way to push branches to
+# your own fork of the repostiory to ensure Travis passes before submitting
+# a PR. For instance, you might run:
+# git push myremote branchname:test-branchname
+branches:
+  only:
+    - master
+    - /^test-.*$/
+
 before_script:
   - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Based on my feedback in https://github.com/cloudflare/cfssl/pull/361, CFSSL now
has four entries in its build matrix: BUILD_FLAGS=""/"nopkcs11" and
(preexisting) Go 1.4 / Go 1.5. For public projects Travis has a limit of five
simultaneous builds, and each entry in the build matrix consumes one.

So we're still under the limit of five, except that Travis builds all branches
plus pull requests. So generally when someone pushes a branch and then makes a
PR based off of it, Travis will be trying to run two builds simultaneously, with
four build matrix entries in each. This means that one of the two builds is
blocked on the other completing, which makes things much slower.

In boulder we've solved this issue by disabling builds for branches except for
master, and any branch named "test-*".