### PR TITLE
The certificate-transparency go dependency is required for the build

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -15,6 +15,7 @@ RUN go get github.com/cloudflare/redoctober/core
 RUN go get github.com/dgryski/go-rc2
 RUN go get golang.org/x/crypto/ocsp
 RUN go get github.com/GeertJohan/go.rice
+RUN go get github.com/google/certificate-transparency/go/client
 
 ENV GOPATH /go/src/github.com/cloudflare/cfssl:/go
 ENV USER root


### PR DESCRIPTION
Fix for issue: cannot find package "github.com/google/certificate-transparency/go/client" in any of... when running /script/build