### PR TITLE
Fix serve UI bug (404 on direct access of '/scan' or '/bundle') 

### DIFF
--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -48,6 +48,10 @@ func TestServe(t *testing.T) {
 	// POST-only endpoints should return '400 Bad Request'
 	expected[v1APIPath("scan")] = http.StatusBadRequest
 
+	// Redirected HTML endpoints should return '200 OK'
+	expected["/scan"] = http.StatusOK
+	expected["/bundle"] = http.StatusOK
+
 	// Non-existent endpoints should return '404 Not Found'
 	expected["/bad_endpoint"] = http.StatusNotFound
 


### PR DESCRIPTION
This sets a redirect mapping in the httpBox for those specific endpoints.