### PR TITLE
Make scans run concurrently

### DIFF
--- a/api/scan/scan.go
+++ b/api/scan/scan.go
@@ -42,12 +42,11 @@ func scanHandler(w http.ResponseWriter, r *http.Request) error {
 		return errors.NewBadRequestString("no host given")
 	}
 
-	resultChan, err := scan.Default.RunScans(host, ip, family, scanner, timeout)
+	results, err := scan.Default.RunScans(host, ip, family, scanner, timeout)
 	if err != nil {
 		return errors.NewBadRequest(err)
 	}
 
-	results := scan.ProcessResults(resultChan)
 	return json.NewEncoder(w).Encode(api.NewSuccessResponse(results))
 }
 

--- a/api/scan/scan_test.go
+++ b/api/scan/scan_test.go
@@ -1,1 +1,56 @@
 package scan
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	handler, _ = NewHandler("")
+	ts         = httptest.NewServer(handler)
+)
+
+func TestBadRequest(t *testing.T) {
+	// Test request with no host
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+	resp, _ := http.DefaultClient.Do(req)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatal(resp.Status)
+	}
+}
+
+func TestScanRESTfulVerbs(t *testing.T) {
+	// GET should work
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+	data := req.URL.Query()
+	data.Add("host", "cloudflare.com")
+	req.URL.RawQuery = data.Encode()
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal(resp.Status)
+	}
+
+	// POST, PUT, DELETE, WHATEVER should return 400 errors
+	req, _ = http.NewRequest("POST", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+	req, _ = http.NewRequest("DELETE", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+	req, _ = http.NewRequest("PUT", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+	req, _ = http.NewRequest("WHATEVER", ts.URL, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatal(resp.Status)
+	}
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -89,7 +89,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.BoolVar(&c.List, "list", false, "list possible scanners")
 	f.StringVar(&c.Family, "family", "", "scanner family regular expression")
 	f.StringVar(&c.Scanner, "scanner", "", "scanner regular expression")
-	f.DurationVar(&c.Timeout, "timeout", 0, "duration (ns, us, ms, s, m, h) to scan each host before timing out")
+	f.DurationVar(&c.Timeout, "timeout", 5*time.Minute, "duration (ns, us, ms, s, m, h) to scan each host before timing out")
 	f.StringVar(&c.Responses, "responses", "", "file to load OCSP responses from")
 	f.StringVar(&c.Path, "path", "/", "Path on which the server will listen")
 	f.StringVar(&c.Password, "password", "0", "Password for accessing PKCS #12 data passed to bundler")

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -139,7 +139,7 @@ func v1APIPath(endpoint string) string {
 // registerHandlers instantiates various handlers and associate them to corresponding endpoints.
 func registerHandlers() {
 	for path, getHandler := range v1Endpoints {
-		path = "/api/v1/cfssl/" + path
+		path = v1APIPath(path)
 		log.Infof("Setting up '%s' endpoint", path)
 		if handler, err := getHandler(); err != nil {
 			log.Warningf("endpoint '%s' is disabled: %v", path, err)

--- a/doc/api/endpoint_scan.txt
+++ b/doc/api/endpoint_scan.txt
@@ -10,6 +10,7 @@ Required parameters:
 Optional parameters:
 
     * ip: IP Address to override DNS lookup of host
+    * timeout: The ammount of time allotted for the scan to complete (default: 1 minute)
 
     The following parameters are used by the scanner to select which 
     scans to run.


### PR DESCRIPTION
This updates PR #278 by @taravancil 

This change runs individual scans from each family concurrently, and
sends the results on a channel when the family scans finish.

Resolves #236 and #269