### PR TITLE
Fix ValidExpiry test that wasn't being run. Add .coverprofile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cfssl_*
 *-386
 dist/*
 cli/serve/static.rice-box.go
+.coverprofile

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -135,7 +135,7 @@ func TestMonthsValid(t *testing.T) {
 	}
 }
 
-func HasValidExpiry(t *testing.T) {
+func TestHasValidExpiry(t *testing.T) {
 	// Issue period > April 1, 2015
 	var cert = &x509.Certificate{
 		NotBefore: time.Date(2015, time.April, 01, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
HasValidExpiry was not run because it didn't start with Test. 
test.sh creates a bunch of .coverprofile files which should be ignored.