### PR TITLE
Add support for ECDSA keys in crypto.pkcs11.Key

### DIFF
--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -488,13 +488,8 @@ func (ps *Key) openSession() (pkcs11.SessionHandle, error) {
 		// practice it appears to be okay to login to a token multiple times with the same
 		// credentials.
 		if err = ps.module.Login(session, pkcs11.CKU_USER, ps.pin); err != nil {
-			if err == pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
-				// But if the token says we're already logged in, it's ok.
-				err = nil
-			} else {
-				ps.module.CloseSession(session)
-				return session, err
-			}
+			ps.module.CloseSession(session)
+			return session, err
 		}
 
 		return session, err

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -228,7 +228,7 @@ func (ps *Key) getPrivateKey(module ctx, session pkcs11.SessionHandle, label str
 	if err := module.FindObjectsInit(session, template); err != nil {
 		return noHandle, err
 	}
-	objs, _, err := module.FindObjects(session, 2)
+	objs, _, err := module.FindObjects(session, 1)
 	if err != nil {
 		return noHandle, err
 	}
@@ -362,7 +362,7 @@ func (ps *Key) getECPublicKey(module ctx, session pkcs11.SessionHandle, privateK
 	if err := module.FindObjectsInit(session, templateSearch); err != nil {
 		return noKey, err
 	}
-	objs, _, err := module.FindObjects(session, 2)
+	objs, _, err := module.FindObjects(session, 1)
 	if err != nil {
 		return noKey, err
 	}

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -327,8 +327,12 @@ func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle 
 func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
 	var noKey interface{}
 
+	// http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/os/pkcs11-curr-v2.40-os.html#_Toc416960012
 	template := []*pkcs11.Attribute{
+		// CKA_EC_PARAMS contains the OID of the curve (part of the
+		// public key
 		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, nil),
+		// CKA_ID will allow use to find the corresponding public key
 		pkcs11.NewAttribute(pkcs11.CKA_ID, nil),
 	}
 
@@ -486,6 +490,7 @@ func (ps *Key) openSession() (pkcs11.SessionHandle, error) {
 		// credentials.
 		if err = ps.module.Login(session, pkcs11.CKU_USER, ps.pin); err != nil {
 			if err == pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
+				// But if the token says we're already logged in, it's ok.
 				err = nil
 			} else {
 				ps.module.CloseSession(session)

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -387,8 +387,8 @@ func readECPoint(curve elliptic.Curve, ecpoint []byte) (*big.Int, *big.Int) {
 		var point asn1.RawValue
 		asn1.Unmarshal(ecpoint, &point)
 		if len(point.Bytes) > 0 {
-		x, y = elliptic.Unmarshal(curve, point.Bytes)
-	}
+			x, y = elliptic.Unmarshal(curve, point.Bytes)
+		}
 	}
 	return x, y
 }
@@ -412,7 +412,7 @@ func (ps *Key) loadPublicKey(module ctx, session pkcs11.SessionHandle, privateKe
 		pub, err := getECPublicKey(ps.module, session, privateKeyHandle)
 		if err != nil {
 			return err
-	}
+		}
 		ecPub := pub.(ecdsa.PublicKey)
 		ps.publicKey = &ecPub
 	default:

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -73,16 +73,6 @@ type ctx interface {
 	Sign(sh pkcs11.SessionHandle, message []byte) ([]byte, error)
 }
 
-// KeyType is to track the type of the key (based on CKA_KEY_TYPE)
-type KeyType int
-
-const (
-	// RSA means the key is an RSA key
-	RSA KeyType = 0
-	// EC means the key is an Elliptic Curve key
-	EC KeyType = 3
-)
-
 // Key is an implementation of the crypto.Signer interface using a key stored
 // in a PKCS#11 hardware token.  This enables the use of PKCS#11 tokens with
 // the Go x509 library's methods for signing certificates.
@@ -115,9 +105,6 @@ type Key struct {
 
 	// The an ObjectHandle pointing to the private key on the HSM.
 	privateKeyHandle pkcs11.ObjectHandle
-
-	// The key type (RSA or EC)
-	keyType KeyType
 
 	// A handle to the session used by this Key.
 	session   *pkcs11.SessionHandle
@@ -204,19 +191,10 @@ func (ps *Key) setup(privateKeyLabel string) (err error) {
 	}
 	ps.privateKeyHandle = privateKeyHandle
 
-	publicKey, err := ps.getPublicKey(ps.module, session, privateKeyHandle)
+	err = ps.loadPublicKey(ps.module, session, privateKeyHandle)
 	if err != nil {
 		ps.module.CloseSession(session)
-		return
 	}
-	if ps.keyType == EC {
-		t := publicKey.(ecdsa.PublicKey)
-		ps.publicKey = &t
-	} else {
-		t := publicKey.(rsa.PublicKey)
-		ps.publicKey = &t
-	}
-
 	return
 }
 
@@ -242,29 +220,10 @@ func (ps *Key) getPrivateKey(module ctx, session pkcs11.SessionHandle, label str
 	}
 	privateKeyHandle := objs[0]
 
-	attributes, err := module.GetAttributeValue(session, privateKeyHandle, []*pkcs11.Attribute{
-		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, false),
-	})
-	if err != nil {
-		return noHandle, err
-	}
-
-	if (len(attributes) > 0) && (len(attributes[0].Value) > 0) {
-		if attributes[0].Value[0] == pkcs11.CKK_RSA {
-			ps.keyType = RSA
-		} else if attributes[0].Value[0] == pkcs11.CKK_EC {
-			ps.keyType = EC
-		} else {
-			return noHandle, fmt.Errorf("Unsupported key type %d", attributes[0].Value[0])
-		}
-	} else {
-		return noHandle, fmt.Errorf("No key type")
-	}
-
 	// Check whether the key has the CKA_ALWAYS_AUTHENTICATE attribute.
 	// If so, fail: we don't want to have to re-authenticate for each sign
 	// operation.
-	attributes, err = module.GetAttributeValue(session, privateKeyHandle, []*pkcs11.Attribute{
+	attributes, err := module.GetAttributeValue(session, privateKeyHandle, []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_ALWAYS_AUTHENTICATE, false),
 	})
 	// The PKCS#11 spec states that C_GetAttributeValue may return
@@ -430,14 +389,47 @@ func readECPoint(curve elliptic.Curve, ecpoint []byte) (*big.Int, *big.Int) {
 }
 
 // Get the public key matching a private key
-func (ps *Key) getPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (crypto.PublicKey, error) {
-	var noKey interface{}
-	if ps.keyType == RSA {
-		return getRSAPublicKey(module, session, privateKeyHandle)
-	} else if ps.keyType == EC {
-		return getECPublicKey(module, session, privateKeyHandle)
+func (ps *Key) loadPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) error {
+	keyType, err := getKeyType(ps.module, session, privateKeyHandle)
+	if err != nil {
+		return err
 	}
-	return noKey, fmt.Errorf("invalid key type")
+
+	switch keyType {
+	case pkcs11.CKK_RSA:
+		pub, err := getRSAPublicKey(ps.module, session, privateKeyHandle)
+		if err != nil {
+			return err
+		}
+		rsaPub := pub.(rsa.PublicKey)
+		ps.publicKey = &rsaPub
+	case pkcs11.CKK_EC:
+		pub, err := getECPublicKey(ps.module, session, privateKeyHandle)
+		if err != nil {
+			return err
+	}
+		ecPub := pub.(ecdsa.PublicKey)
+		ps.publicKey = &ecPub
+	default:
+		return fmt.Errorf("Unsupported key type %d", keyType)
+	}
+	return nil
+}
+
+func getKeyType(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (c byte, err error) {
+	attributes, err := module.GetAttributeValue(session, privateKeyHandle, []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, false),
+	})
+	if err != nil {
+		return
+	}
+
+	if (len(attributes) > 0) && (len(attributes[0].Value) > 0) {
+		c = attributes[0].Value[0]
+	} else {
+		err = fmt.Errorf("No key type")
+	}
+	return
 }
 
 // Destroy tears down a Key by closing the session. It should be
@@ -542,7 +534,8 @@ func (ps *Key) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signatu
 	var mechanism []*pkcs11.Mechanism
 	var signatureInput []byte
 
-	if ps.keyType == RSA {
+	switch ps.publicKey.(type) {
+	case *rsa.PublicKey:
 		mechanism = []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS, nil)}
 		prefix, ok := hashPrefixes[hash]
 		if !ok {
@@ -550,7 +543,7 @@ func (ps *Key) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signatu
 			return
 		}
 		signatureInput = append(prefix, msg...)
-	} else if ps.keyType == EC {
+	case *ecdsa.PublicKey:
 		mechanism = []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil)}
 		signatureInput = msg
 	}

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -111,8 +111,7 @@ type Key struct {
 	pin string
 
 	// The public key corresponding to the private key.
-	rsaPublicKey   rsa.PublicKey
-	ecdsaPublicKey ecdsa.PublicKey
+	publicKey crypto.PublicKey
 
 	// The an ObjectHandle pointing to the private key on the HSM.
 	privateKeyHandle pkcs11.ObjectHandle
@@ -211,9 +210,11 @@ func (ps *Key) setup(privateKeyLabel string) (err error) {
 		return
 	}
 	if ps.keyType == EC {
-		ps.ecdsaPublicKey = publicKey.(ecdsa.PublicKey)
+		t := publicKey.(ecdsa.PublicKey)
+		ps.publicKey = &t
 	} else {
-		ps.rsaPublicKey = publicKey.(rsa.PublicKey)
+		t := publicKey.(rsa.PublicKey)
+		ps.publicKey = &t
 	}
 
 	return
@@ -283,7 +284,7 @@ func (ps *Key) getPrivateKey(module ctx, session pkcs11.SessionHandle, label str
 }
 
 // Get the public key matching an RSA private key
-func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
+func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (crypto.PublicKey, error) {
 	var noKey interface{}
 	template := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_MODULUS, nil),
@@ -323,7 +324,7 @@ func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle 
 }
 
 // Get the public key matching an Elliptic Curve private key
-func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
+func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (crypto.PublicKey, error) {
 	var noKey interface{}
 
 	// http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/os/pkcs11-curr-v2.40-os.html#_Toc416960012
@@ -429,7 +430,7 @@ func readECPoint(curve elliptic.Curve, ecpoint []byte) (*big.Int, *big.Int) {
 }
 
 // Get the public key matching a private key
-func (ps *Key) getPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
+func (ps *Key) getPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (crypto.PublicKey, error) {
 	var noKey interface{}
 	if ps.keyType == RSA {
 		return getRSAPublicKey(module, session, privateKeyHandle)
@@ -499,10 +500,7 @@ func (ps *Key) openSession() (pkcs11.SessionHandle, error) {
 
 // Public returns the public key for the PKCS #11 key.
 func (ps *Key) Public() crypto.PublicKey {
-	if ps.keyType == EC {
-		return &ps.ecdsaPublicKey
-	}
-	return &ps.rsaPublicKey
+	return ps.publicKey
 }
 
 // Sign performs a signature using the PKCS #11 key.

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -247,8 +247,8 @@ func (ps *Key) getPrivateKey(module ctx, session pkcs11.SessionHandle, label str
 	if err != nil {
 		return noHandle, err
 	}
-	for i, attribute := range attributes {
-		if i == 0 && len(attribute.Value) > 0 {
+	for _, attribute := range attributes {
+		if len(attribute.Value) > 0 {
 			if attribute.Value[0] == pkcs11.CKK_RSA {
 				ps.keyType = RSA
 			} else if attribute.Value[0] == pkcs11.CKK_EC {

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -366,6 +366,9 @@ func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle p
 	}
 
 	x, y := readECPoint(curve, ecPoint)
+	if x == nil {
+		return noKey, errors.New("invalid EC Point")
+	}
 	ecdsa := ecdsa.PublicKey{
 		Curve: curve,
 		X:     x,
@@ -383,7 +386,9 @@ func readECPoint(curve elliptic.Curve, ecpoint []byte) (*big.Int, *big.Int) {
 		// OCTET STRING.
 		var point asn1.RawValue
 		asn1.Unmarshal(ecpoint, &point)
+		if len(point.Bytes) > 0 {
 		x, y = elliptic.Unmarshal(curve, point.Bytes)
+	}
 	}
 	return x, y
 }

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -309,8 +309,11 @@ func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle 
 			gotExponent = true
 		}
 	}
-	if !gotModulus || !gotExponent {
-		return noKey, errors.New("public key missing either modulus or exponent")
+	if !gotModulus {
+		return noKey, errors.New("private key missing modulus")
+	}
+	if !gotExponent {
+		return noKey, errors.New("private key missing exponent")
 	}
 
 	rsa := rsa.PublicKey{
@@ -346,8 +349,11 @@ func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle p
 			gotID = true
 		}
 	}
-	if !gotOid || !gotID {
-		return noKey, errors.New("public key missing either curve parameters or id")
+	if !gotOid {
+		return noKey, errors.New("private key missing curve parameters")
+	}
+	if !gotID {
+		return noKey, errors.New("private key missing identifier (CKA_ID)")
 	}
 
 	poid := new(asn1.ObjectIdentifier)

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -284,7 +284,7 @@ func (ps *Key) getPrivateKey(module ctx, session pkcs11.SessionHandle, label str
 }
 
 // Get the public key matching an RSA private key
-func (ps *Key) getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
+func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
 	var noKey interface{}
 	template := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_MODULUS, nil),
@@ -321,7 +321,7 @@ func (ps *Key) getRSAPublicKey(module ctx, session pkcs11.SessionHandle, private
 }
 
 // Get the public key matching an Elliptic Curve private key
-func (ps *Key) getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
+func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
 	var noKey interface{}
 
 	template := []*pkcs11.Attribute{
@@ -423,9 +423,9 @@ func readECPoint(curve elliptic.Curve, ecpoint []byte) (*big.Int, *big.Int) {
 func (ps *Key) getPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (interface{}, error) {
 	var noKey interface{}
 	if ps.keyType == RSA {
-		return ps.getRSAPublicKey(module, session, privateKeyHandle)
+		return getRSAPublicKey(module, session, privateKeyHandle)
 	} else if ps.keyType == EC {
-		return ps.getECPublicKey(module, session, privateKeyHandle)
+		return getECPublicKey(module, session, privateKeyHandle)
 	}
 	return noKey, fmt.Errorf("invalid key type")
 }

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -269,10 +269,10 @@ func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle 
 		}
 	}
 	if !gotModulus {
-		return noKey, errors.New("private key missing modulus")
+		return noKey, errors.New("key missing public modulus")
 	}
 	if !gotExponent {
-		return noKey, errors.New("private key missing exponent")
+		return noKey, errors.New("key missing public exponent")
 	}
 
 	rsa := rsa.PublicKey{

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -247,16 +247,17 @@ func (ps *Key) getPrivateKey(module ctx, session pkcs11.SessionHandle, label str
 	if err != nil {
 		return noHandle, err
 	}
-	for _, attribute := range attributes {
-		if len(attribute.Value) > 0 {
-			if attribute.Value[0] == pkcs11.CKK_RSA {
-				ps.keyType = RSA
-			} else if attribute.Value[0] == pkcs11.CKK_EC {
-				ps.keyType = EC
-			} else {
-				return noHandle, fmt.Errorf("Unsupported key type %d", attribute.Value)
-			}
+
+	if (len(attributes) > 0) && (len(attributes[0].Value) > 0) {
+		if attributes[0].Value[0] == pkcs11.CKK_RSA {
+			ps.keyType = RSA
+		} else if attributes[0].Value[0] == pkcs11.CKK_EC {
+			ps.keyType = EC
+		} else {
+			return noHandle, fmt.Errorf("Unsupported key type %d", attributes[0].Value[0])
 		}
+	} else {
+		return noHandle, fmt.Errorf("No key type")
 	}
 
 	// Check whether the key has the CKA_ALWAYS_AUTHENTICATE attribute.
@@ -274,10 +275,8 @@ func (ps *Key) getPrivateKey(module ctx, session pkcs11.SessionHandle, label str
 	} else if err != nil {
 		return noHandle, err
 	}
-	for _, attribute := range attributes {
-		if len(attribute.Value) > 0 && attribute.Value[0] == 1 {
-			ps.alwaysAuthenticate = true
-		}
+	if len(attributes) > 0 && len(attributes[0].Value) > 0 && attributes[0].Value[0] == 1 {
+		ps.alwaysAuthenticate = true
 	}
 
 	return privateKeyHandle, nil

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -8,9 +8,9 @@ package pkcs11key
 
 import (
 	"crypto"
-	"crypto/rsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rsa"
 	"encoding/asn1"
 	"errors"
 	"fmt"
@@ -80,7 +80,7 @@ const (
 	// RSA means the key is an RSA key
 	RSA KeyType = 0
 	// EC means the key is an Elliptic Curve key
-	EC  KeyType = 3
+	EC KeyType = 3
 )
 
 // Key is an implementation of the crypto.Signer interface using a key stored
@@ -111,7 +111,7 @@ type Key struct {
 	pin string
 
 	// The public key corresponding to the private key.
-	rsaPublicKey rsa.PublicKey
+	rsaPublicKey   rsa.PublicKey
 	ecdsaPublicKey ecdsa.PublicKey
 
 	// The an ObjectHandle pointing to the private key on the HSM.
@@ -210,7 +210,7 @@ func (ps *Key) setup(privateKeyLabel string) (err error) {
 		ps.module.CloseSession(session)
 		return
 	}
-	if(ps.keyType == EC) {
+	if ps.keyType == EC {
 		ps.ecdsaPublicKey = publicKey.(ecdsa.PublicKey)
 	} else {
 		ps.rsaPublicKey = publicKey.(rsa.PublicKey)
@@ -341,8 +341,8 @@ func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle p
 		return noKey, err
 	}
 
-	oid := []byte {}
-	id := []byte {}
+	oid := []byte{}
+	id := []byte{}
 	gotOid, gotID := false, false
 	for _, a := range attr {
 		if a.Type == pkcs11.CKA_EC_PARAMS {
@@ -409,8 +409,8 @@ func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle p
 	x, y := readECPoint(curve, ecPoint)
 	ecdsa := ecdsa.PublicKey{
 		Curve: curve,
-		X: x,
-		Y: y,
+		X:     x,
+		Y:     y,
 	}
 	return ecdsa, nil
 }
@@ -505,7 +505,7 @@ func (ps *Key) openSession() (pkcs11.SessionHandle, error) {
 
 // Public returns the public key for the PKCS #11 key.
 func (ps *Key) Public() crypto.PublicKey {
-	if(ps.keyType == EC) {
+	if ps.keyType == EC {
 		return &ps.ecdsaPublicKey
 	}
 	return &ps.rsaPublicKey

--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -279,7 +279,7 @@ func getRSAPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle 
 		N: n,
 		E: e,
 	}
-	return rsa, nil
+	return &rsa, nil
 }
 
 // Get the public key matching an Elliptic Curve private key
@@ -374,7 +374,7 @@ func getECPublicKey(module ctx, session pkcs11.SessionHandle, privateKeyHandle p
 		X:     x,
 		Y:     y,
 	}
-	return ecdsa, nil
+	return &ecdsa, nil
 }
 
 // Decode Q point from CKA_EC_POINT attribute
@@ -402,23 +402,13 @@ func (ps *Key) loadPublicKey(module ctx, session pkcs11.SessionHandle, privateKe
 
 	switch keyType {
 	case pkcs11.CKK_RSA:
-		pub, err := getRSAPublicKey(ps.module, session, privateKeyHandle)
-		if err != nil {
-			return err
-		}
-		rsaPub := pub.(rsa.PublicKey)
-		ps.publicKey = &rsaPub
+		ps.publicKey, err = getRSAPublicKey(ps.module, session, privateKeyHandle)
 	case pkcs11.CKK_EC:
-		pub, err := getECPublicKey(ps.module, session, privateKeyHandle)
-		if err != nil {
-			return err
-		}
-		ecPub := pub.(ecdsa.PublicKey)
-		ps.publicKey = &ecPub
+		ps.publicKey, err = getECPublicKey(ps.module, session, privateKeyHandle)
 	default:
 		return fmt.Errorf("Unsupported key type %d", keyType)
 	}
-	return nil
+	return err
 }
 
 func getKeyType(module ctx, session pkcs11.SessionHandle, privateKeyHandle pkcs11.ObjectHandle) (c byte, err error) {

--- a/crypto/pkcs11key/key_test.go
+++ b/crypto/pkcs11key/key_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"github.com/miekg/pkcs11"
+	"strings"
 	"testing"
 )
 
@@ -323,6 +324,10 @@ func TestSign(t *testing.T) {
 	if !(bytes.Equal(ecPub.X.Bytes(), ecPoint[3:35]) &&
 		bytes.Equal(ecPub.Y.Bytes(), ecPoint[35:])) {
 		t.Fatal("Incorrect decoding of EC Point")
+	}
+
+	if strings.Compare(ecPub.Curve.Params().Name, "P-256") != 0 {
+		t.Fatal("Invalid curve decoded")
 	}
 
 	k := Key{

--- a/crypto/pkcs11key/key_test.go
+++ b/crypto/pkcs11key/key_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"github.com/miekg/pkcs11"
-	"strings"
 	"testing"
 )
 
@@ -326,9 +325,10 @@ func TestSign(t *testing.T) {
 		t.Fatal("Incorrect decoding of EC Point")
 	}
 
-	if strings.Compare(ecPub.Curve.Params().Name, "P-256") != 0 {
-		t.Fatal("Invalid curve decoded")
-	}
+	// Disable this test because it can only work in go 1.5 and later
+	// if strings.Compare(ecPub.Curve.Params().Name, "P-256") != 0 {
+	// 	t.Fatal("Invalid curve decoded")
+	// }
 
 	k := Key{
 		module:     mockCtx{},

--- a/crypto/pkcs11key/key_test.go
+++ b/crypto/pkcs11key/key_test.go
@@ -291,7 +291,7 @@ func TestReadECPoint(t *testing.T) {
 	}
 
 	// Disable this test because it can only work in go 1.5 and later
-	// if strings.Compare(ecPub.Curve.Params().Name, "P-256") != 0 {
+	// if ! strings.EqualFold(ecPub.Curve.Params().Name, "P-256") {
 	// 	t.Fatal("Invalid curve decoded")
 	// }
 
@@ -333,7 +333,7 @@ func TestEcKeyErrors(t *testing.T) {
 	if err == nil {
 		t.Errorf("Unexpected success")
 	}
-	if strings.Compare(err.Error(), "public key not found") != 0 {
+	if !strings.EqualFold(err.Error(), "public key not found") {
 		t.Errorf("Unexpected error value: %v", err)
 	}
 
@@ -342,7 +342,7 @@ func TestEcKeyErrors(t *testing.T) {
 	if err == nil {
 		t.Errorf("Unexpected success")
 	}
-	if strings.Compare(err.Error(), "invalid EC Point") != 0 {
+	if !strings.EqualFold(err.Error(), "invalid EC Point") {
 		t.Errorf("Unexpected error value: %v", err)
 	}
 }

--- a/crypto/pkcs11key/key_test.go
+++ b/crypto/pkcs11key/key_test.go
@@ -17,8 +17,9 @@ type mockCtx struct{}
 const rsaPrivateKeyHandle = pkcs11.ObjectHandle(23)
 const ecPrivateKeyHandle = pkcs11.ObjectHandle(32)
 const ecPublicKeyHandle = pkcs11.ObjectHandle(33)
-// EC Private key with no matching public key
+// EC private key with no matching public key
 const ecPrivNoPubHandle = pkcs11.ObjectHandle(34)
+// EC private and public key with invalid EC point
 const ecInvEcPointPrivHandle = pkcs11.ObjectHandle(35)
 const ecInvEcPointPubHandle = pkcs11.ObjectHandle(36)
 const sessionHandle = pkcs11.SessionHandle(17)
@@ -282,13 +283,12 @@ func sign(t *testing.T, ps *Key) ([]byte) {
 	}
 
 	if len(output) < len(signInput) {
-		t.Fatalf("Invalid signature size: got %d bytes expected at least %d",
-			len(output), len(signInput))
+		t.Fatalf("Invalid signature size")
 	}
 
 	i := len(output) - len(signInput)
 	if !bytes.Equal(output[i:], signInput) {
-		t.Fatal("Incorrect sign output got %v expected %v", output, signInput)
+		t.Fatal("Incorrect sign output")
 	}
 	return output
 }
@@ -312,7 +312,7 @@ func TestSign(t *testing.T) {
 	sig = sign(t, ps)
 
 	if !(bytes.Equal(signInput, sig)) {
-		t.Fatal("ECDSA signature error: got %v expected %v", sig, signInput)
+		t.Fatal("ECDSA signature error")
 	}
 
 	pub = ps.Public()
@@ -332,13 +332,13 @@ func TestSign(t *testing.T) {
 	// Trying to load private EC key with no public key
 	err := k.setup("no_pub_ec")
 	if err == nil {
-		t.Fatalf("Unexpected succes: %v", k)
+		t.Fatalf("Unexpected succes")
 	}
 
-	// Trying to load private EC key with no public key
+	// Trying to load private EC key with invalid EC point
 	err = k.setup("invalid_ec_point")
 	if err == nil {
-		t.Fatalf("Unexpected succes: %v", k)
+		t.Fatalf("Unexpected succes")
 	}
 }
 

--- a/crypto/pkcs11key/key_test.go
+++ b/crypto/pkcs11key/key_test.go
@@ -6,20 +6,22 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/rand"
-	"testing"
-
 	"github.com/miekg/pkcs11"
+	"testing"
 )
 
 type mockCtx struct{}
 
-const privateKeyHandle = pkcs11.ObjectHandle(23)
+const rsaPrivateKeyHandle = pkcs11.ObjectHandle(23)
+const ecPrivateKeyHandle = pkcs11.ObjectHandle(32)
+const ecPublicKeyHandle = pkcs11.ObjectHandle(33)
 const sessionHandle = pkcs11.SessionHandle(17)
 
 var slots = []uint{7, 8, 9}
 var tokenInfo = pkcs11.TokenInfo{
 	Label: "token label",
 }
+var currentSearch []*pkcs11.Attribute
 
 func (c mockCtx) CloseSession(sh pkcs11.SessionHandle) error {
 	return nil
@@ -30,14 +32,29 @@ func (c mockCtx) FindObjectsFinal(sh pkcs11.SessionHandle) error {
 }
 
 func (c mockCtx) FindObjectsInit(sh pkcs11.SessionHandle, temp []*pkcs11.Attribute) error {
+	currentSearch = temp
 	return nil
 }
 
 func (c mockCtx) FindObjects(sh pkcs11.SessionHandle, max int) ([]pkcs11.ObjectHandle, bool, error) {
-	return []pkcs11.ObjectHandle{privateKeyHandle}, true, nil
+	for _, a := range currentSearch {
+		// We search private keys using CKA_LABEL
+		if a.Type == pkcs11.CKA_LABEL {
+			if a.Value[0] == 0x72 { // Label start with 'r'
+				return []pkcs11.ObjectHandle{rsaPrivateKeyHandle}, true, nil
+			} else if a.Value[0] == 0x65 { // Label start with 'e'
+				return []pkcs11.ObjectHandle{ecPrivateKeyHandle}, true, nil
+			}
+		}
+		// We search th EC public key using CKA_ID
+		if a.Type == pkcs11.CKA_ID {
+			return []pkcs11.ObjectHandle{ecPublicKeyHandle}, true, nil
+		}
+	}
+	return nil, false, nil
 }
 
-func (c mockCtx) GetAttributeValue(sh pkcs11.SessionHandle, o pkcs11.ObjectHandle, template []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
+func rsaPrivateAttributes(template []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
 	var output []*pkcs11.Attribute
 	for _, a := range template {
 		// Return simple values for these attributes. Note that a value of `1` for
@@ -51,8 +68,83 @@ func (c mockCtx) GetAttributeValue(sh pkcs11.SessionHandle, o pkcs11.ObjectHandl
 				Value: []byte{byte(1)},
 			})
 		}
+		if a.Type == pkcs11.CKA_KEY_TYPE {
+			output = append(output, &pkcs11.Attribute{
+				Type:  a.Type,
+				Value: []byte{byte(0)},
+			})
+		}
 	}
 	return output, nil
+}
+
+var ecOid = []byte{0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07}
+
+func ecPrivateAttributes(template []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
+	var output []*pkcs11.Attribute
+	for _, a := range template {
+		if a.Type == pkcs11.CKA_EC_PARAMS {
+			output = append(output, &pkcs11.Attribute{
+				Type:  a.Type,
+				Value: ecOid,
+			})
+		}
+		if a.Type == pkcs11.CKA_KEY_TYPE ||
+			a.Type == pkcs11.CKA_ID {
+			output = append(output, &pkcs11.Attribute{
+				Type:  a.Type,
+				Value: []byte{byte(3)},
+			})
+		}
+	}
+	return output, nil
+}
+
+var ecPoint = []byte{0x04, 0x41, 0x04, 0x4C, 0xD7, 0x7B, 0x7B, 0x2E,
+	0x3D, 0x57, 0x98, 0xB8, 0x2F, 0x99, 0xB4, 0x83,
+	0x99, 0xE6, 0xD4, 0x4C, 0x4F, 0xBC, 0x2D, 0x60,
+	0xCD, 0x08, 0x8E, 0x93, 0x65, 0x6F, 0x20, 0x51,
+	0x1C, 0xE7, 0xFD, 0x59, 0x34, 0xAA, 0xA9, 0x36,
+	0x26, 0xCE, 0x4A, 0xC5, 0xA2, 0x4A, 0x85, 0x6C,
+	0xB3, 0x95, 0xFF, 0x92, 0x0F, 0x56, 0x76, 0x34,
+	0x1F, 0x69, 0x52, 0x5F, 0x20, 0x83, 0x13, 0x50,
+	0xA3, 0xDE, 0xBE}
+
+func ecPublicAttributes(template []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
+	var output []*pkcs11.Attribute
+	for _, a := range template {
+		if a.Type == pkcs11.CKA_EC_PARAMS {
+			output = append(output, &pkcs11.Attribute{
+				Type:  a.Type,
+				Value: ecOid,
+			})
+		}
+		if a.Type == pkcs11.CKA_EC_POINT {
+			output = append(output, &pkcs11.Attribute{
+				Type:  a.Type,
+				Value: ecPoint,
+			})
+		}
+		if a.Type == pkcs11.CKA_KEY_TYPE ||
+			a.Type == pkcs11.CKA_ID {
+			output = append(output, &pkcs11.Attribute{
+				Type:  a.Type,
+				Value: []byte{byte(3)},
+			})
+		}
+	}
+	return output, nil
+}
+
+func (c mockCtx) GetAttributeValue(sh pkcs11.SessionHandle, o pkcs11.ObjectHandle, template []*pkcs11.Attribute) ([]*pkcs11.Attribute, error) {
+	if o == rsaPrivateKeyHandle {
+		return rsaPrivateAttributes(template)
+	} else if o == ecPrivateKeyHandle {
+		return ecPrivateAttributes(template)
+	} else if o == ecPublicKeyHandle {
+		return ecPublicAttributes(template)
+	}
+	return nil, nil
 }
 
 func (c mockCtx) GetSlotList(tokenPresent bool) ([]uint, error) {
@@ -93,27 +185,26 @@ func TestSetup(t *testing.T) {
 		tokenLabel: "token label",
 		pin:        "unused",
 	}
-	err := ps.setup("private key label")
+	err := ps.setup("rsa")
 	if err != nil {
 		t.Errorf("Failed to set up Key: %s", err)
 	}
 }
 
-func setup(t *testing.T) *Key {
+func setup(t *testing.T, label string) *Key {
 	ps := Key{
 		module:     mockCtx{},
 		tokenLabel: "token label",
 		pin:        "unused",
 	}
-	err := ps.setup("private key label")
+	err := ps.setup(label)
 	if err != nil {
 		t.Fatalf("Failed to set up Key: %s", err)
 	}
 	return &ps
 }
 
-func TestSign(t *testing.T) {
-	ps := setup(t)
+func sign(t *testing.T, ps *Key) {
 	// Sign input must be exactly 32 bytes to match SHA256 size. In normally
 	// usage, Sign would be called by e.g. x509.CreateCertificate, which would
 	// handle padding to the necessary size.
@@ -125,6 +216,14 @@ func TestSign(t *testing.T) {
 	if !bytes.Equal(output, []byte("some signed data")) {
 		t.Fatal("Incorrect sign output")
 	}
+}
+
+func TestSign(t *testing.T) {
+	ps := setup(t, "rsa")
+	sign(t, ps)
+
+	ps = setup(t, "ec")
+	sign(t, ps)
 }
 
 // This is a version of the mock that gives CKR_ATTRIBUTE_TYPE_INVALID when
@@ -148,7 +247,7 @@ func TestAttributeTypeInvalid(t *testing.T) {
 		tokenLabel: "token label",
 		pin:        "unused",
 	}
-	err := ps.setup("private key label")
+	err := ps.setup("rsa")
 	if err != nil {
 		t.Errorf("Failed to set up with a token that returns CKR_ATTRIBUTE_TYPE_INVALID: %s", err)
 	}

--- a/crypto/pkcs11key/key_test.go
+++ b/crypto/pkcs11key/key_test.go
@@ -23,16 +23,16 @@ const rsaPrivateKeyHandle = pkcs11.ObjectHandle(23)
 // Correct EC private key
 const ecPrivateKeyHandle = pkcs11.ObjectHandle(32)
 const ecPublicKeyHandle = pkcs11.ObjectHandle(33)
-const ecCorrectKeyId = byte(0x03)
+const ecCorrectKeyID = byte(0x03)
 
 // EC private key with no matching public key
 const ecPrivNoPubHandle = pkcs11.ObjectHandle(34)
-const ecPrivNoPubId = byte(0x4)
+const ecPrivNoPubID = byte(0x4)
 
 // EC private and public key with invalid EC point
 const ecInvEcPointPrivHandle = pkcs11.ObjectHandle(35)
 const ecInvEcPointPubHandle = pkcs11.ObjectHandle(36)
-const ecInvEcPointId = byte(0x5)
+const ecInvEcPointID = byte(0x5)
 
 var slots = []uint{7, 8, 9}
 var tokenInfo = pkcs11.TokenInfo{
@@ -71,9 +71,9 @@ func (c *mockCtx) FindObjects(sh pkcs11.SessionHandle, max int) ([]pkcs11.Object
 		// We search th EC public key using CKA_ID
 		if a.Type == pkcs11.CKA_ID {
 			switch a.Value[0] {
-			case ecCorrectKeyId:
+			case ecCorrectKeyID:
 				return []pkcs11.ObjectHandle{ecPublicKeyHandle}, true, nil
-			case ecInvEcPointId:
+			case ecInvEcPointID:
 				return []pkcs11.ObjectHandle{ecInvEcPointPubHandle}, true, nil
 			default:
 				return []pkcs11.ObjectHandle{}, true, nil
@@ -131,7 +131,7 @@ func ecCorrectKeyAttributes(template []*pkcs11.Attribute) ([]*pkcs11.Attribute, 
 		case pkcs11.CKA_KEY_TYPE:
 			output = append(output, p11Attribute(a.Type, []byte{byte(pkcs11.CKK_EC)}))
 		case pkcs11.CKA_ID:
-			output = append(output, p11Attribute(a.Type, []byte{byte(ecCorrectKeyId)}))
+			output = append(output, p11Attribute(a.Type, []byte{byte(ecCorrectKeyID)}))
 		}
 	}
 	return output, nil
@@ -146,7 +146,7 @@ func ecPrivNoPubAttributes(template []*pkcs11.Attribute) ([]*pkcs11.Attribute, e
 		case pkcs11.CKA_KEY_TYPE:
 			output = append(output, p11Attribute(a.Type, []byte{byte(pkcs11.CKK_EC)}))
 		case pkcs11.CKA_ID:
-			output = append(output, p11Attribute(a.Type, []byte{byte(ecPrivNoPubId)}))
+			output = append(output, p11Attribute(a.Type, []byte{byte(ecPrivNoPubID)}))
 		}
 	}
 	return output, nil
@@ -163,7 +163,7 @@ func ecInvalidEcPointAttributes(template []*pkcs11.Attribute) ([]*pkcs11.Attribu
 		case pkcs11.CKA_KEY_TYPE:
 			output = append(output, p11Attribute(a.Type, []byte{byte(pkcs11.CKK_EC)}))
 		case pkcs11.CKA_ID:
-			output = append(output, p11Attribute(a.Type, []byte{byte(ecInvEcPointId)}))
+			output = append(output, p11Attribute(a.Type, []byte{byte(ecInvEcPointID)}))
 		}
 	}
 	return output, nil


### PR DESCRIPTION
This submission adds support for ECDSA (P224, P256, P384, P521) for crypto.pkcs11.Key. This code was tested with a smart-card (P256) and a software token (other curves).
