### PR TITLE
Update csr.New() to properly use csr.NewBasicKeyRequest()

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -145,7 +145,7 @@ type CertificateRequest struct {
 // BasicKeyRequest.
 func New() *CertificateRequest {
 	return &CertificateRequest{
-		KeyRequest: &BasicKeyRequest{},
+		KeyRequest: NewBasicKeyRequest(),
 	}
 }
 


### PR DESCRIPTION
This should fix #456 
Apparently `csr.New()` wasn't implemented correctly (setting algo to `""`)