### PR TITLE
Add universal signer

### DIFF
--- a/api/sign/sign.go
+++ b/api/sign/sign.go
@@ -2,27 +2,13 @@
 package sign
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"math/big"
 	"net/http"
 
-	"github.com/cloudflare/cfssl/api"
-	"github.com/cloudflare/cfssl/auth"
+	"github.com/cloudflare/cfssl/api/signhandler"
 	"github.com/cloudflare/cfssl/config"
-	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
-	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/universal"
 )
-
-// A Handler accepts requests with a hostname and certficate
-// parameter (which should be PEM-encoded) and returns a new signed
-// certificate. It includes upstream servers indexed by their
-// profile name.
-type Handler struct {
-	signer signer.Signer
-}
 
 // NewHandler generates a new Handler using the certificate
 // authority private key and certficate to sign certificates. If remote
@@ -41,133 +27,7 @@ func NewHandler(caFile, caKeyFile string, policy *config.Signing) (http.Handler,
 		return nil, err
 	}
 
-	return NewHandlerFromSigner(s)
-}
-
-// NewHandlerFromSigner generates a new Handler directly from
-// an existing signer.
-func NewHandlerFromSigner(signer signer.Signer) (h *api.HTTPHandler, err error) {
-	policy := signer.Policy()
-	if policy == nil {
-		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
-		return
-	}
-
-	// Sign will only respond for profiles that have no auth provider.
-	// So if all of the profiles require authentication, we return an error.
-	haveUnauth := (policy.Default.Provider == nil)
-	for _, profile := range policy.Profiles {
-		haveUnauth = haveUnauth || (profile.Provider == nil)
-	}
-
-	if !haveUnauth {
-		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
-		return
-	}
-
-	return &api.HTTPHandler{
-		Handler: &Handler{
-			signer: signer,
-		},
-		Methods: []string{"POST"},
-	}, nil
-}
-
-// This type is meant to be unmarshalled from JSON so that there can be a
-// hostname field in the API
-// TODO: Change the API such that the normal struct can be used.
-type jsonSignRequest struct {
-	Hostname string          `json:"hostname"`
-	Hosts    []string        `json:"hosts"`
-	Request  string          `json:"certificate_request"`
-	Subject  *signer.Subject `json:"subject,omitempty"`
-	Profile  string          `json:"profile"`
-	Label    string          `json:"label"`
-	Serial   *big.Int        `json:"serial,omitempty"`
-}
-
-func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
-	sub := new(signer.Subject)
-	if js.Subject == nil {
-		sub = nil
-	} else {
-		// make a copy
-		*sub = *js.Subject
-	}
-
-	if js.Hostname != "" {
-		return signer.SignRequest{
-			Hosts:   signer.SplitHosts(js.Hostname),
-			Subject: sub,
-			Request: js.Request,
-			Profile: js.Profile,
-			Label:   js.Label,
-			Serial:  js.Serial,
-		}
-	}
-
-	return signer.SignRequest{
-		Hosts:   js.Hosts,
-		Subject: sub,
-		Request: js.Request,
-		Profile: js.Profile,
-		Label:   js.Label,
-		Serial:  js.Serial,
-	}
-}
-
-// Handle responds to requests for the CA to sign the certificate request
-// present in the "certificate_request" parameter for the host named
-// in the "hostname" parameter. The certificate should be PEM-encoded. If
-// provided, subject information from the "subject" parameter will be used
-// in place of the subject information from the CSR.
-func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
-	log.Info("signature request received")
-
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	r.Body.Close()
-
-	var req jsonSignRequest
-
-	err = json.Unmarshal(body, &req)
-	if err != nil {
-		return errors.NewBadRequestString("Unable to parse sign request")
-	}
-
-	signReq := jsonReqToTrue(req)
-
-	if req.Request == "" {
-		return errors.NewBadRequestString("missing parameter 'certificate_request'")
-	}
-
-	var cert []byte
-	profile, err := signer.Profile(h.signer, req.Profile)
-	if err != nil {
-		return err
-	}
-
-	if profile.Provider != nil {
-		log.Error("profile requires authentication")
-		return errors.NewBadRequestString("authentication required")
-	}
-
-	cert, err = h.signer.Sign(signReq)
-	if err != nil {
-		log.Warningf("failed to sign request: %v", err)
-		return err
-	}
-
-	result := map[string]string{"certificate": string(cert)}
-	log.Info("wrote response")
-	return api.SendResponse(w, result)
-}
-
-// An AuthHandler verifies and signs incoming signature requests.
-type AuthHandler struct {
-	signer signer.Signer
+	return signhandler.NewHandlerFromSigner(s)
 }
 
 // NewAuthHandler generates a new AuthHandler using the certificate
@@ -187,105 +47,5 @@ func NewAuthHandler(caFile, caKeyFile string, policy *config.Signing) (http.Hand
 		return nil, err
 	}
 
-	return NewAuthHandlerFromSigner(s)
-}
-
-// NewAuthHandlerFromSigner creates a new AuthHandler from the signer
-// that is passed in.
-func NewAuthHandlerFromSigner(signer signer.Signer) (http.Handler, error) {
-	policy := signer.Policy()
-	if policy == nil {
-		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
-	}
-
-	if policy.Default == nil && policy.Profiles == nil {
-		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
-	}
-
-	// AuthSign will not respond for profiles that have no auth provider.
-	// So if there are no profiles with auth providers in this policy,
-	// we return an error.
-	haveAuth := (policy.Default.Provider != nil)
-	for _, profile := range policy.Profiles {
-		if haveAuth {
-			break
-		}
-		haveAuth = (profile.Provider != nil)
-	}
-
-	if !haveAuth {
-		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
-	}
-
-	return &api.HTTPHandler{
-		Handler: &AuthHandler{
-			signer: signer,
-		},
-		Methods: []string{"POST"},
-	}, nil
-}
-
-// Handle receives the incoming request, validates it, and processes it.
-func (h *AuthHandler) Handle(w http.ResponseWriter, r *http.Request) error {
-	log.Info("signature request received")
-
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.Errorf("failed to read response body: %v", err)
-		return err
-	}
-	r.Body.Close()
-
-	var aReq auth.AuthenticatedRequest
-	err = json.Unmarshal(body, &aReq)
-	if err != nil {
-		log.Errorf("failed to unmarshal authenticated request: %v", err)
-		return errors.NewBadRequest(err)
-	}
-
-	var req jsonSignRequest
-	err = json.Unmarshal(aReq.Request, &req)
-	if err != nil {
-		log.Errorf("failed to unmarshal request from authenticated request: %v", err)
-		return errors.NewBadRequestString("Unable to parse authenticated sign request")
-	}
-
-	// Sanity checks to ensure that we have a valid policy. This
-	// should have been checked in NewAuthHandler.
-	policy := h.signer.Policy()
-	if policy == nil {
-		log.Critical("signer was initialised without a signing policy")
-		return errors.NewBadRequestString("invalid policy")
-	}
-
-	profile, err := signer.Profile(h.signer, req.Profile)
-	if err != nil {
-		return err
-	}
-
-	if profile.Provider == nil {
-		log.Error("profile has no authentication provider")
-		return errors.NewBadRequestString("no authentication provider")
-	}
-
-	if !profile.Provider.Verify(&aReq) {
-		log.Warning("received authenticated request with invalid token")
-		return errors.NewBadRequestString("invalid token")
-	}
-
-	signReq := jsonReqToTrue(req)
-
-	if signReq.Request == "" {
-		return errors.NewBadRequestString("missing parameter 'certificate_request'")
-	}
-
-	cert, err := h.signer.Sign(signReq)
-	if err != nil {
-		log.Errorf("signature failed: %v", err)
-		return err
-	}
-
-	result := map[string]string{"certificate": string(cert)}
-	log.Info("wrote response")
-	return api.SendResponse(w, result)
+	return signhandler.NewAuthHandlerFromSigner(s)
 }

--- a/api/sign/sign_test.go
+++ b/api/sign/sign_test.go
@@ -11,11 +11,8 @@ import (
 
 	"github.com/cloudflare/cfssl/api"
 	"github.com/cloudflare/cfssl/auth"
-	"github.com/cloudflare/cfssl/certdb"
-	"github.com/cloudflare/cfssl/certdb/testdb"
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/signer"
-	"github.com/cloudflare/cfssl/signer/local"
 )
 
 const (
@@ -32,18 +29,6 @@ var validLocalConfig = `
 		"default": {
 			"usages": ["digital signature", "email protection"],
 			"expiry": "1m"
-		}
-	}
-}`
-
-// GetUnexpiredCertificates sometimes doesn't return a certificate with an
-// expiry of 1m as above
-var validLocalConfigLongerExpiry = `
-{
-	"signing": {
-		"default": {
-		    "usages": ["digital signature", "email protection"],
-			"expiry": "10m"
 		}
 	}
 }`
@@ -542,80 +527,5 @@ func TestAuthSign(t *testing.T) {
 			t.Fatal(resp.Status, test.ExpectedHTTPStatus, message)
 		}
 
-	}
-}
-
-func TestSignerDBPersistence(t *testing.T) {
-	conf, err := config.LoadConfig([]byte(validLocalConfigLongerExpiry))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var s *local.Signer
-	s, err = local.NewSignerFromFile(testCaFile, testCaKeyFile, conf.Signing)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db := testdb.SQLiteDB("../../certdb/testdb/certstore_development.db")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	s.SetDB(db)
-
-	var handler *api.HTTPHandler
-	handler, err = NewHandlerFromSigner(signer.Signer(s))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	var csrPEM, body []byte
-	csrPEM, err = ioutil.ReadFile(testCSRFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	blob, err := json.Marshal(&map[string]string{"certificate_request": string(csrPEM)})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var resp *http.Response
-	resp, err = http.Post(ts.URL, "application/json", bytes.NewReader(blob))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	body, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatal(resp.Status, string(body))
-	}
-
-	message := new(api.Response)
-	err = json.Unmarshal(body, message)
-	if err != nil {
-		t.Fatalf("failed to read response body: %v", err)
-	}
-
-	if !message.Success {
-		t.Fatal("API operation failed")
-	}
-
-	var crs []*certdb.CertificateRecord
-	crs, err = certdb.GetUnexpiredCertificates(db)
-	if err != nil {
-		t.Fatal("Failed to get unexpired certificates")
-	}
-
-	if len(crs) != 1 {
-		t.Fatal("Expected 1 unexpired certificate in the database after signing 1")
 	}
 }

--- a/api/signhandler/signhandler.go
+++ b/api/signhandler/signhandler.go
@@ -1,0 +1,249 @@
+// Package signhandler provides the handlers for signers.
+package signhandler
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/auth"
+	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/signer"
+)
+
+// A Handler accepts requests with a hostname and certficate
+// parameter (which should be PEM-encoded) and returns a new signed
+// certificate. It includes upstream servers indexed by their
+// profile name.
+type Handler struct {
+	signer signer.Signer
+}
+
+// NewHandlerFromSigner generates a new Handler directly from
+// an existing signer.
+func NewHandlerFromSigner(signer signer.Signer) (h *api.HTTPHandler, err error) {
+	policy := signer.Policy()
+	if policy == nil {
+		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
+		return
+	}
+
+	// Sign will only respond for profiles that have no auth provider.
+	// So if all of the profiles require authentication, we return an error.
+	haveUnauth := (policy.Default.Provider == nil)
+	for _, profile := range policy.Profiles {
+		haveUnauth = haveUnauth || (profile.Provider == nil)
+	}
+
+	if !haveUnauth {
+		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
+		return
+	}
+
+	return &api.HTTPHandler{
+		Handler: &Handler{
+			signer: signer,
+		},
+		Methods: []string{"POST"},
+	}, nil
+}
+
+// This type is meant to be unmarshalled from JSON so that there can be a
+// hostname field in the API
+// TODO: Change the API such that the normal struct can be used.
+type jsonSignRequest struct {
+	Hostname string          `json:"hostname"`
+	Hosts    []string        `json:"hosts"`
+	Request  string          `json:"certificate_request"`
+	Subject  *signer.Subject `json:"subject,omitempty"`
+	Profile  string          `json:"profile"`
+	Label    string          `json:"label"`
+	Serial   *big.Int        `json:"serial,omitempty"`
+}
+
+func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
+	sub := new(signer.Subject)
+	if js.Subject == nil {
+		sub = nil
+	} else {
+		// make a copy
+		*sub = *js.Subject
+	}
+
+	if js.Hostname != "" {
+		return signer.SignRequest{
+			Hosts:   signer.SplitHosts(js.Hostname),
+			Subject: sub,
+			Request: js.Request,
+			Profile: js.Profile,
+			Label:   js.Label,
+			Serial:  js.Serial,
+		}
+	}
+
+	return signer.SignRequest{
+		Hosts:   js.Hosts,
+		Subject: sub,
+		Request: js.Request,
+		Profile: js.Profile,
+		Label:   js.Label,
+		Serial:  js.Serial,
+	}
+}
+
+// Handle responds to requests for the CA to sign the certificate request
+// present in the "certificate_request" parameter for the host named
+// in the "hostname" parameter. The certificate should be PEM-encoded. If
+// provided, subject information from the "subject" parameter will be used
+// in place of the subject information from the CSR.
+func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
+	log.Info("signature request received")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	var req jsonSignRequest
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return errors.NewBadRequestString("Unable to parse sign request")
+	}
+
+	signReq := jsonReqToTrue(req)
+
+	if req.Request == "" {
+		return errors.NewBadRequestString("missing parameter 'certificate_request'")
+	}
+
+	var cert []byte
+	profile, err := signer.Profile(h.signer, req.Profile)
+	if err != nil {
+		return err
+	}
+
+	if profile.Provider != nil {
+		log.Error("profile requires authentication")
+		return errors.NewBadRequestString("authentication required")
+	}
+
+	cert, err = h.signer.Sign(signReq)
+	if err != nil {
+		log.Warningf("failed to sign request: %v", err)
+		return err
+	}
+
+	result := map[string]string{"certificate": string(cert)}
+	log.Info("wrote response")
+	return api.SendResponse(w, result)
+}
+
+// An AuthHandler verifies and signs incoming signature requests.
+type AuthHandler struct {
+	signer signer.Signer
+}
+
+// NewAuthHandlerFromSigner creates a new AuthHandler from the signer
+// that is passed in.
+func NewAuthHandlerFromSigner(signer signer.Signer) (http.Handler, error) {
+	policy := signer.Policy()
+	if policy == nil {
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
+	}
+
+	if policy.Default == nil && policy.Profiles == nil {
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
+	}
+
+	// AuthSign will not respond for profiles that have no auth provider.
+	// So if there are no profiles with auth providers in this policy,
+	// we return an error.
+	haveAuth := (policy.Default.Provider != nil)
+	for _, profile := range policy.Profiles {
+		if haveAuth {
+			break
+		}
+		haveAuth = (profile.Provider != nil)
+	}
+
+	if !haveAuth {
+		return nil, errors.New(errors.PolicyError, errors.InvalidPolicy)
+	}
+
+	return &api.HTTPHandler{
+		Handler: &AuthHandler{
+			signer: signer,
+		},
+		Methods: []string{"POST"},
+	}, nil
+}
+
+// Handle receives the incoming request, validates it, and processes it.
+func (h *AuthHandler) Handle(w http.ResponseWriter, r *http.Request) error {
+	log.Info("signature request received")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Errorf("failed to read response body: %v", err)
+		return err
+	}
+	r.Body.Close()
+
+	var aReq auth.AuthenticatedRequest
+	err = json.Unmarshal(body, &aReq)
+	if err != nil {
+		log.Errorf("failed to unmarshal authenticated request: %v", err)
+		return errors.NewBadRequest(err)
+	}
+
+	var req jsonSignRequest
+	err = json.Unmarshal(aReq.Request, &req)
+	if err != nil {
+		log.Errorf("failed to unmarshal request from authenticated request: %v", err)
+		return errors.NewBadRequestString("Unable to parse authenticated sign request")
+	}
+
+	// Sanity checks to ensure that we have a valid policy. This
+	// should have been checked in NewAuthHandler.
+	policy := h.signer.Policy()
+	if policy == nil {
+		log.Critical("signer was initialised without a signing policy")
+		return errors.NewBadRequestString("invalid policy")
+	}
+
+	profile, err := signer.Profile(h.signer, req.Profile)
+	if err != nil {
+		return err
+	}
+
+	if profile.Provider == nil {
+		log.Error("profile has no authentication provider")
+		return errors.NewBadRequestString("no authentication provider")
+	}
+
+	if !profile.Provider.Verify(&aReq) {
+		log.Warning("received authenticated request with invalid token")
+		return errors.NewBadRequestString("invalid token")
+	}
+
+	signReq := jsonReqToTrue(req)
+
+	if signReq.Request == "" {
+		return errors.NewBadRequestString("missing parameter 'certificate_request'")
+	}
+
+	cert, err := h.signer.Sign(signReq)
+	if err != nil {
+		log.Errorf("signature failed: %v", err)
+		return err
+	}
+
+	result := map[string]string{"certificate": string(cert)}
+	log.Info("wrote response")
+	return api.SendResponse(w, result)
+}

--- a/api/signhandler/signhandler_test.go
+++ b/api/signhandler/signhandler_test.go
@@ -1,0 +1,110 @@
+package signhandler
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/certdb"
+	"github.com/cloudflare/cfssl/certdb/testdb"
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+)
+
+const (
+	testCaFile    = "../testdata/ca.pem"
+	testCaKeyFile = "../testdata/ca_key.pem"
+	testCSRFile   = "../testdata/csr.pem"
+)
+
+// GetUnexpiredCertificates sometimes doesn't return a certificate with an
+// expiry of 1m as above
+var validLocalConfigLongerExpiry = `
+{
+	"signing": {
+		"default": {
+		    "usages": ["digital signature", "email protection"],
+			"expiry": "10m"
+		}
+	}
+}`
+
+func TestSignerDBPersistence(t *testing.T) {
+	conf, err := config.LoadConfig([]byte(validLocalConfigLongerExpiry))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var s *local.Signer
+	s, err = local.NewSignerFromFile(testCaFile, testCaKeyFile, conf.Signing)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db := testdb.SQLiteDB("../../certdb/testdb/certstore_development.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.SetDB(db)
+
+	var handler *api.HTTPHandler
+	handler, err = NewHandlerFromSigner(signer.Signer(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	var csrPEM, body []byte
+	csrPEM, err = ioutil.ReadFile(testCSRFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blob, err := json.Marshal(&map[string]string{"certificate_request": string(csrPEM)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp *http.Response
+	resp, err = http.Post(ts.URL, "application/json", bytes.NewReader(blob))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal(resp.Status, string(body))
+	}
+
+	message := new(api.Response)
+	err = json.Unmarshal(body, message)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	if !message.Success {
+		t.Fatal("API operation failed")
+	}
+
+	var crs []*certdb.CertificateRecord
+	crs, err = certdb.GetUnexpiredCertificates(db)
+	if err != nil {
+		t.Fatal("Failed to get unexpired certificates")
+	}
+
+	if len(crs) != 1 {
+		t.Fatal("Expected 1 unexpired certificate in the database after signing 1")
+	}
+}

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -21,7 +21,7 @@ import (
 	apiocsp "github.com/cloudflare/cfssl/api/ocsp"
 	"github.com/cloudflare/cfssl/api/revoke"
 	"github.com/cloudflare/cfssl/api/scan"
-	apisign "github.com/cloudflare/cfssl/api/sign"
+	"github.com/cloudflare/cfssl/api/signhandler"
 	"github.com/cloudflare/cfssl/bundler"
 	"github.com/cloudflare/cfssl/certdb"
 	"github.com/cloudflare/cfssl/cli"
@@ -109,14 +109,14 @@ var endpoints = map[string]func() (http.Handler, error){
 		if s == nil {
 			return nil, errBadSigner
 		}
-		return apisign.NewHandlerFromSigner(s)
+		return signhandler.NewHandlerFromSigner(s)
 	},
 
 	"authsign": func() (http.Handler, error) {
 		if s == nil {
 			return nil, errBadSigner
 		}
-		return apisign.NewAuthHandlerFromSigner(s)
+		return signhandler.NewAuthHandlerFromSigner(s)
 	},
 
 	"info": func() (http.Handler, error) {

--- a/doc/errorcode.txt
+++ b/doc/errorcode.txt
@@ -28,6 +28,7 @@
     5100: NoKeyUsages
     5200: InvalidPolicy
     5300: InvalidRequest
+    5400: UnknownProfile
 6XXX: DialError
 7XXX: APIClientError
     7100: AuthenticationFailure

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -37,6 +37,7 @@ The index of codes are listed below:
 	    5100: NoKeyUsages
 	    5200: InvalidPolicy
 	    5300: InvalidRequest
+	    5400: UnknownProfile
 	    6XXX: DialError
 
 2. Type HttpError is intended for CF SSL API to consume. It contains a HTTP status code that will be read and returned

--- a/errors/error.go
+++ b/errors/error.go
@@ -146,6 +146,9 @@ const (
 	// InvalidRequest indicates a certificate request violated the
 	// constraints of the policy being applied to the request.
 	InvalidRequest // 53XX
+
+	// UnknownProfile indicates that the profile does not exist.
+	UnknownProfile // 54XX
 )
 
 // The following are API client related errors, and should be
@@ -308,6 +311,8 @@ func New(category Category, reason Reason) *Error {
 			msg = "Invalid or unknown policy"
 		case InvalidRequest:
 			msg = "Policy violation request"
+		case UnknownProfile:
+			msg = "Unknown policy profile"
 		default:
 			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category PolicyError.",
 				reason))

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -154,6 +154,10 @@ func TestNew(t *testing.T) {
 	if code != 5300 {
 		t.Fatal("Improper error code")
 	}
+	code = New(PolicyError, UnknownProfile).ErrorCode
+	if code != 5400 {
+		t.Fatal("Improper error code")
+	}
 
 	code = New(DialError, Unknown).ErrorCode
 	if code != 6000 {

--- a/helpers/testsuite/testing_helpers.go
+++ b/helpers/testsuite/testing_helpers.go
@@ -4,6 +4,7 @@ package testsuite
 
 import (
 	"bufio"
+	"testing"
 	// "crypto/tls"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	// "github.com/cloudflare/cfssl/helpers/testsuite/stoppable"
 )
@@ -358,4 +360,65 @@ func cleanCLIOutput(CLIOutput []byte, item string) (cleanedOutput []byte, err er
 	outputString = strings.Replace(outputString, "\\n", "\n", -1)
 
 	return []byte(outputString), nil
+}
+
+// NewConfig returns a config object from the data passed.
+func NewConfig(t *testing.T, configBytes []byte) *config.Config {
+	conf, err := config.LoadConfig([]byte(configBytes))
+	if err != nil {
+		t.Fatal("config loading error:", err)
+	}
+	if !conf.Valid() {
+		t.Fatal("config is not valid")
+	}
+	return conf
+}
+
+// CSRTest holds information about CSR test files.
+type CSRTest struct {
+	File    string
+	KeyAlgo string
+	KeyLen  int
+	// Error checking function
+	ErrorCallback func(*testing.T, error)
+}
+
+// CSRTests define a set of CSR files for testing.
+var CSRTests = []CSRTest{
+	{
+		File:          "../../signer/local/testdata/rsa2048.csr",
+		KeyAlgo:       "rsa",
+		KeyLen:        2048,
+		ErrorCallback: nil,
+	},
+	{
+		File:          "../../signer/local/testdata/rsa3072.csr",
+		KeyAlgo:       "rsa",
+		KeyLen:        3072,
+		ErrorCallback: nil,
+	},
+	{
+		File:          "../../signer/local/testdata/rsa4096.csr",
+		KeyAlgo:       "rsa",
+		KeyLen:        4096,
+		ErrorCallback: nil,
+	},
+	{
+		File:          "../../signer/local/testdata/ecdsa256.csr",
+		KeyAlgo:       "ecdsa",
+		KeyLen:        256,
+		ErrorCallback: nil,
+	},
+	{
+		File:          "../../signer/local/testdata/ecdsa384.csr",
+		KeyAlgo:       "ecdsa",
+		KeyLen:        384,
+		ErrorCallback: nil,
+	},
+	{
+		File:          "../../signer/local/testdata/ecdsa521.csr",
+		KeyAlgo:       "ecdsa",
+		KeyLen:        521,
+		ErrorCallback: nil,
+	},
 }

--- a/signer/universal/universal.go
+++ b/signer/universal/universal.go
@@ -2,13 +2,24 @@
 package universal
 
 import (
+	"crypto/x509"
+
 	"github.com/cloudflare/cfssl/config"
 	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/info"
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/local"
 	"github.com/cloudflare/cfssl/signer/pkcs11"
 	"github.com/cloudflare/cfssl/signer/remote"
 )
+
+// Signer represents a universal signer which is both local and remote
+// to fulfill the signer.Signer interface.
+type Signer struct {
+	local  signer.Signer
+	remote signer.Signer
+	policy *config.Signing
+}
 
 // Root is used to define where the universal signer gets its public
 // certificate and private keys for signing.
@@ -67,6 +78,51 @@ var localSignerList = []localSignerCheck{
 	fileBackedSigner,
 }
 
+func newLocalSigner(root Root, policy *config.Signing) (s signer.Signer, err error) {
+	// shouldProvide indicates whether the
+	// function *should* have produced a key. If
+	// it's true, we should use the signer and
+	// error returned. Otherwise, keep looking for
+	// signers.
+	var shouldProvide bool
+
+	// localSignerList is defined in the
+	// universal_signers*.go files. These activate
+	// and deactivate signers based on build
+	// flags; for example,
+	// universal_signers_pkcs11.go contains a list
+	// of valid signers when PKCS #11 is turned
+	// on.
+	for _, possibleSigner := range localSignerList {
+		s, shouldProvide, err = possibleSigner(&root, policy)
+		if shouldProvide {
+			break
+		}
+	}
+
+	if s == nil {
+		err = cferr.New(cferr.PrivateKeyError, cferr.Unknown)
+	}
+
+	return s, err
+}
+
+func newUniversalSigner(root Root, policy *config.Signing) (*Signer, error) {
+	ls, err := newLocalSigner(root, policy)
+	if err != nil {
+		return nil, err
+	}
+
+	rs, err := remote.NewSigner(policy)
+
+	s := &Signer{
+		policy: policy,
+		local:  ls,
+		remote: rs,
+	}
+	return s, err
+}
+
 // NewSigner generates a new certificate signer from a Root structure.
 // This is one of two standard signers: local or remote. If the root
 // structure specifies a force remote, then a remote signer is created,
@@ -91,40 +147,78 @@ func NewSigner(root Root, policy *config.Signing) (signer.Signer, error) {
 		s, err = remote.NewSigner(policy)
 	} else {
 		if policy.NeedsLocalSigner() && policy.NeedsRemoteSigner() {
-			// Currently we don't support a hybrid signer
-			return nil, cferr.New(cferr.PolicyError, cferr.InvalidPolicy)
-		}
-
-		if policy.NeedsLocalSigner() {
-			// shouldProvide indicates whether the
-			// function *should* have produced a key. If
-			// it's true, we should use the signer and
-			// error returned. Otherwise, keep looking for
-			// signers.
-			var shouldProvide bool
-			// localSignerList is defined in the
-			// universal_signers*.go files. These activate
-			// and deactivate signers based on build
-			// flags; for example,
-			// universal_signers_pkcs11.go contains a list
-			// of valid signers when PKCS #11 is turned
-			// on.
-			for _, possibleSigner := range localSignerList {
-				s, shouldProvide, err = possibleSigner(&root, policy)
-				if shouldProvide {
-					break
-				}
+			s, err = newUniversalSigner(root, policy)
+		} else {
+			if policy.NeedsLocalSigner() {
+				s, err = newLocalSigner(root, policy)
 			}
-
-			if s == nil {
-				err = cferr.New(cferr.PrivateKeyError, cferr.Unknown)
+			if policy.NeedsRemoteSigner() {
+				s, err = remote.NewSigner(policy)
 			}
-		}
-
-		if policy.NeedsRemoteSigner() {
-			s, err = remote.NewSigner(policy)
 		}
 	}
 
 	return s, err
+}
+
+// getMatchingProfile returns the SigningProfile that matches the profile passed.
+func (s *Signer) getMatchingProfile(profile string) (*config.SigningProfile, error) {
+	for p, signingProfile := range s.policy.Profiles {
+		if p == profile {
+			return signingProfile, nil
+		}
+	}
+
+	return nil, cferr.New(cferr.PolicyError, cferr.UnknownProfile)
+}
+
+// Sign sends a signature request to either the remote or local signer,
+// receiving a signed certificate or an error in response.
+func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
+	profile, err := s.getMatchingProfile(req.Profile)
+	if err != nil {
+		return cert, err
+	}
+
+	if profile.RemoteServer != "" {
+		return s.remote.Sign(req)
+	}
+	return s.local.Sign(req)
+
+}
+
+// Info sends an info request to the remote or local CFSSL server
+// receiving an Resp struct or an error in response.
+func (s *Signer) Info(req info.Req) (resp *info.Resp, err error) {
+	profile, err := s.getMatchingProfile(req.Profile)
+	if err != nil {
+		return resp, err
+	}
+
+	if profile.RemoteServer != "" {
+		return s.remote.Info(req)
+	}
+	return s.local.Info(req)
+
+}
+
+// SigAlgo returns the RSA signer's signature algorithm.
+func (s *Signer) SigAlgo() x509.SignatureAlgorithm {
+	if s.local != nil {
+		return s.local.SigAlgo()
+	}
+
+	// currently remote.SigAlgo just returns
+	// x509.UnknownSignatureAlgorithm.
+	return s.remote.SigAlgo()
+}
+
+// SetPolicy sets the signer's signature policy.
+func (s *Signer) SetPolicy(policy *config.Signing) {
+	s.policy = policy
+}
+
+// Policy returns the signer's policy.
+func (s *Signer) Policy() *config.Signing {
+	return s.policy
 }

--- a/signer/universal/universal_test.go
+++ b/signer/universal/universal_test.go
@@ -2,7 +2,6 @@ package universal
 
 import (
 	"bytes"
-	"encoding/json"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -11,13 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudflare/cfssl/api"
 	apiinfo "github.com/cloudflare/cfssl/api/info"
+	apisign "github.com/cloudflare/cfssl/api/signhandler"
 	"github.com/cloudflare/cfssl/config"
-	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/helpers/testsuite"
 	"github.com/cloudflare/cfssl/info"
-	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/signer"
 )
 
@@ -49,7 +47,7 @@ var validMinimalRemoteConfig = `
       "CA": {
         "usages": [
           "cert sign",
-          "clr sign"
+          "crl sign"
         ],
         "expiry": "720h",
         "auth_key": "ca-auth"
@@ -78,7 +76,7 @@ var validMinimalUniversalConfig = `
       "CA": {
         "usages": [
           "cert sign",
-          "clr sign"
+          "crl sign"
         ],
         "expiry": "720h",
         "auth_key": "local-auth",
@@ -124,7 +122,7 @@ var validRemoteConfig = `
       "CA": {
         "usages": [
           "cert sign",
-          "clr sign"
+          "crl sign"
         ],
         "expiry": "720h",
         "auth_key": "ca-auth"
@@ -159,7 +157,7 @@ var validUniversalConfig = `
       "CA": {
         "usages": [
           "cert sign",
-          "clr sign"
+          "crl sign"
         ],
         "expiry": "720h",
         "auth_key": "local-auth",
@@ -212,7 +210,7 @@ var validNoAuthRemoteConfig = `
       "CA": {
         "usages": [
           "cert sign",
-          "clr sign"
+          "crl sign"
         ],
         "expiry": "720h"
       },
@@ -240,7 +238,7 @@ var validNoAuthUniversalConfig = `
       "CA": {
         "usages": [
           "cert sign",
-          "clr sign"
+          "crl sign"
         ],
         "expiry": "720h",
 		"remote": "localhost"
@@ -289,13 +287,37 @@ func TestNewSigner(t *testing.T) {
 	}
 }
 
+func checkInfo(t *testing.T, s signer.Signer, name string, profile *config.SigningProfile) {
+	req := info.Req{
+		Profile: name,
+	}
+	resp, err := s.Info(req)
+	if err != nil {
+		t.Fatal("remote info failed:", err)
+	}
+
+	if strings.Join(profile.Usage, ",") != strings.Join(resp.Usage, ",") {
+		t.Fatalf("Expected usage for profile %s to be %+v, got %+v", name, profile.Usage, resp.Usage)
+	}
+
+	caBytes, err := ioutil.ReadFile(testCaFile)
+	caBytes = bytes.TrimSpace(caBytes)
+	if err != nil {
+		t.Fatal("fail to read test CA cert:", err)
+	}
+
+	if bytes.Compare(caBytes, []byte(resp.Certificate)) != 0 {
+		t.Fatal("Get a different CA cert through info api.", len(resp.Certificate), len(caBytes))
+	}
+}
+
 func TestUniversalRemoteAndLocalInfo(t *testing.T) {
 	// set up remote server
-	remoteConfig := newConfig(t, []byte(validMinimalRemoteConfig))
+	remoteConfig := testsuite.NewConfig(t, []byte(validMinimalRemoteConfig))
 	remoteServer := newTestInfoServer(t, newTestUniversalSigner(t, remoteConfig.Signing))
 	defer closeTestServer(t, remoteServer)
 
-	universalConfig := newConfig(t, []byte(validMinimalUniversalConfig))
+	universalConfig := testsuite.NewConfig(t, []byte(validMinimalUniversalConfig))
 	// override with test server address, ignore url prefix "http://"
 	for name, profile := range universalConfig.Signing.Profiles {
 		if profile.RemoteServer != "" {
@@ -305,37 +327,20 @@ func TestUniversalRemoteAndLocalInfo(t *testing.T) {
 	s := newTestUniversalSigner(t, universalConfig.Signing)
 
 	for name, profile := range universalConfig.Signing.Profiles {
-		req := info.Req{
-			Profile: name,
-		}
-		resp, err := s.Info(req)
-		if err != nil {
-			t.Fatal("remote info failed:", err)
-		}
-
-		if strings.Join(profile.Usage, ",") != strings.Join(resp.Usage, ",") {
-			t.Fatalf("Expected usage for profile %s to be %+v, got %+v", name, profile.Usage, resp.Usage)
-		}
-
-		caBytes, err := ioutil.ReadFile(testCaFile)
-		caBytes = bytes.TrimSpace(caBytes)
-		if err != nil {
-			t.Fatal("fail to read test CA cert:", err)
-		}
-
-		if bytes.Compare(caBytes, []byte(resp.Certificate)) != 0 {
-			t.Fatal("Get a different CA cert through info api.", len(resp.Certificate), len(caBytes))
-		}
+		checkInfo(t, s, name, profile)
 	}
+
+	// add check for default profile
+	checkInfo(t, s, "", universalConfig.Signing.Default)
 }
 
 func TestUniversalMultipleRemoteAndLocalInfo(t *testing.T) {
 	// set up remote server
-	remoteConfig := newConfig(t, []byte(validRemoteConfig))
+	remoteConfig := testsuite.NewConfig(t, []byte(validRemoteConfig))
 	remoteServer := newTestInfoServer(t, newTestUniversalSigner(t, remoteConfig.Signing))
 	defer closeTestServer(t, remoteServer)
 
-	universalConfig := newConfig(t, []byte(validUniversalConfig))
+	universalConfig := testsuite.NewConfig(t, []byte(validUniversalConfig))
 	// override with test server address, ignore url prefix "http://"
 	for name, profile := range universalConfig.Signing.Profiles {
 		if profile.RemoteServer != "" {
@@ -345,84 +350,20 @@ func TestUniversalMultipleRemoteAndLocalInfo(t *testing.T) {
 	s := newTestUniversalSigner(t, universalConfig.Signing)
 
 	for name, profile := range universalConfig.Signing.Profiles {
-		req := info.Req{
-			Profile: name,
-		}
-		resp, err := s.Info(req)
-		if err != nil {
-			t.Fatal("remote info failed:", err)
-		}
-
-		if strings.Join(profile.Usage, ",") != strings.Join(resp.Usage, ",") {
-			t.Fatalf("Expected usage for profile %s to be %+v, got %+v", name, profile.Usage, resp.Usage)
-		}
-
-		caBytes, err := ioutil.ReadFile(testCaFile)
-		caBytes = bytes.TrimSpace(caBytes)
-		if err != nil {
-			t.Fatal("fail to read test CA cert:", err)
-		}
-
-		if bytes.Compare(caBytes, []byte(resp.Certificate)) != 0 {
-			t.Fatal("Get a different CA cert through info api.", len(resp.Certificate), len(caBytes))
-		}
+		checkInfo(t, s, name, profile)
 	}
-}
 
-type csrTest struct {
-	file    string
-	keyAlgo string
-	keyLen  int
-	// Error checking function
-	errorCallback func(*testing.T, error)
-}
-
-var csrTests = []csrTest{
-	{
-		file:          "../local/testdata/rsa2048.csr",
-		keyAlgo:       "rsa",
-		keyLen:        2048,
-		errorCallback: nil,
-	},
-	{
-		file:          "../local/testdata/rsa3072.csr",
-		keyAlgo:       "rsa",
-		keyLen:        3072,
-		errorCallback: nil,
-	},
-	{
-		file:          "../local/testdata/rsa4096.csr",
-		keyAlgo:       "rsa",
-		keyLen:        4096,
-		errorCallback: nil,
-	},
-	{
-		file:          "../local/testdata/ecdsa256.csr",
-		keyAlgo:       "ecdsa",
-		keyLen:        256,
-		errorCallback: nil,
-	},
-	{
-		file:          "../local/testdata/ecdsa384.csr",
-		keyAlgo:       "ecdsa",
-		keyLen:        384,
-		errorCallback: nil,
-	},
-	{
-		file:          "../local/testdata/ecdsa521.csr",
-		keyAlgo:       "ecdsa",
-		keyLen:        521,
-		errorCallback: nil,
-	},
+	// add check for default profile
+	checkInfo(t, s, "", universalConfig.Signing.Default)
 }
 
 func TestUniversalRemoteAndLocalSign(t *testing.T) {
 	// set up remote server
-	remoteConfig := newConfig(t, []byte(validNoAuthRemoteConfig))
+	remoteConfig := testsuite.NewConfig(t, []byte(validNoAuthRemoteConfig))
 	remoteServer := newTestSignServer(t, newTestUniversalSigner(t, remoteConfig.Signing))
 	defer closeTestServer(t, remoteServer)
 
-	universalConfig := newConfig(t, []byte(validNoAuthUniversalConfig))
+	universalConfig := testsuite.NewConfig(t, []byte(validNoAuthUniversalConfig))
 	// override with test server address, ignore url prefix "http://"
 	for name, profile := range universalConfig.Signing.Profiles {
 		if profile.RemoteServer != "" {
@@ -431,10 +372,10 @@ func TestUniversalRemoteAndLocalSign(t *testing.T) {
 	}
 	s := newTestUniversalSigner(t, universalConfig.Signing)
 
-	for name, profile := range universalConfig.Signing.Profiles {
+	checkSign := func(name string, profile *config.SigningProfile) {
 		hosts := []string{"cloudflare.com"}
-		for _, test := range csrTests {
-			csr, err := ioutil.ReadFile(test.file)
+		for _, test := range testsuite.CSRTests {
+			csr, err := ioutil.ReadFile(test.File)
 			if err != nil {
 				t.Fatalf("CSR loading error (%s): %v", name, err)
 			}
@@ -446,11 +387,11 @@ func TestUniversalRemoteAndLocalSign(t *testing.T) {
 				Serial:  testSerial,
 				Profile: name,
 			})
-			if test.errorCallback != nil {
-				test.errorCallback(t, err)
+			if test.ErrorCallback != nil {
+				test.ErrorCallback(t, err)
 			} else {
 				if err != nil {
-					t.Fatalf("Expected no error. Got %s. Param %s %d", err.Error(), test.keyAlgo, test.keyLen)
+					t.Fatalf("Expected no error. Got %s. Param %s %d", err.Error(), test.KeyAlgo, test.KeyLen)
 				}
 				cert, err := helpers.ParseCertificatePEM(certBytes)
 				if err != nil {
@@ -463,17 +404,13 @@ func TestUniversalRemoteAndLocalSign(t *testing.T) {
 			}
 		}
 	}
-}
 
-func newConfig(t *testing.T, configBytes []byte) *config.Config {
-	conf, err := config.LoadConfig([]byte(configBytes))
-	if err != nil {
-		t.Fatal("config loading error:", err)
+	for name, profile := range universalConfig.Signing.Profiles {
+		checkSign(name, profile)
 	}
-	if !conf.Valid() {
-		t.Fatal("config is not valid")
-	}
-	return conf
+
+	// add check for default profile
+	checkSign("", universalConfig.Signing.Default)
 }
 
 func newTestUniversalSigner(t *testing.T, policy *config.Signing) signer.Signer {
@@ -496,7 +433,7 @@ func newTestUniversalSigner(t *testing.T, policy *config.Signing) signer.Signer 
 }
 
 func newTestSignHandler(t *testing.T, s signer.Signer) (h http.Handler) {
-	h, err := NewSignHandlerFromSigner(s)
+	h, err := apisign.NewHandlerFromSigner(s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -532,100 +469,4 @@ func newTestInfoServer(t *testing.T, s signer.Signer) *httptest.Server {
 func closeTestServer(t *testing.T, ts *httptest.Server) {
 	t.Log("Finalizing test server.")
 	ts.Close()
-}
-
-// NewSignHandlerFromSigner generates a new SignHandler directly from
-// an existing signer.
-func NewSignHandlerFromSigner(s signer.Signer) (h http.Handler, err error) {
-	policy := s.Policy()
-	if policy == nil {
-		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
-		return
-	}
-
-	// Sign will only respond for profiles that have no auth provider.
-	// So if all of the profiles require authentication, we return an error.
-	haveUnauth := (policy.Default.Provider == nil)
-	for _, profile := range policy.Profiles {
-		if !haveUnauth {
-			break
-		}
-		haveUnauth = (profile.Provider == nil)
-	}
-
-	if !haveUnauth {
-		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
-		return
-	}
-
-	return &api.HTTPHandler{
-		Handler: &SignHandler{
-			signer: s,
-		},
-		Methods: []string{"POST"},
-	}, nil
-}
-
-// A SignHandler accepts requests with a hostname and certficate
-// parameter (which should be PEM-encoded) and returns a new signed
-// certificate. It includes upstream servers indexed by their
-// profile name.
-type SignHandler struct {
-	signer signer.Signer
-}
-
-// Handle responds to requests for the CA to sign the certificate request
-// present in the "certificate_request" parameter for the host named
-// in the "hostname" parameter. The certificate should be PEM-encoded. If
-// provided, subject information from the "subject" parameter will be used
-// in place of the subject information from the CSR.
-func (h *SignHandler) Handle(w http.ResponseWriter, r *http.Request) error {
-	log.Info("signature request received")
-
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	r.Body.Close()
-
-	var req signer.SignRequest
-	err = json.Unmarshal(body, &req)
-	if err != nil {
-		return err
-	}
-
-	if len(req.Hosts) == 0 {
-		return errors.NewBadRequestString("missing paratmeter 'hosts'")
-	}
-
-	if req.Request == "" {
-		return errors.NewBadRequestString("missing parameter 'certificate_request'")
-	}
-
-	var cert []byte
-	var profile *config.SigningProfile
-
-	policy := h.signer.Policy()
-	if policy != nil && policy.Profiles != nil && req.Profile != "" {
-		profile = policy.Profiles[req.Profile]
-	}
-
-	if profile == nil && policy != nil {
-		profile = policy.Default
-	}
-
-	if profile.Provider != nil {
-		log.Error("profile requires authentication")
-		return errors.NewBadRequestString("authentication required")
-	}
-
-	cert, err = h.signer.Sign(req)
-	if err != nil {
-		log.Warningf("failed to sign request: %v", err)
-		return err
-	}
-
-	result := map[string]string{"certificate": string(cert)}
-	log.Info("wrote response")
-	return api.SendResponse(w, result)
 }

--- a/signer/universal/universal_test.go
+++ b/signer/universal/universal_test.go
@@ -1,10 +1,29 @@
 package universal
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/cloudflare/cfssl/api"
+	apiinfo "github.com/cloudflare/cfssl/api/info"
 	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/info"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/signer"
+)
+
+const (
+	testCaFile    = "../local/testdata/ca.pem"
+	testCaKeyFile = "../local/testdata/ca_key.pem"
 )
 
 var expiry = 1 * time.Minute
@@ -23,10 +42,240 @@ var validLocalConfig = &config.Config{
 	},
 }
 
+var validMinimalRemoteConfig = `
+{
+  "signing": {
+    "profiles": {
+      "CA": {
+        "usages": [
+          "cert sign",
+          "clr sign"
+        ],
+        "expiry": "720h",
+        "auth_key": "ca-auth"
+      }
+    },
+    "default": {
+      "usages": [
+        "digital signature",
+        "email protection"
+      ],
+      "expiry": "8000h"
+    }
+  },
+  "auth_keys": {
+    "ca-auth": {
+      "type": "standard",
+      "key": "0123456789ABCDEF0123456789ABCDEF"
+    }
+  }
+}`
+
+var validMinimalUniversalConfig = `
+{
+  "signing": {
+    "profiles": {
+      "CA": {
+        "usages": [
+          "cert sign",
+          "clr sign"
+        ],
+        "expiry": "720h",
+        "auth_key": "local-auth",
+        "auth_remote": {
+          "remote": "localhost",
+          "auth_key": "ca-auth"
+        }
+      },
+      "email": {
+        "usages": [
+          "s/mime"
+        ],
+        "expiry": "720h"
+      }
+    },
+    "default": {
+      "usages": [
+        "digital signature",
+        "email protection"
+      ],
+      "expiry": "8000h"
+    }
+  },
+  "auth_keys": {
+    "local-auth": {
+      "type": "standard",
+      "key": "123456789ABCDEF0123456789ABCDEF0"
+    },
+    "ca-auth": {
+      "type": "standard",
+      "key": "0123456789ABCDEF0123456789ABCDEF"
+    }
+  },
+  "remotes": {
+    "localhost": "127.0.0.1:1234"
+  }
+}`
+
+var validRemoteConfig = `
+{
+  "signing": {
+    "profiles": {
+      "CA": {
+        "usages": [
+          "cert sign",
+          "clr sign"
+        ],
+        "expiry": "720h",
+        "auth_key": "ca-auth"
+      },
+      "ipsec": {
+        "usages": [
+          "ipsec tunnel"
+        ],
+        "expiry": "720h"
+      }
+    },
+    "default": {
+      "usages": [
+        "digital signature",
+        "email protection"
+      ],
+      "expiry": "8000h"
+    }
+  },
+  "auth_keys": {
+    "ca-auth": {
+      "type": "standard",
+      "key": "0123456789ABCDEF0123456789ABCDEF"
+    }
+  }
+}`
+
+var validUniversalConfig = `
+{
+  "signing": {
+    "profiles": {
+      "CA": {
+        "usages": [
+          "cert sign",
+          "clr sign"
+        ],
+        "expiry": "720h",
+        "auth_key": "local-auth",
+        "auth_remote": {
+          "remote": "localhost",
+          "auth_key": "ca-auth"
+        }
+      },
+      "ipsec": {
+        "usages": [
+          "ipsec tunnel"
+        ],
+        "expiry": "720h",
+		"remote": "localhost"
+      },
+      "email": {
+        "usages": [
+          "s/mime"
+        ],
+        "expiry": "720h"
+      }
+    },
+    "default": {
+      "usages": [
+        "digital signature",
+        "email protection"
+      ],
+      "expiry": "8000h"
+    }
+  },
+  "auth_keys": {
+    "local-auth": {
+      "type": "standard",
+      "key": "123456789ABCDEF0123456789ABCDEF0"
+    },
+    "ca-auth": {
+      "type": "standard",
+      "key": "0123456789ABCDEF0123456789ABCDEF"
+    }
+  },
+  "remotes": {
+    "localhost": "127.0.0.1:1234"
+  }
+}`
+
+var validNoAuthRemoteConfig = `
+{
+  "signing": {
+    "profiles": {
+      "CA": {
+        "usages": [
+          "cert sign",
+          "clr sign"
+        ],
+        "expiry": "720h"
+      },
+      "ipsec": {
+        "usages": [
+          "ipsec tunnel"
+        ],
+        "expiry": "720h"
+      }
+    },
+    "default": {
+      "usages": [
+        "digital signature",
+        "email protection"
+      ],
+      "expiry": "8000h"
+    }
+  }
+}`
+
+var validNoAuthUniversalConfig = `
+{
+  "signing": {
+    "profiles": {
+      "CA": {
+        "usages": [
+          "cert sign",
+          "clr sign"
+        ],
+        "expiry": "720h",
+		"remote": "localhost"
+      },
+      "ipsec": {
+        "usages": [
+          "ipsec tunnel"
+        ],
+        "expiry": "720h",
+		"remote": "localhost"
+      },
+      "email": {
+        "usages": [
+          "s/mime"
+        ],
+        "expiry": "720h"
+      }
+    },
+    "default": {
+      "usages": [
+        "digital signature",
+        "email protection"
+      ],
+      "expiry": "8000h"
+    }
+  },
+  "remotes": {
+    "localhost": "127.0.0.1:1234"
+  }
+}`
+
 func TestNewSigner(t *testing.T) {
 	h := map[string]string{
-		"key-file":  "../local/testdata/ca_key.pem",
-		"cert-file": "../local/testdata/ca.pem",
+		"key-file":  testCaKeyFile,
+		"cert-file": testCaFile,
 	}
 
 	r := &Root{
@@ -38,5 +287,345 @@ func TestNewSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
 
+func TestUniversalRemoteAndLocalInfo(t *testing.T) {
+	// set up remote server
+	remoteConfig := newConfig(t, []byte(validMinimalRemoteConfig))
+	remoteServer := newTestInfoServer(t, newTestUniversalSigner(t, remoteConfig.Signing))
+	defer closeTestServer(t, remoteServer)
+
+	universalConfig := newConfig(t, []byte(validMinimalUniversalConfig))
+	// override with test server address, ignore url prefix "http://"
+	for name, profile := range universalConfig.Signing.Profiles {
+		if profile.RemoteServer != "" {
+			universalConfig.Signing.Profiles[name].RemoteServer = remoteServer.URL[7:]
+		}
+	}
+	s := newTestUniversalSigner(t, universalConfig.Signing)
+
+	for name, profile := range universalConfig.Signing.Profiles {
+		req := info.Req{
+			Profile: name,
+		}
+		resp, err := s.Info(req)
+		if err != nil {
+			t.Fatal("remote info failed:", err)
+		}
+
+		if strings.Join(profile.Usage, ",") != strings.Join(resp.Usage, ",") {
+			t.Fatalf("Expected usage for profile %s to be %+v, got %+v", name, profile.Usage, resp.Usage)
+		}
+
+		caBytes, err := ioutil.ReadFile(testCaFile)
+		caBytes = bytes.TrimSpace(caBytes)
+		if err != nil {
+			t.Fatal("fail to read test CA cert:", err)
+		}
+
+		if bytes.Compare(caBytes, []byte(resp.Certificate)) != 0 {
+			t.Fatal("Get a different CA cert through info api.", len(resp.Certificate), len(caBytes))
+		}
+	}
+}
+
+func TestUniversalMultipleRemoteAndLocalInfo(t *testing.T) {
+	// set up remote server
+	remoteConfig := newConfig(t, []byte(validRemoteConfig))
+	remoteServer := newTestInfoServer(t, newTestUniversalSigner(t, remoteConfig.Signing))
+	defer closeTestServer(t, remoteServer)
+
+	universalConfig := newConfig(t, []byte(validUniversalConfig))
+	// override with test server address, ignore url prefix "http://"
+	for name, profile := range universalConfig.Signing.Profiles {
+		if profile.RemoteServer != "" {
+			universalConfig.Signing.Profiles[name].RemoteServer = remoteServer.URL[7:]
+		}
+	}
+	s := newTestUniversalSigner(t, universalConfig.Signing)
+
+	for name, profile := range universalConfig.Signing.Profiles {
+		req := info.Req{
+			Profile: name,
+		}
+		resp, err := s.Info(req)
+		if err != nil {
+			t.Fatal("remote info failed:", err)
+		}
+
+		if strings.Join(profile.Usage, ",") != strings.Join(resp.Usage, ",") {
+			t.Fatalf("Expected usage for profile %s to be %+v, got %+v", name, profile.Usage, resp.Usage)
+		}
+
+		caBytes, err := ioutil.ReadFile(testCaFile)
+		caBytes = bytes.TrimSpace(caBytes)
+		if err != nil {
+			t.Fatal("fail to read test CA cert:", err)
+		}
+
+		if bytes.Compare(caBytes, []byte(resp.Certificate)) != 0 {
+			t.Fatal("Get a different CA cert through info api.", len(resp.Certificate), len(caBytes))
+		}
+	}
+}
+
+type csrTest struct {
+	file    string
+	keyAlgo string
+	keyLen  int
+	// Error checking function
+	errorCallback func(*testing.T, error)
+}
+
+var csrTests = []csrTest{
+	{
+		file:          "../local/testdata/rsa2048.csr",
+		keyAlgo:       "rsa",
+		keyLen:        2048,
+		errorCallback: nil,
+	},
+	{
+		file:          "../local/testdata/rsa3072.csr",
+		keyAlgo:       "rsa",
+		keyLen:        3072,
+		errorCallback: nil,
+	},
+	{
+		file:          "../local/testdata/rsa4096.csr",
+		keyAlgo:       "rsa",
+		keyLen:        4096,
+		errorCallback: nil,
+	},
+	{
+		file:          "../local/testdata/ecdsa256.csr",
+		keyAlgo:       "ecdsa",
+		keyLen:        256,
+		errorCallback: nil,
+	},
+	{
+		file:          "../local/testdata/ecdsa384.csr",
+		keyAlgo:       "ecdsa",
+		keyLen:        384,
+		errorCallback: nil,
+	},
+	{
+		file:          "../local/testdata/ecdsa521.csr",
+		keyAlgo:       "ecdsa",
+		keyLen:        521,
+		errorCallback: nil,
+	},
+}
+
+func TestUniversalRemoteAndLocalSign(t *testing.T) {
+	// set up remote server
+	remoteConfig := newConfig(t, []byte(validNoAuthRemoteConfig))
+	remoteServer := newTestSignServer(t, newTestUniversalSigner(t, remoteConfig.Signing))
+	defer closeTestServer(t, remoteServer)
+
+	universalConfig := newConfig(t, []byte(validNoAuthUniversalConfig))
+	// override with test server address, ignore url prefix "http://"
+	for name, profile := range universalConfig.Signing.Profiles {
+		if profile.RemoteServer != "" {
+			universalConfig.Signing.Profiles[name].RemoteServer = remoteServer.URL[7:]
+		}
+	}
+	s := newTestUniversalSigner(t, universalConfig.Signing)
+
+	for name, profile := range universalConfig.Signing.Profiles {
+		hosts := []string{"cloudflare.com"}
+		for _, test := range csrTests {
+			csr, err := ioutil.ReadFile(test.file)
+			if err != nil {
+				t.Fatalf("CSR loading error (%s): %v", name, err)
+			}
+			testSerial := big.NewInt(0x7007F)
+
+			certBytes, err := s.Sign(signer.SignRequest{
+				Hosts:   hosts,
+				Request: string(csr),
+				Serial:  testSerial,
+				Profile: name,
+			})
+			if test.errorCallback != nil {
+				test.errorCallback(t, err)
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error. Got %s. Param %s %d", err.Error(), test.keyAlgo, test.keyLen)
+				}
+				cert, err := helpers.ParseCertificatePEM(certBytes)
+				if err != nil {
+					t.Fatal("Fail to parse returned certificate:", err)
+				}
+				ku, _, _ := profile.Usages()
+				if cert.KeyUsage != ku {
+					t.Fatalf("Key usage was incorrect expected %+v, got %+v", ku, cert.KeyUsage)
+				}
+			}
+		}
+	}
+}
+
+func newConfig(t *testing.T, configBytes []byte) *config.Config {
+	conf, err := config.LoadConfig([]byte(configBytes))
+	if err != nil {
+		t.Fatal("config loading error:", err)
+	}
+	if !conf.Valid() {
+		t.Fatal("config is not valid")
+	}
+	return conf
+}
+
+func newTestUniversalSigner(t *testing.T, policy *config.Signing) signer.Signer {
+	h := map[string]string{
+		"key-file":  testCaKeyFile,
+		"cert-file": testCaFile,
+	}
+
+	r := &Root{
+		Config:      h,
+		ForceRemote: false,
+	}
+
+	s, err := NewSigner(*r, policy)
+	if err != nil {
+		t.Fatal("fail to init universal signer:", err)
+	}
+
+	return s
+}
+
+func newTestSignHandler(t *testing.T, s signer.Signer) (h http.Handler) {
+	h, err := NewSignHandlerFromSigner(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+func newTestInfoHandler(t *testing.T, s signer.Signer) (h http.Handler) {
+	h, err := apiinfo.NewHandler(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+func newTestSignServer(t *testing.T, s signer.Signer) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/cfssl/sign", newTestSignHandler(t, s))
+	ts := httptest.NewUnstartedServer(mux)
+	ts.Start()
+	t.Log(ts.URL)
+	return ts
+}
+
+func newTestInfoServer(t *testing.T, s signer.Signer) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/cfssl/info", newTestInfoHandler(t, s))
+	ts := httptest.NewUnstartedServer(mux)
+	ts.Start()
+	t.Log(ts.URL)
+	return ts
+}
+
+func closeTestServer(t *testing.T, ts *httptest.Server) {
+	t.Log("Finalizing test server.")
+	ts.Close()
+}
+
+// NewSignHandlerFromSigner generates a new SignHandler directly from
+// an existing signer.
+func NewSignHandlerFromSigner(s signer.Signer) (h http.Handler, err error) {
+	policy := s.Policy()
+	if policy == nil {
+		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
+		return
+	}
+
+	// Sign will only respond for profiles that have no auth provider.
+	// So if all of the profiles require authentication, we return an error.
+	haveUnauth := (policy.Default.Provider == nil)
+	for _, profile := range policy.Profiles {
+		if !haveUnauth {
+			break
+		}
+		haveUnauth = (profile.Provider == nil)
+	}
+
+	if !haveUnauth {
+		err = errors.New(errors.PolicyError, errors.InvalidPolicy)
+		return
+	}
+
+	return &api.HTTPHandler{
+		Handler: &SignHandler{
+			signer: s,
+		},
+		Methods: []string{"POST"},
+	}, nil
+}
+
+// A SignHandler accepts requests with a hostname and certficate
+// parameter (which should be PEM-encoded) and returns a new signed
+// certificate. It includes upstream servers indexed by their
+// profile name.
+type SignHandler struct {
+	signer signer.Signer
+}
+
+// Handle responds to requests for the CA to sign the certificate request
+// present in the "certificate_request" parameter for the host named
+// in the "hostname" parameter. The certificate should be PEM-encoded. If
+// provided, subject information from the "subject" parameter will be used
+// in place of the subject information from the CSR.
+func (h *SignHandler) Handle(w http.ResponseWriter, r *http.Request) error {
+	log.Info("signature request received")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	var req signer.SignRequest
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return err
+	}
+
+	if len(req.Hosts) == 0 {
+		return errors.NewBadRequestString("missing paratmeter 'hosts'")
+	}
+
+	if req.Request == "" {
+		return errors.NewBadRequestString("missing parameter 'certificate_request'")
+	}
+
+	var cert []byte
+	var profile *config.SigningProfile
+
+	policy := h.signer.Policy()
+	if policy != nil && policy.Profiles != nil && req.Profile != "" {
+		profile = policy.Profiles[req.Profile]
+	}
+
+	if profile == nil && policy != nil {
+		profile = policy.Default
+	}
+
+	if profile.Provider != nil {
+		log.Error("profile requires authentication")
+		return errors.NewBadRequestString("authentication required")
+	}
+
+	cert, err = h.signer.Sign(req)
+	if err != nil {
+		log.Warningf("failed to sign request: %v", err)
+		return err
+	}
+
+	result := map[string]string{"certificate": string(cert)}
+	log.Info("wrote response")
+	return api.SendResponse(w, result)
 }


### PR DESCRIPTION
This expands the `signer/universal` pkg to implement a hybrid
`signer.Signer` interface that can be both local and remote.

So now the config in #381 works.