### PR TITLE
rice requires the value specifed to FindBox to be a string literal, not

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -68,8 +68,8 @@ type httpBox struct {
 	redirects map[string]string
 }
 
-func (hb *httpBox) findBox(name string) (err error) {
-	hb.Box, err = rice.FindBox(name)
+func (hb *httpBox) findStaticBox() (err error) {
+	hb.Box, err = rice.FindBox("static")
 	return
 }
 
@@ -157,7 +157,7 @@ var endpoints = map[string]func() (http.Handler, error){
 	},
 
 	"/": func() (http.Handler, error) {
-		if err := staticBox.findBox("static"); err != nil {
+		if err := staticBox.findStaticBox(); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
a variable. Since the only use of FindBox is to look up the static
folder, make it a static parameter.