### PR TITLE
enable https connection when endpoint-cert and endpoint-key available

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	CSRFile           string
 	CAFile            string
 	CAKeyFile         string
+	EPCAFile          string
+	EPCAKeyFile       string
 	KeyFile           string
 	IntermediatesFile string
 	CABundleFile      string
@@ -63,6 +65,8 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.CSRFile, "csr", "", "Certificate signature request file for new public key")
 	f.StringVar(&c.CAFile, "ca", "ca.pem", "CA used to sign the new certificate")
 	f.StringVar(&c.CAKeyFile, "ca-key", "ca-key.pem", "CA private key")
+	f.StringVar(&c.EPCAFile, "endpoint-cert", "", "Other endpoint CA used to sign the new certificate")
+	f.StringVar(&c.EPCAKeyFile, "endpoint-key", "", "Other endpoint CA private key")
 	f.StringVar(&c.KeyFile, "key", "", "private key for the certificate")
 	f.StringVar(&c.IntermediatesFile, "intermediates", "", "intermediate certs")
 	f.StringVar(&c.CABundleFile, "ca-bundle", "", "path to root certificate store")


### PR DESCRIPTION
Added tags "-endpoint-cert" and "-endpoint-key" for "cfssl serve" command.
With a endpoint user's certificate and key (pem files) , the cfssl can be served on a secure HTTP protocol (HTTPS) 

Below is a list of cipher suites used to cover different browsers, please comment if your browser supports other cipher suites thats not listed.

        TLS_RSA_WITH_RC4_128_SHA                
        TLS_RSA_WITH_3DES_EDE_CBC_SHA           
        TLS_RSA_WITH_AES_128_CBC_SHA            
        TLS_RSA_WITH_AES_256_CBC_SHA            
        TLS_ECDHE_ECDSA_WITH_RC4_128_SHA       
        TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA    
        TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA   
        TLS_ECDHE_RSA_WITH_RC4_128_SHA          
        TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA    
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA      
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  
        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384   
        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384