### PR TITLE
Update AWS Dockerfile bundle metadata

### DIFF
--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -13,4 +13,4 @@ RUN git clone https://github.com/cloudflare/cfssl.git /go/src/github.com/cloudfl
 EXPOSE 80
 
 ENTRYPOINT ["cfssl", "serve"]
-CMD ["-address=0.0.0.0", "-port=80"]
+CMD ["-address=0.0.0.0", "-port=80", "-ca-bundle=/etc/cfssl/ca-bundle.crt", "-int-bundle=/etc/cfssl/int-bundle.crt", "-metadata=/etc/cfssl/ca-bundle.crt.metadata"]


### PR DESCRIPTION
I had missed @lziest's change removing the default bundle/metadata flags. https://github.com/cloudflare/cfssl/commit/e089235c3eb4e5422b783a48c9eb8396132095ed