### PR TITLE
Return error if config file has no "Signing" field

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -527,6 +527,10 @@ func LoadConfig(config []byte) (*Config, error) {
 			errors.New("failed to unmarshal configuration: "+err.Error()))
 	}
 
+	if cfg.Signing == nil {
+		return nil, errors.New("No \"signing\" field present")
+	}
+
 	if cfg.Signing.Default == nil {
 		log.Debugf("no default given: using default config")
 		cfg.Signing.Default = DefaultConfig()


### PR DESCRIPTION
Running `cfssl gencert` with a config file that lacks the `Signing` field would cause a `runtime error: invalid memory address or nil pointer dereference`. Now, `config.go` returns an error if there is no `Signing` field