### PR TITLE
Certificate Transparency support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ type SigningProfile struct {
 	NotAfter            time.Time  `json:"not_after"`
 	NameWhitelistString string     `json:"name_whitelist"`
 	AuthRemote          AuthRemote `json:"auth_remote"`
+	CTLog               string     `json:"ct_log"`
 
 	Policies                    []CertificatePolicy
 	Expiry                      time.Duration

--- a/config/config.go
+++ b/config/config.go
@@ -62,21 +62,21 @@ type AuthRemote struct {
 // A SigningProfile stores information that the CA needs to store
 // signature policy.
 type SigningProfile struct {
-	Usage                       []string   `json:"usages"`
-	IssuerURL                   []string   `json:"issuer_urls"`
-	OCSP                        string     `json:"ocsp_url"`
-	CRL                         string     `json:"crl_url"`
-	CA                          bool       `json:"is_ca"`
-	OCSPNoCheck                 bool       `json:"ocsp_no_check"`
-	ExpiryString                string     `json:"expiry"`
-	BackdateString              string     `json:"backdate"`
-	AuthKeyName                 string     `json:"auth_key"`
-	RemoteName                  string     `json:"remote"`
-	NotBefore                   time.Time  `json:"not_before"`
-	NotAfter                    time.Time  `json:"not_after"`
-	NameWhitelistString         string     `json:"name_whitelist"`
-	AuthRemote                  AuthRemote `json:"auth_remote"`
-	CTLogServers                []string   `json:"ct_log_servers"`
+	Usage               []string   `json:"usages"`
+	IssuerURL           []string   `json:"issuer_urls"`
+	OCSP                string     `json:"ocsp_url"`
+	CRL                 string     `json:"crl_url"`
+	CA                  bool       `json:"is_ca"`
+	OCSPNoCheck         bool       `json:"ocsp_no_check"`
+	ExpiryString        string     `json:"expiry"`
+	BackdateString      string     `json:"backdate"`
+	AuthKeyName         string     `json:"auth_key"`
+	RemoteName          string     `json:"remote"`
+	NotBefore           time.Time  `json:"not_before"`
+	NotAfter            time.Time  `json:"not_after"`
+	NameWhitelistString string     `json:"name_whitelist"`
+	AuthRemote          AuthRemote `json:"auth_remote"`
+	CTLogServers        []string   `json:"ct_log_servers"`
 
 	Policies                    []CertificatePolicy
 	Expiry                      time.Duration
@@ -91,10 +91,10 @@ type SigningProfile struct {
 
 // UnmarshalJSON unmarshals a JSON string into an OID.
 func (oid *OID) UnmarshalJSON(data []byte) (err error) {
-	if data[0] != '"' || data[len(data) - 1] != '"' {
+	if data[0] != '"' || data[len(data)-1] != '"' {
 		return errors.New("OID JSON string not wrapped in quotes." + string(data))
 	}
-	data = data[1 : len(data) - 1]
+	data = data[1 : len(data)-1]
 	parsedOid, err := parseObjectIdentifier(string(data))
 	if err != nil {
 		return err
@@ -487,7 +487,7 @@ type AuthKey struct {
 	Type string `json:"type"`
 	// Key contains the key information, such as a hex-encoded
 	// HMAC key.
-	Key  string `json:"key"`
+	Key string `json:"key"`
 }
 
 // DefaultConfig returns a default configuration specifying basic key
@@ -525,7 +525,7 @@ func LoadConfig(config []byte) (*Config, error) {
 	err := json.Unmarshal(config, &cfg)
 	if err != nil {
 		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
-			errors.New("failed to unmarshal configuration: " + err.Error()))
+			errors.New("failed to unmarshal configuration: "+err.Error()))
 	}
 
 	if cfg.Signing == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -62,21 +62,21 @@ type AuthRemote struct {
 // A SigningProfile stores information that the CA needs to store
 // signature policy.
 type SigningProfile struct {
-	Usage               []string   `json:"usages"`
-	IssuerURL           []string   `json:"issuer_urls"`
-	OCSP                string     `json:"ocsp_url"`
-	CRL                 string     `json:"crl_url"`
-	CA                  bool       `json:"is_ca"`
-	OCSPNoCheck         bool       `json:"ocsp_no_check"`
-	ExpiryString        string     `json:"expiry"`
-	BackdateString      string     `json:"backdate"`
-	AuthKeyName         string     `json:"auth_key"`
-	RemoteName          string     `json:"remote"`
-	NotBefore           time.Time  `json:"not_before"`
-	NotAfter            time.Time  `json:"not_after"`
-	NameWhitelistString string     `json:"name_whitelist"`
-	AuthRemote          AuthRemote `json:"auth_remote"`
-	CTLog               string     `json:"ct_log"`
+	Usage                       []string   `json:"usages"`
+	IssuerURL                   []string   `json:"issuer_urls"`
+	OCSP                        string     `json:"ocsp_url"`
+	CRL                         string     `json:"crl_url"`
+	CA                          bool       `json:"is_ca"`
+	OCSPNoCheck                 bool       `json:"ocsp_no_check"`
+	ExpiryString                string     `json:"expiry"`
+	BackdateString              string     `json:"backdate"`
+	AuthKeyName                 string     `json:"auth_key"`
+	RemoteName                  string     `json:"remote"`
+	NotBefore                   time.Time  `json:"not_before"`
+	NotAfter                    time.Time  `json:"not_after"`
+	NameWhitelistString         string     `json:"name_whitelist"`
+	AuthRemote                  AuthRemote `json:"auth_remote"`
+	CTLogServers                []string   `json:"ct_log_servers"`
 
 	Policies                    []CertificatePolicy
 	Expiry                      time.Duration
@@ -91,10 +91,10 @@ type SigningProfile struct {
 
 // UnmarshalJSON unmarshals a JSON string into an OID.
 func (oid *OID) UnmarshalJSON(data []byte) (err error) {
-	if data[0] != '"' || data[len(data)-1] != '"' {
+	if data[0] != '"' || data[len(data) - 1] != '"' {
 		return errors.New("OID JSON string not wrapped in quotes." + string(data))
 	}
-	data = data[1 : len(data)-1]
+	data = data[1 : len(data) - 1]
 	parsedOid, err := parseObjectIdentifier(string(data))
 	if err != nil {
 		return err
@@ -487,7 +487,7 @@ type AuthKey struct {
 	Type string `json:"type"`
 	// Key contains the key information, such as a hex-encoded
 	// HMAC key.
-	Key string `json:"key"`
+	Key  string `json:"key"`
 }
 
 // DefaultConfig returns a default configuration specifying basic key
@@ -525,7 +525,7 @@ func LoadConfig(config []byte) (*Config, error) {
 	err := json.Unmarshal(config, &cfg)
 	if err != nil {
 		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
-			errors.New("failed to unmarshal configuration: "+err.Error()))
+			errors.New("failed to unmarshal configuration: " + err.Error()))
 	}
 
 	if cfg.Signing == nil {

--- a/doc/errorcode.txt
+++ b/doc/errorcode.txt
@@ -26,4 +26,6 @@
     5100: NoKeyUsages
     5200: InvalidPolicy
     5300: InvalidRequest
-
+10XXX: CTError
+    10000: Unknown
+    10100: PrecertSubmissionFailed

--- a/errors/error.go
+++ b/errors/error.go
@@ -22,38 +22,38 @@ type Category int
 type Reason int
 
 const (
-// Success indicates no error occurred.
+	// Success indicates no error occurred.
 	Success Category = 1000 * iota // 0XXX
 
-// CertificateError indicates a fault in a certificate.
+	// CertificateError indicates a fault in a certificate.
 	CertificateError // 1XXX
 
-// PrivateKeyError indicates a fault in a private key.
+	// PrivateKeyError indicates a fault in a private key.
 	PrivateKeyError // 2XXX
 
-// IntermediatesError indicates a fault in an intermediate.
+	// IntermediatesError indicates a fault in an intermediate.
 	IntermediatesError // 3XXX
 
-// RootError indicates a fault in a root.
+	// RootError indicates a fault in a root.
 	RootError // 4XXX
 
-// PolicyError indicates an error arising from a malformed or
-// non-existent policy, or a breach of policy.
+	// PolicyError indicates an error arising from a malformed or
+	// non-existent policy, or a breach of policy.
 	PolicyError // 5XXX
 
-// DialError indicates a network fault.
+	// DialError indicates a network fault.
 	DialError // 6XXX
 
-// APIClientError indicates a problem with the API client.
+	// APIClientError indicates a problem with the API client.
 	APIClientError // 7XXX
 
-// OCSPError indicates a problem with OCSP signing
+	// OCSPError indicates a problem with OCSP signing
 	OCSPError // 8XXX
 
-// CSRError indicates a problem with CSR parsing
+	// CSRError indicates a problem with CSR parsing
 	CSRError // 9XXX
 
-// CTError indicates a problem with the certificate transparency process
+	// CTError indicates a problem with the certificate transparency process
 	CTError // 10XXX
 )
 
@@ -79,21 +79,21 @@ const (
 // The following represent certificate non-parsing errors, and must be
 // specified along with CertificateError.
 const (
-// SelfSigned indicates that a certificate is self-signed and
-// cannot be used in the manner being attempted.
+	// SelfSigned indicates that a certificate is self-signed and
+	// cannot be used in the manner being attempted.
 	SelfSigned Reason = 100 * (iota + 1) // Code 11XX
 
-// VerifyFailed is an X.509 verification failure. The least two
-// significant digits of 12XX is determined as the actual x509
-// error is examined.
+	// VerifyFailed is an X.509 verification failure. The least two
+	// significant digits of 12XX is determined as the actual x509
+	// error is examined.
 	VerifyFailed // Code 12XX
 
-// BadRequest indicates that the certificate request is invalid.
+	// BadRequest indicates that the certificate request is invalid.
 	BadRequest // Code 13XX
 
-// MissingSerial indicates that the profile specified
-// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
-// number.
+	// MissingSerial indicates that the profile specified
+	// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
+	// number.
 	MissingSerial // Code 14XX
 )
 
@@ -105,77 +105,84 @@ const (
 // The following represent private-key non-parsing errors, and must be
 // specified with PrivateKeyError.
 const (
-// Encrypted indicates that the private key is a PKCS #8 encrypted
-// private key. At this time, CFSSL does not support decrypting
-// these keys.
+	// Encrypted indicates that the private key is a PKCS #8 encrypted
+	// private key. At this time, CFSSL does not support decrypting
+	// these keys.
 	Encrypted Reason = 100 * (iota + 1) //21XX
 
-// NotRSAOrECC indicates that they key is not an RSA or ECC
-// private key; these are the only two private key types supported
-// at this time by CFSSL.
+	// NotRSAOrECC indicates that they key is not an RSA or ECC
+	// private key; these are the only two private key types supported
+	// at this time by CFSSL.
 	NotRSAOrECC //22XX
 
-// KeyMismatch indicates that the private key does not match
-// the public key or certificate being presented with the key.
+	// KeyMismatch indicates that the private key does not match
+	// the public key or certificate being presented with the key.
 	KeyMismatch //23XX
 
-// GenerationFailed indicates that a private key could not
-// be generated.
+	// GenerationFailed indicates that a private key could not
+	// be generated.
 	GenerationFailed //24XX
 
-// Unavailable indicates that a private key mechanism (such as
-// PKCS #11) was requested but support for that mechanism is
-// not available.
+	// Unavailable indicates that a private key mechanism (such as
+	// PKCS #11) was requested but support for that mechanism is
+	// not available.
 	Unavailable
 )
 
 // The following are policy-related non-parsing errors, and must be
 // specified along with PolicyError.
 const (
-// NoKeyUsages indicates that the profile does not permit any
-// key usages for the certificate.
+	// NoKeyUsages indicates that the profile does not permit any
+	// key usages for the certificate.
 	NoKeyUsages Reason = 100 * (iota + 1) // 51XX
 
-// InvalidPolicy indicates that policy being requested is not
-// a valid policy or does not exist.
+	// InvalidPolicy indicates that policy being requested is not
+	// a valid policy or does not exist.
 	InvalidPolicy // 52XX
 
-// InvalidRequest indicates a certificate request violated the
-// constraints of the policy being applied to the request.
+	// InvalidRequest indicates a certificate request violated the
+	// constraints of the policy being applied to the request.
 	InvalidRequest // 53XX
 )
 
 // The following are API client related errors, and should be
 // specified with APIClientError.
 const (
-// AuthenticationFailure occurs when the client is unable
-// to obtain an authentication token for the request.
+	// AuthenticationFailure occurs when the client is unable
+	// to obtain an authentication token for the request.
 	AuthenticationFailure Reason = 100 * (iota + 1)
 
-// JSONError wraps an encoding/json error.
+	// JSONError wraps an encoding/json error.
 	JSONError
 
-// IOError wraps an io/ioutil error.
+	// IOError wraps an io/ioutil error.
 	IOError
 
-// ClientHTTPError wraps a net/http error.
+	// ClientHTTPError wraps a net/http error.
 	ClientHTTPError
 
-// ServerRequestFailed covers any other failures from the API
-// client.
+	// ServerRequestFailed covers any other failures from the API
+	// client.
 	ServerRequestFailed
 )
 
 // The following are OCSP related errors, and should be
 // specified with OCSPError
 const (
-// IssuerMismatch ocurs when the certificate in the OCSP signing
-// request was not issued by the CA that this responder responds for.
+	// IssuerMismatch ocurs when the certificate in the OCSP signing
+	// request was not issued by the CA that this responder responds for.
 	IssuerMismatch Reason = 100 * (iota + 1) // 81XX
 
-// InvalidStatus occurs when the OCSP signing requests includes an
-// invalid value for the certificate status.
+	// InvalidStatus occurs when the OCSP signing requests includes an
+	// invalid value for the certificate status.
 	InvalidStatus
+)
+
+// Certificate transparency related errors specified with CTError
+const (
+	// PrecertSubmissionFailed occurs when submitting a precertificate to
+	// a log server fails
+	PrecertSubmissionFailed = 100 * (iota + 1)
 )
 
 // The error interface implementation, which formats to a JSON object string.
@@ -336,6 +343,8 @@ func New(category Category, reason Reason) *Error {
 		switch reason {
 		case Unknown:
 			msg = "Certificate transparency parsing failed due to unknown error"
+		case PrecertSubmissionFailed:
+			msg = "Certificate transparency precertificate submission failed"
 		default:
 			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category CTError.", reason))
 		}

--- a/errors/error.go
+++ b/errors/error.go
@@ -22,38 +22,38 @@ type Category int
 type Reason int
 
 const (
-	// Success indicates no error occurred.
+// Success indicates no error occurred.
 	Success Category = 1000 * iota // 0XXX
 
-	// CertificateError indicates a fault in a certificate.
+// CertificateError indicates a fault in a certificate.
 	CertificateError // 1XXX
 
-	// PrivateKeyError indicates a fault in a private key.
+// PrivateKeyError indicates a fault in a private key.
 	PrivateKeyError // 2XXX
 
-	// IntermediatesError indicates a fault in an intermediate.
+// IntermediatesError indicates a fault in an intermediate.
 	IntermediatesError // 3XXX
 
-	// RootError indicates a fault in a root.
+// RootError indicates a fault in a root.
 	RootError // 4XXX
 
-	// PolicyError indicates an error arising from a malformed or
-	// non-existent policy, or a breach of policy.
+// PolicyError indicates an error arising from a malformed or
+// non-existent policy, or a breach of policy.
 	PolicyError // 5XXX
 
-	// DialError indicates a network fault.
+// DialError indicates a network fault.
 	DialError // 6XXX
 
-	// APIClientError indicates a problem with the API client.
+// APIClientError indicates a problem with the API client.
 	APIClientError // 7XXX
 
-	// OCSPError indicates a problem with OCSP signing
+// OCSPError indicates a problem with OCSP signing
 	OCSPError // 8XXX
 
-	// CSRError indicates a problem with CSR parsing
+// CSRError indicates a problem with CSR parsing
 	CSRError // 9XXX
 
-	// CTError indicates a problem with the certificate transparency process
+// CTError indicates a problem with the certificate transparency process
 	CTError // 10XXX
 )
 
@@ -79,21 +79,21 @@ const (
 // The following represent certificate non-parsing errors, and must be
 // specified along with CertificateError.
 const (
-	// SelfSigned indicates that a certificate is self-signed and
-	// cannot be used in the manner being attempted.
+// SelfSigned indicates that a certificate is self-signed and
+// cannot be used in the manner being attempted.
 	SelfSigned Reason = 100 * (iota + 1) // Code 11XX
 
-	// VerifyFailed is an X.509 verification failure. The least two
-	// significant digits of 12XX is determined as the actual x509
-	// error is examined.
+// VerifyFailed is an X.509 verification failure. The least two
+// significant digits of 12XX is determined as the actual x509
+// error is examined.
 	VerifyFailed // Code 12XX
 
-	// BadRequest indicates that the certificate request is invalid.
+// BadRequest indicates that the certificate request is invalid.
 	BadRequest // Code 13XX
 
-	// MissingSerial indicates that the profile specified
-	// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
-	// number.
+// MissingSerial indicates that the profile specified
+// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
+// number.
 	MissingSerial // Code 14XX
 )
 
@@ -105,76 +105,76 @@ const (
 // The following represent private-key non-parsing errors, and must be
 // specified with PrivateKeyError.
 const (
-	// Encrypted indicates that the private key is a PKCS #8 encrypted
-	// private key. At this time, CFSSL does not support decrypting
-	// these keys.
+// Encrypted indicates that the private key is a PKCS #8 encrypted
+// private key. At this time, CFSSL does not support decrypting
+// these keys.
 	Encrypted Reason = 100 * (iota + 1) //21XX
 
-	// NotRSAOrECC indicates that they key is not an RSA or ECC
-	// private key; these are the only two private key types supported
-	// at this time by CFSSL.
+// NotRSAOrECC indicates that they key is not an RSA or ECC
+// private key; these are the only two private key types supported
+// at this time by CFSSL.
 	NotRSAOrECC //22XX
 
-	// KeyMismatch indicates that the private key does not match
-	// the public key or certificate being presented with the key.
+// KeyMismatch indicates that the private key does not match
+// the public key or certificate being presented with the key.
 	KeyMismatch //23XX
 
-	// GenerationFailed indicates that a private key could not
-	// be generated.
+// GenerationFailed indicates that a private key could not
+// be generated.
 	GenerationFailed //24XX
 
-	// Unavailable indicates that a private key mechanism (such as
-	// PKCS #11) was requested but support for that mechanism is
-	// not available.
+// Unavailable indicates that a private key mechanism (such as
+// PKCS #11) was requested but support for that mechanism is
+// not available.
 	Unavailable
 )
 
 // The following are policy-related non-parsing errors, and must be
 // specified along with PolicyError.
 const (
-	// NoKeyUsages indicates that the profile does not permit any
-	// key usages for the certificate.
+// NoKeyUsages indicates that the profile does not permit any
+// key usages for the certificate.
 	NoKeyUsages Reason = 100 * (iota + 1) // 51XX
 
-	// InvalidPolicy indicates that policy being requested is not
-	// a valid policy or does not exist.
+// InvalidPolicy indicates that policy being requested is not
+// a valid policy or does not exist.
 	InvalidPolicy // 52XX
 
-	// InvalidRequest indicates a certificate request violated the
-	// constraints of the policy being applied to the request.
+// InvalidRequest indicates a certificate request violated the
+// constraints of the policy being applied to the request.
 	InvalidRequest // 53XX
 )
 
 // The following are API client related errors, and should be
 // specified with APIClientError.
 const (
-	// AuthenticationFailure occurs when the client is unable
-	// to obtain an authentication token for the request.
+// AuthenticationFailure occurs when the client is unable
+// to obtain an authentication token for the request.
 	AuthenticationFailure Reason = 100 * (iota + 1)
 
-	// JSONError wraps an encoding/json error.
+// JSONError wraps an encoding/json error.
 	JSONError
 
-	// IOError wraps an io/ioutil error.
+// IOError wraps an io/ioutil error.
 	IOError
 
-	// ClientHTTPError wraps a net/http error.
+// ClientHTTPError wraps a net/http error.
 	ClientHTTPError
 
-	// ServerRequestFailed covers any other failures from the API
-	// client.
+// ServerRequestFailed covers any other failures from the API
+// client.
 	ServerRequestFailed
 )
 
 // The following are OCSP related errors, and should be
 // specified with OCSPError
 const (
-	// IssuerMismatch ocurs when the certificate in the OCSP signing
-	// request was not issued by the CA that this responder responds for.
+// IssuerMismatch ocurs when the certificate in the OCSP signing
+// request was not issued by the CA that this responder responds for.
 	IssuerMismatch Reason = 100 * (iota + 1) // 81XX
 
-	// InvalidStatus occurs when the OCSP signing requests includes an
-	// invalid value for the certificate status.
+// InvalidStatus occurs when the OCSP signing requests includes an
+// invalid value for the certificate status.
 	InvalidStatus
 )
 
@@ -337,7 +337,7 @@ func New(category Category, reason Reason) *Error {
 		case Unknown:
 			msg = "Certificate transparency parsing failed due to unknown error"
 		default:
-			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category APIClientError.", reason))
+			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category CTError.", reason))
 		}
 
 	default:

--- a/errors/error.go
+++ b/errors/error.go
@@ -22,36 +22,39 @@ type Category int
 type Reason int
 
 const (
-	// Success indicates no error occurred.
+// Success indicates no error occurred.
 	Success Category = 1000 * iota // 0XXX
 
-	// CertificateError indicates a fault in a certificate.
+// CertificateError indicates a fault in a certificate.
 	CertificateError // 1XXX
 
-	// PrivateKeyError indicates a fault in a private key.
+// PrivateKeyError indicates a fault in a private key.
 	PrivateKeyError // 2XXX
 
-	// IntermediatesError indicates a fault in an intermediate.
+// IntermediatesError indicates a fault in an intermediate.
 	IntermediatesError // 3XXX
 
-	// RootError indicates a fault in a root.
+// RootError indicates a fault in a root.
 	RootError // 4XXX
 
-	// PolicyError indicates an error arising from a malformed or
-	// non-existent policy, or a breach of policy.
+// PolicyError indicates an error arising from a malformed or
+// non-existent policy, or a breach of policy.
 	PolicyError // 5XXX
 
-	// DialError indicates a network fault.
+// DialError indicates a network fault.
 	DialError // 6XXX
 
-	// APIClientError indicates a problem with the API client.
+// APIClientError indicates a problem with the API client.
 	APIClientError // 7XXX
 
-	// OCSPError indicates a problem with OCSP signing
+// OCSPError indicates a problem with OCSP signing
 	OCSPError // 8XXX
 
-	// CSRError indicates a problem with CSR parsing
+// CSRError indicates a problem with CSR parsing
 	CSRError // 9XXX
+
+// CTError indicates a problem with the certificate transparency process
+	CTError // 10XXX
 )
 
 // None is a non-specified error.
@@ -76,21 +79,21 @@ const (
 // The following represent certificate non-parsing errors, and must be
 // specified along with CertificateError.
 const (
-	// SelfSigned indicates that a certificate is self-signed and
-	// cannot be used in the manner being attempted.
+// SelfSigned indicates that a certificate is self-signed and
+// cannot be used in the manner being attempted.
 	SelfSigned Reason = 100 * (iota + 1) // Code 11XX
 
-	// VerifyFailed is an X.509 verification failure. The least two
-	// significant digits of 12XX is determined as the actual x509
-	// error is examined.
+// VerifyFailed is an X.509 verification failure. The least two
+// significant digits of 12XX is determined as the actual x509
+// error is examined.
 	VerifyFailed // Code 12XX
 
-	// BadRequest indicates that the certificate request is invalid.
+// BadRequest indicates that the certificate request is invalid.
 	BadRequest // Code 13XX
 
-	// MissingSerial indicates that the profile specified
-	// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
-	// number.
+// MissingSerial indicates that the profile specified
+// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
+// number.
 	MissingSerial // Code 14XX
 )
 
@@ -102,76 +105,76 @@ const (
 // The following represent private-key non-parsing errors, and must be
 // specified with PrivateKeyError.
 const (
-	// Encrypted indicates that the private key is a PKCS #8 encrypted
-	// private key. At this time, CFSSL does not support decrypting
-	// these keys.
+// Encrypted indicates that the private key is a PKCS #8 encrypted
+// private key. At this time, CFSSL does not support decrypting
+// these keys.
 	Encrypted Reason = 100 * (iota + 1) //21XX
 
-	// NotRSAOrECC indicates that they key is not an RSA or ECC
-	// private key; these are the only two private key types supported
-	// at this time by CFSSL.
+// NotRSAOrECC indicates that they key is not an RSA or ECC
+// private key; these are the only two private key types supported
+// at this time by CFSSL.
 	NotRSAOrECC //22XX
 
-	// KeyMismatch indicates that the private key does not match
-	// the public key or certificate being presented with the key.
+// KeyMismatch indicates that the private key does not match
+// the public key or certificate being presented with the key.
 	KeyMismatch //23XX
 
-	// GenerationFailed indicates that a private key could not
-	// be generated.
+// GenerationFailed indicates that a private key could not
+// be generated.
 	GenerationFailed //24XX
 
-	// Unavailable indicates that a private key mechanism (such as
-	// PKCS #11) was requested but support for that mechanism is
-	// not available.
+// Unavailable indicates that a private key mechanism (such as
+// PKCS #11) was requested but support for that mechanism is
+// not available.
 	Unavailable
 )
 
 // The following are policy-related non-parsing errors, and must be
 // specified along with PolicyError.
 const (
-	// NoKeyUsages indicates that the profile does not permit any
-	// key usages for the certificate.
+// NoKeyUsages indicates that the profile does not permit any
+// key usages for the certificate.
 	NoKeyUsages Reason = 100 * (iota + 1) // 51XX
 
-	// InvalidPolicy indicates that policy being requested is not
-	// a valid policy or does not exist.
+// InvalidPolicy indicates that policy being requested is not
+// a valid policy or does not exist.
 	InvalidPolicy // 52XX
 
-	// InvalidRequest indicates a certificate request violated the
-	// constraints of the policy being applied to the request.
+// InvalidRequest indicates a certificate request violated the
+// constraints of the policy being applied to the request.
 	InvalidRequest // 53XX
 )
 
 // The following are API client related errors, and should be
 // specified with APIClientError.
 const (
-	// AuthenticationFailure occurs when the client is unable
-	// to obtain an authentication token for the request.
+// AuthenticationFailure occurs when the client is unable
+// to obtain an authentication token for the request.
 	AuthenticationFailure Reason = 100 * (iota + 1)
 
-	// JSONError wraps an encoding/json error.
+// JSONError wraps an encoding/json error.
 	JSONError
 
-	// IOError wraps an io/ioutil error.
+// IOError wraps an io/ioutil error.
 	IOError
 
-	// ClientHTTPError wraps a net/http error.
+// ClientHTTPError wraps a net/http error.
 	ClientHTTPError
 
-	// ServerRequestFailed covers any other failures from the API
-	// client.
+// ServerRequestFailed covers any other failures from the API
+// client.
 	ServerRequestFailed
 )
 
 // The following are OCSP related errors, and should be
 // specified with OCSPError
 const (
-	// IssuerMismatch ocurs when the certificate in the OCSP signing
-	// request was not issued by the CA that this responder responds for.
+// IssuerMismatch ocurs when the certificate in the OCSP signing
+// request was not issued by the CA that this responder responds for.
 	IssuerMismatch Reason = 100 * (iota + 1) // 81XX
 
-	// InvalidStatus occurs when the OCSP signing requests includes an
-	// invalid value for the certificate status.
+// InvalidStatus occurs when the OCSP signing requests includes an
+// invalid value for the certificate status.
 	InvalidStatus
 )
 
@@ -329,6 +332,13 @@ func New(category Category, reason Reason) *Error {
 		default:
 			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category APIClientError.", reason))
 		}
+	case CTError:
+		switch reason {
+		case Unknown:
+			msg = "Certificate transparency parsing failed due to unknown error"
+		default:
+			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category APIClientError.", reason))
+		}
 
 	default:
 		panic(fmt.Sprintf("Unsupported CFSSL error type: %d.",
@@ -364,8 +374,8 @@ func Wrap(category Category, reason Reason, err error) *Error {
 				errorCode += unknownAuthority
 			}
 		}
-	case PrivateKeyError, IntermediatesError, RootError, PolicyError, DialError, APIClientError, CSRError:
-		// no-op, just use the error
+	case PrivateKeyError, IntermediatesError, RootError, PolicyError, DialError, APIClientError, CSRError, CTError:
+	// no-op, just use the error
 	default:
 		panic(fmt.Sprintf("Unsupported CFSSL error type: %d.",
 			category))

--- a/errors/error.go
+++ b/errors/error.go
@@ -22,38 +22,38 @@ type Category int
 type Reason int
 
 const (
-// Success indicates no error occurred.
+	// Success indicates no error occurred.
 	Success Category = 1000 * iota // 0XXX
 
-// CertificateError indicates a fault in a certificate.
+	// CertificateError indicates a fault in a certificate.
 	CertificateError // 1XXX
 
-// PrivateKeyError indicates a fault in a private key.
+	// PrivateKeyError indicates a fault in a private key.
 	PrivateKeyError // 2XXX
 
-// IntermediatesError indicates a fault in an intermediate.
+	// IntermediatesError indicates a fault in an intermediate.
 	IntermediatesError // 3XXX
 
-// RootError indicates a fault in a root.
+	// RootError indicates a fault in a root.
 	RootError // 4XXX
 
-// PolicyError indicates an error arising from a malformed or
-// non-existent policy, or a breach of policy.
+	// PolicyError indicates an error arising from a malformed or
+	// non-existent policy, or a breach of policy.
 	PolicyError // 5XXX
 
-// DialError indicates a network fault.
+	// DialError indicates a network fault.
 	DialError // 6XXX
 
-// APIClientError indicates a problem with the API client.
+	// APIClientError indicates a problem with the API client.
 	APIClientError // 7XXX
 
-// OCSPError indicates a problem with OCSP signing
+	// OCSPError indicates a problem with OCSP signing
 	OCSPError // 8XXX
 
-// CSRError indicates a problem with CSR parsing
+	// CSRError indicates a problem with CSR parsing
 	CSRError // 9XXX
 
-// CTError indicates a problem with the certificate transparency process
+	// CTError indicates a problem with the certificate transparency process
 	CTError // 10XXX
 )
 
@@ -79,21 +79,21 @@ const (
 // The following represent certificate non-parsing errors, and must be
 // specified along with CertificateError.
 const (
-// SelfSigned indicates that a certificate is self-signed and
-// cannot be used in the manner being attempted.
+	// SelfSigned indicates that a certificate is self-signed and
+	// cannot be used in the manner being attempted.
 	SelfSigned Reason = 100 * (iota + 1) // Code 11XX
 
-// VerifyFailed is an X.509 verification failure. The least two
-// significant digits of 12XX is determined as the actual x509
-// error is examined.
+	// VerifyFailed is an X.509 verification failure. The least two
+	// significant digits of 12XX is determined as the actual x509
+	// error is examined.
 	VerifyFailed // Code 12XX
 
-// BadRequest indicates that the certificate request is invalid.
+	// BadRequest indicates that the certificate request is invalid.
 	BadRequest // Code 13XX
 
-// MissingSerial indicates that the profile specified
-// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
-// number.
+	// MissingSerial indicates that the profile specified
+	// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
+	// number.
 	MissingSerial // Code 14XX
 )
 
@@ -105,76 +105,76 @@ const (
 // The following represent private-key non-parsing errors, and must be
 // specified with PrivateKeyError.
 const (
-// Encrypted indicates that the private key is a PKCS #8 encrypted
-// private key. At this time, CFSSL does not support decrypting
-// these keys.
+	// Encrypted indicates that the private key is a PKCS #8 encrypted
+	// private key. At this time, CFSSL does not support decrypting
+	// these keys.
 	Encrypted Reason = 100 * (iota + 1) //21XX
 
-// NotRSAOrECC indicates that they key is not an RSA or ECC
-// private key; these are the only two private key types supported
-// at this time by CFSSL.
+	// NotRSAOrECC indicates that they key is not an RSA or ECC
+	// private key; these are the only two private key types supported
+	// at this time by CFSSL.
 	NotRSAOrECC //22XX
 
-// KeyMismatch indicates that the private key does not match
-// the public key or certificate being presented with the key.
+	// KeyMismatch indicates that the private key does not match
+	// the public key or certificate being presented with the key.
 	KeyMismatch //23XX
 
-// GenerationFailed indicates that a private key could not
-// be generated.
+	// GenerationFailed indicates that a private key could not
+	// be generated.
 	GenerationFailed //24XX
 
-// Unavailable indicates that a private key mechanism (such as
-// PKCS #11) was requested but support for that mechanism is
-// not available.
+	// Unavailable indicates that a private key mechanism (such as
+	// PKCS #11) was requested but support for that mechanism is
+	// not available.
 	Unavailable
 )
 
 // The following are policy-related non-parsing errors, and must be
 // specified along with PolicyError.
 const (
-// NoKeyUsages indicates that the profile does not permit any
-// key usages for the certificate.
+	// NoKeyUsages indicates that the profile does not permit any
+	// key usages for the certificate.
 	NoKeyUsages Reason = 100 * (iota + 1) // 51XX
 
-// InvalidPolicy indicates that policy being requested is not
-// a valid policy or does not exist.
+	// InvalidPolicy indicates that policy being requested is not
+	// a valid policy or does not exist.
 	InvalidPolicy // 52XX
 
-// InvalidRequest indicates a certificate request violated the
-// constraints of the policy being applied to the request.
+	// InvalidRequest indicates a certificate request violated the
+	// constraints of the policy being applied to the request.
 	InvalidRequest // 53XX
 )
 
 // The following are API client related errors, and should be
 // specified with APIClientError.
 const (
-// AuthenticationFailure occurs when the client is unable
-// to obtain an authentication token for the request.
+	// AuthenticationFailure occurs when the client is unable
+	// to obtain an authentication token for the request.
 	AuthenticationFailure Reason = 100 * (iota + 1)
 
-// JSONError wraps an encoding/json error.
+	// JSONError wraps an encoding/json error.
 	JSONError
 
-// IOError wraps an io/ioutil error.
+	// IOError wraps an io/ioutil error.
 	IOError
 
-// ClientHTTPError wraps a net/http error.
+	// ClientHTTPError wraps a net/http error.
 	ClientHTTPError
 
-// ServerRequestFailed covers any other failures from the API
-// client.
+	// ServerRequestFailed covers any other failures from the API
+	// client.
 	ServerRequestFailed
 )
 
 // The following are OCSP related errors, and should be
 // specified with OCSPError
 const (
-// IssuerMismatch ocurs when the certificate in the OCSP signing
-// request was not issued by the CA that this responder responds for.
+	// IssuerMismatch ocurs when the certificate in the OCSP signing
+	// request was not issued by the CA that this responder responds for.
 	IssuerMismatch Reason = 100 * (iota + 1) // 81XX
 
-// InvalidStatus occurs when the OCSP signing requests includes an
-// invalid value for the certificate status.
+	// InvalidStatus occurs when the OCSP signing requests includes an
+	// invalid value for the certificate status.
 	InvalidStatus
 )
 

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -62,7 +62,7 @@ func NewSigner(priv crypto.Signer, cert *x509.Certificate, sigAlgo x509.Signatur
 
 // NewSignerFromFile generates a new local signer from a caFile
 // and a caKey file, both PEM encoded.
-func  NewSignerFromFile(caFile, caKeyFile string, policy *config.Signing) (*Signer, error) {
+func NewSignerFromFile(caFile, caKeyFile string, policy *config.Signing) (*Signer, error) {
 	log.Debug("Loading CA: ", caFile)
 	ca, err := ioutil.ReadFile(caFile)
 	if err != nil {

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -260,7 +260,7 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 	cert, err = s.sign(&safeTemplate, profile)
 
 	if err != nil {
-		return nil, err
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.Unknown, err)
 	}
 
 	derCert, _ := pem.Decode(cert)
@@ -270,7 +270,7 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 		var ctclient = client.New(server)
 		_, err = ctclient.AddChain(chain)
 		if err != nil {
-			return nil, err
+			return nil, cferr.Wrap(cferr.CTError, cferr.Unknown, err)
 		}
 	}
 

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -259,11 +259,16 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 
 	cert, err = s.sign(&safeTemplate, profile)
 
-	if profile.CTLog != "" {
-		var derCert, _ = pem.Decode(cert)
-		var ctclient = client.New(profile.CTLog)
-		chain := []ct.ASN1Cert{derCert.Bytes, s.ca.Raw}
-		var _, err = ctclient.AddChain(chain)
+	if err != nil {
+		return nil, err
+	}
+
+	derCert, _ := pem.Decode(cert)
+	chain := []ct.ASN1Cert{derCert.Bytes, s.ca.Raw}
+
+	for _, server := range profile.CTLogServers {
+		var ctclient = client.New(server)
+		_, err = ctclient.AddChain(chain)
 		if err != nil {
 			return nil, err
 		}

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -311,6 +311,14 @@ var (
 	// iso(1) identified-organization(3) dod(6) internet(1) security(5)
 	//   mechanisms(5) pkix(7) id-qt(2) id-qt-unotice(2)
 	iDQTUserNotice = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
+
+	// CTPoisonOID is the object ID of the critical poison extension for precertificates
+	// https://tools.ietf.org/html/rfc6962#page-9
+	CTPoisonOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
+
+	// SCTListOID is the object ID for the Signed Certificate Timestamp certificate extension
+	// https://tools.ietf.org/html/rfc6962#page-14
+	SCTListOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}
 )
 
 // addPolicies adds Certificate Policies and optional Policy Qualifiers to a


### PR DESCRIPTION
Add a config field "ct-log" to specify the URL of a CT log server

cfssl sign will submit a poisoned certificate to each CT log server 
and embed the resulting SCTs in the certificate before returning 
the certificate to the client. The signing operation will fail if any 
of the CT log servers reject the certificate.