### PR TITLE
Ignore CKR_USER_ALREADY_LOGGED_IN on C_Login

### DIFF
--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -307,8 +307,13 @@ func (ps *Key) openSession() (pkcs11.SessionHandle, error) {
 		// practice it appears to be okay to login to a token multiple times with the same
 		// credentials.
 		if err = ps.module.Login(session, pkcs11.CKU_USER, ps.pin); err != nil {
-			ps.module.CloseSession(session)
-			return session, err
+			if err == pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
+				// But if the token says we're already logged in, it's ok.
+				err = nil
+			} else {
+				ps.module.CloseSession(session)
+				return session, err
+			}
 		}
 
 		return session, err


### PR DESCRIPTION
Some module return CKR_USER_ALREADY_LOGGED_IN when trying to log multiple times on the same token (whereas some just respond CKR_OK).

I've found that for instance [OpenSSH](https://github.com/openssh/openssh-portable/blob/master/ssh-pkcs11.c#L380) and [GnuTLS](https://gitlab.com/gnutls/gnutls/blob/master/lib/pkcs11.c#L2552) treat `CKR_USER_ALREADY_LOGGED_IN` as equivalent and CKR_OK for `C_Login`.

There was additional discussion on the topic in #391 with @jsha.