### PR TITLE
enable https connection with endpoint CA and key provided

### DIFF
--- a/api/client/group.go
+++ b/api/client/group.go
@@ -43,7 +43,11 @@ func StrategyFromString(s string) Strategy {
 func NewGroup(remotes []string, strategy Strategy) (Remote, error) {
 	var servers = make([]*server, len(remotes))
 	for i := range remotes {
-		servers[i] = newServer(remotes[i])
+		u, err := normalizeURL(remotes[i])
+		if err != nil {
+			return nil, err
+		}
+		servers[i], _ = newServer(u)
 	}
 
 	switch strategy {

--- a/cli/config.go
+++ b/cli/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	CSRFile           string
 	CAFile            string
 	CAKeyFile         string
+	TLSCertFile       string
+	TLSKeyFile        string
 	KeyFile           string
 	IntermediatesFile string
 	CABundleFile      string
@@ -65,6 +67,8 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.CSRFile, "csr", "", "Certificate signature request file for new public key")
 	f.StringVar(&c.CAFile, "ca", "", "CA used to sign the new certificate")
 	f.StringVar(&c.CAKeyFile, "ca-key", "", "CA private key")
+	f.StringVar(&c.TLSCertFile, "tls-cert", "", "Other endpoint CA to set up TLS protocol")
+	f.StringVar(&c.TLSKeyFile, "tls-key", "", "Other endpoint CA private key")
 	f.StringVar(&c.KeyFile, "key", "", "private key for the certificate")
 	f.StringVar(&c.IntermediatesFile, "intermediates", "", "intermediate certs")
 	f.StringVar(&c.CABundleFile, "ca-bundle", "", "path to root certificate store")

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -36,13 +36,14 @@ Usage of serve:
         cfssl serve [-address address] [-ca cert] [-ca-bundle bundle] \
                     [-ca-key key] [-int-bundle bundle] [-int-dir dir] [-port port] \
                     [-metadata file] [-remote remote_host] [-config config] \
-                    [-responder cert] [-responder-key key]
+                    [-responder cert] [-responder-key key] [-tls-cert cert] [-tls-key key]\
 
 Flags:
 `
 
 // Flags used by 'cfssl serve'
-var serverFlags = []string{"address", "port", "ca", "ca-key", "ca-bundle", "int-bundle", "int-dir", "metadata", "remote", "config", "responder", "responder-key"}
+var serverFlags = []string{"address", "port", "ca", "ca-key", "ca-bundle", "int-bundle", "int-dir", "metadata",
+	"remote", "config", "responder", "responder-key", "tls-key", "tls-cert"}
 
 var (
 	conf       cli.Config
@@ -208,8 +209,16 @@ func serverMain(args []string, c cli.Config) error {
 	registerHandlers()
 
 	addr := net.JoinHostPort(conf.Address, strconv.Itoa(conf.Port))
-	log.Info("Now listening on ", addr)
-	return http.ListenAndServe(addr, nil)
+
+	if conf.TLSCertFile == "" || conf.TLSKeyFile == "" {
+		log.Info("Now listening on ", addr)
+		return http.ListenAndServe(addr, nil)
+	}
+
+	log.Info("Now listening on https://", addr)
+
+	return http.ListenAndServeTLS(addr, conf.TLSCertFile, conf.TLSKeyFile, nil)
+
 }
 
 // Command assembles the definition of Command 'serve'

--- a/cmd/multirootca/ca.go
+++ b/cmd/multirootca/ca.go
@@ -41,6 +41,8 @@ func main() {
 	flagAddr := flag.String("a", ":8888", "listening address")
 	flagRootFile := flag.String("roots", "", "configuration file specifying root keys")
 	flagDefaultLabel := flag.String("l", "", "specify a default label")
+	flagEndpointCert := flag.String("tls-cert", "", "server certificate")
+	flagEndpointKey := flag.String("tls-key", "", "server private key")
 	flag.IntVar(&log.Level, "loglevel", log.LevelInfo, "log level (0 = DEBUG, 4 = ERROR)")
 	flag.Parse()
 
@@ -84,6 +86,14 @@ func main() {
 	http.HandleFunc("/api/v1/cfssl/authsign", dispatchRequest)
 	http.Handle("/api/v1/cfssl/info", infoHandler)
 	http.Handle("/api/v1/cfssl/metrics", metrics)
-	log.Info("listening on ", *flagAddr)
-	log.Error(http.ListenAndServe(*flagAddr, nil))
+
+	if *flagEndpointCert == "" && *flagEndpointKey == "" {
+		log.Info("Now listening on ", *flagAddr)
+		log.Fatal(http.ListenAndServe(*flagAddr, nil))
+	} else {
+
+		log.Info("Now listening on https:// ", *flagAddr)
+		log.Fatal(http.ListenAndServeTLS(*flagAddr, *flagEndpointCert, *flagEndpointKey, nil))
+	}
+
 }


### PR DESCRIPTION
Added tags "-tls-cert" and "-tls-key" for "cfssl serve" command.
With a endpoint user's certificate and key (pem files) , the cfssl can be served on a secure HTTP protocol (HTTPS)

using Go's default cipher suites , please comment if your browser supports other cipher suites thats not listed.

    TLS_RSA_WITH_RC4_128_SHA                
    TLS_RSA_WITH_3DES_EDE_CBC_SHA           
    TLS_RSA_WITH_AES_128_CBC_SHA            
    TLS_RSA_WITH_AES_256_CBC_SHA            
    TLS_ECDHE_ECDSA_WITH_RC4_128_SHA       
    TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA    
    TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA   
    TLS_ECDHE_RSA_WITH_RC4_128_SHA          
    TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA    
    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA      
    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  
    TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384   
    TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384