### PR TITLE
Omit empty qualifiers in Certificate Policies.

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -35,12 +35,12 @@ type Subject struct {
 // SignRequest stores a signature request, which contains the hostname,
 // the CSR, optional subject information, and the signature profile.
 type SignRequest struct {
-	Hosts     []string `json:"hosts"`
-	Request   string   `json:"certificate_request"`
-	Subject   *Subject `json:"subject,omitempty"`
-	Profile   string   `json:"profile"`
-	Label     string   `json:"label"`
-	Serial    *big.Int `json:"serial,omitempty"`
+	Hosts   []string `json:"hosts"`
+	Request string   `json:"certificate_request"`
+	Subject *Subject `json:"subject,omitempty"`
+	Profile string   `json:"profile"`
+	Label   string   `json:"label"`
+	Serial  *big.Int `json:"serial,omitempty"`
 }
 
 // appendIf appends to a if s is not an empty string.
@@ -282,12 +282,8 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 }
 
 type policyInformation struct {
-	PolicyIdentifier    asn1.ObjectIdentifier
-	Qualifiers          []interface{}
-	CPSPolicyQualifiers []cpsPolicyQualifier `asn1:"omitempty"`
-	// User Notice policy qualifiers have a slightly different ASN.1 structure
-	// from that used for CPS policy qualifiers.
-	UserNoticePolicyQualifiers []userNoticePolicyQualifier `asn1:"omitempty"`
+	PolicyIdentifier asn1.ObjectIdentifier
+	Qualifiers       []interface{} `asn1:"tag:optional,omitempty"`
 }
 
 type cpsPolicyQualifier struct {

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -64,9 +64,9 @@ func TestAddPolicies(t *testing.T) {
 	if ext.Critical {
 		t.Fatal("Policy qualifier marked critical")
 	}
-	expectedBytes, _ := hex.DecodeString("3009300706032a03043000")
+	expectedBytes, _ := hex.DecodeString("3007300506032a0304")
 	if !bytes.Equal(ext.Value, expectedBytes) {
-		t.Fatal(fmt.Sprintf("Value didn't match expected bytes: %s vs %s",
+		t.Fatal(fmt.Sprintf("Value didn't match expected bytes: got %s, expected %s",
 			hex.EncodeToString(ext.Value), hex.EncodeToString(expectedBytes)))
 	}
 }


### PR DESCRIPTION
The previous code would emit a zero-length `SEQUENCE` for any CertificatePolicy,
which caused Java's keytool to complain (and is incorrect DER encoding).

Also, remove two unused fields.

Relevant support thread: https://community.letsencrypt.org/t/no-data-available-in-policyqualifiers/3975/11