### PR TITLE
Fixed unitialized interface type field in genSignRequest, so it can b…

### DIFF
--- a/api/generator/generator.go
+++ b/api/generator/generator.go
@@ -206,6 +206,8 @@ func (cg *CertGeneratorHandler) Handle(w http.ResponseWriter, r *http.Request) e
 	log.Info("request for CSR")
 
 	req := new(genSignRequest)
+	req.Request = csr.New()
+
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Warningf("failed to read request body: %v", err)


### PR DESCRIPTION
It fixes #439 by properly initializing KeyRequest field of csr.CertificateRequest struct with BaseKeyRequest.