### PR TITLE
Allow for email addresses in the 'hosts' list for the SubjectAltName

### DIFF
--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/big"
 	"net"
+	"net/mail"
 
 	"github.com/cloudflare/cfssl/config"
 	cferr "github.com/cloudflare/cfssl/errors"
@@ -150,17 +151,20 @@ func PopulateSubjectFromCSR(s *signer.Subject, req pkix.Name) pkix.Name {
 	return name
 }
 
-// OverrideHosts fills template's IPAddresses and DNSNames with the
+// OverrideHosts fills template's IPAddresses, EmailAddresses, and DNSNames with the
 // content of hosts, if it is not nil.
 func OverrideHosts(template *x509.Certificate, hosts []string) {
 	if hosts != nil {
 		template.IPAddresses = []net.IP{}
+		template.EmailAddresses = []string{}
 		template.DNSNames = []string{}
 	}
 
 	for i := range hosts {
 		if ip := net.ParseIP(hosts[i]); ip != nil {
 			template.IPAddresses = append(template.IPAddresses, ip)
+		} else if email, err := mail.ParseAddress(hosts[i]); err == nil && email != nil {
+			template.EmailAddresses = append(template.EmailAddresses, email.Address)
 		} else {
 			template.DNSNames = append(template.DNSNames, hosts[i])
 		}

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -554,7 +554,7 @@ func TestOverrideSubject(t *testing.T) {
 	s := newCustomSigner(t, testECDSACaFile, testECDSACaKeyFile)
 
 	request := signer.SignRequest{
-		Hosts:   []string{"127.0.0.1", "localhost"},
+		Hosts:   []string{"127.0.0.1", "localhost", "xyz@example.com"},
 		Request: string(csrPEM),
 		Subject: req,
 	}
@@ -626,7 +626,7 @@ func TestOverwriteHosts(t *testing.T) {
 		for _, hosts := range [][]string{
 			nil,
 			[]string{},
-			[]string{"127.0.0.1", "localhost"},
+			[]string{"127.0.0.1", "localhost", "xyz@example.com"},
 		} {
 			request := signer.SignRequest{
 				Hosts:   hosts,
@@ -644,10 +644,14 @@ func TestOverwriteHosts(t *testing.T) {
 				t.Fatalf("%v", err)
 			}
 
-			// get the hosts, and add the ips
+			// get the hosts, and add the ips and email addresses
 			certHosts := cert.DNSNames
 			for _, ip := range cert.IPAddresses {
 				certHosts = append(certHosts, ip.String())
+			}
+
+			for _, email := range cert.EmailAddresses {
+				certHosts = append(certHosts, email)
 			}
 
 			// compare the sorted host lists


### PR DESCRIPTION
Changes the local signer so that email addresses in the hostname list are properly added to the SubjectAltName as email: email@address.com.  Also adds a to the test.