### PR TITLE
Adding Heartbleed Detection to Scan

### DIFF
--- a/scan/scan_common.go
+++ b/scan/scan_common.go
@@ -121,11 +121,12 @@ type FamilySet map[string]*Family
 
 // Default contains each scan Family that is defined
 var Default = FamilySet{
-	"Connectivity": Connectivity,
-	"TLSHandshake": TLSHandshake,
-	"TLSSession":   TLSSession,
-	"PKI":          PKI,
-	"Broad":        Broad,
+	"Vulnerability": Vulnerability,
+	"Connectivity":  Connectivity,
+	"TLSHandshake":  TLSHandshake,
+	"TLSSession":    TLSSession,
+	"PKI":           PKI,
+	"Broad":         Broad,
 }
 
 // ScannerResult contains the result for a single scan.

--- a/scan/vulnerability.go
+++ b/scan/vulnerability.go
@@ -1,0 +1,55 @@
+package scan
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/FiloSottile/Heartbleed/heartbleed"
+)
+
+var Vulnerability = &Family{
+	Description: "Scans a host to detect TLS vulnerabilities.",
+	Scanners: map[string]*Scanner{
+		"Heartbleed": {
+			"Scan for Heartbleed vulnerability",
+			heartbleedScan,
+		},
+	},
+}
+
+func heartbleedScan(addr, hostname string) (grade Grade, output Output, err error) {
+	tgt := &heartbleed.Target{
+		Service: "https",
+		HostIp:  hostname,
+	}
+
+	u, err := url.Parse(tgt.HostIp)
+	if err == nil && u.Host != "" {
+		tgt.HostIp = u.Host
+		if u.Scheme != "" {
+			tgt.Service = u.Scheme
+		}
+	}
+
+	out, err := heartbleed.Heartbleed(tgt,
+		[]byte("github.com/FiloSottile/Heartbleed"), true)
+	if err == heartbleed.Safe {
+		str := fmt.Sprintf("%v - SAFE", tgt.HostIp)
+		grade, output = Good, str
+		err = nil
+	} else if err != nil {
+		if err.Error() == "Please try again" {
+			str := fmt.Sprintf("%v - TRYAGAIN: %v", tgt.HostIp, err)
+			grade, output = Warning, str
+		} else {
+			str := fmt.Sprintf("%v - ERROR: %v", tgt.HostIp, err)
+			grade, output = Warning, str
+		}
+	} else {
+		log.Printf("%v\n", out)
+		str := fmt.Sprintf("%v - VULNERABLE", tgt.HostIp)
+		grade, output = Bad, str
+	}
+	return
+}


### PR DESCRIPTION
Part of https://github.com/cloudflare/cfssl/wiki/Adding-Vulnerability-scaning-to-Scan.

Extends CFSSL Scan to scan a host for vulnerability to Heartbleed using https://github.com/FiloSottile/Heartbleed. Thoughts on using this third-party tool? Should a custom version of this scan be implemented locally instead?


Next steps would be adding more scans to detect TLS POODLE, BERserk, LogJam, and FREAK. I haven't been able to find helpful articles detailing how to detect these vulnerabilities, any links/resources suggestions would be great.