### PR TITLE
Update scan cli to use a worker pool

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	Timeout           time.Duration
 	Scanner           string
 	CSVFile           string
+	NumWorkers        int
 	MaxHosts          int
 	Responses         string
 	Path              string
@@ -100,7 +101,8 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.Scanner, "scanner", "", "scanner regular expression")
 	f.DurationVar(&c.Timeout, "timeout", 5*time.Minute, "duration (ns, us, ms, s, m, h) to scan each host before timing out")
 	f.StringVar(&c.CSVFile, "csv", "", "file containing CSV of hosts")
-	f.IntVar(&c.MaxHosts, "max-hosts", 10, "maximum number of hosts to scan")
+	f.IntVar(&c.NumWorkers, "num-workers", 10, "number of workers to use for scan")
+	f.IntVar(&c.MaxHosts, "max-hosts", 100, "maximum number of hosts to scan")
 	f.StringVar(&c.Responses, "responses", "", "file to load OCSP responses from")
 	f.StringVar(&c.Path, "path", "/", "Path on which the server will listen")
 	f.StringVar(&c.Password, "password", "0", "Password for accessing PKCS #12 data passed to bundler")

--- a/cli/scan/scan.go
+++ b/cli/scan/scan.go
@@ -15,14 +15,14 @@ import (
 
 var scanUsageText = `cfssl scan -- scan a host for issues
 Usage of scan:
-        cfssl scan [-family regexp] [-scanner regexp] [-timeout duration] [-ip IPAddr] HOST+
+        cfssl scan [-family regexp] [-scanner regexp] [-timeout duration] [-ip IPAddr] [-num-workers num] [-max-hosts num] [-csv hosts.csv] HOST+
         cfssl scan -list
 
 Arguments:
         HOST:    Host(s) to scan (including port)
 Flags:
 `
-var scanFlags = []string{"list", "family", "scanner", "timeout", "ip", "ca-bundle", "csv", "max-hosts"}
+var scanFlags = []string{"list", "family", "scanner", "timeout", "ip", "ca-bundle", "num-workers", "csv", "max-hosts"}
 
 func printJSON(v interface{}) {
 	b, err := json.MarshalIndent(v, "", "  ")
@@ -34,23 +34,32 @@ func printJSON(v interface{}) {
 
 type context struct {
 	sync.WaitGroup
-	c cli.Config
+	c     cli.Config
+	hosts chan string
 }
 
-func newContext(c cli.Config, numHosts int) *context {
-	ctx := &context{c: c}
-	ctx.Add(numHosts)
+func newContext(c cli.Config, numWorkers int) *context {
+	ctx := &context{
+		c:     c,
+		hosts: make(chan string, numWorkers),
+	}
+	ctx.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go ctx.runWorker()
+	}
 	return ctx
 }
 
-func (ctx *context) RunScans(host string) {
-	fmt.Printf("Scanning %s...\n", host)
-	results, err := scan.Default.RunScans(host, ctx.c.IP, ctx.c.Family, ctx.c.Scanner, ctx.c.Timeout)
-	fmt.Printf("=== %s ===\n", host)
-	if err != nil {
-		log.Error(err)
-	} else {
-		printJSON(results)
+func (ctx *context) runWorker() {
+	for host := range ctx.hosts {
+		fmt.Printf("Scanning %s...\n", host)
+		results, err := scan.Default.RunScans(host, ctx.c.IP, ctx.c.Family, ctx.c.Scanner, ctx.c.Timeout)
+		fmt.Printf("=== %s ===\n", host)
+		if err != nil {
+			log.Error(err)
+		} else {
+			printJSON(results)
+		}
 	}
 	ctx.Done()
 }
@@ -93,7 +102,7 @@ func scanMain(args []string, c cli.Config) (err error) {
 			}
 		}
 
-		ctx := newContext(c, len(args))
+		ctx := newContext(c, c.NumWorkers)
 		// Execute for each HOST argument given
 		for len(args) > 0 {
 			var host string
@@ -102,8 +111,9 @@ func scanMain(args []string, c cli.Config) (err error) {
 				return
 			}
 
-			go ctx.RunScans(host)
+			ctx.hosts <- host
 		}
+		close(ctx.hosts)
 		ctx.Wait()
 	}
 	return

--- a/cmd/cfssl-scan/cfssl-scan.go
+++ b/cmd/cfssl-scan/cfssl-scan.go
@@ -17,15 +17,15 @@ func main() {
 
 	var scanFlagSet = flag.NewFlagSet("scan", flag.ExitOnError)
 	var c cli.Config
-	var usageText = `cfssl-scan -- scan a host for issues
-		Usage of scan:
-        	scan [-family regexp] [-scanner regexp] [-timeout duration] [-ip IPAddr] HOST+
-        	scan -list
+	var usageText = `cfssl scan -- scan a host for issues
+Usage of scan:
+        cfssl scan [-family regexp] [-scanner regexp] [-timeout duration] [-ip IPAddr] [-num-workers num] [-max-hosts num] [-csv hosts.csv] HOST+
+        cfssl scan -list
 
-		Arguments:
-        	HOST:    Host(s) to scan (including port)
-		Flags:
-		`
+Arguments:
+        HOST:    Host(s) to scan (including port)
+Flags:
+`
 	registerFlags(&c, scanFlagSet)
 
 	scanFlagSet.Usage = func() {
@@ -71,6 +71,9 @@ func registerFlags(c *cli.Config, f *flag.FlagSet) {
 	f.StringVar(&c.Family, "family", "", "scanner family regular expression")
 	f.StringVar(&c.Scanner, "scanner", "", "scanner regular expression")
 	f.DurationVar(&c.Timeout, "timeout", 5*time.Minute, "duration (ns, us, ms, s, m, h) to scan each host before timing out")
+	f.StringVar(&c.CSVFile, "csv", "", "file containing CSV of hosts")
+	f.IntVar(&c.NumWorkers, "num-workers", 10, "number of workers to use for scan")
+	f.IntVar(&c.MaxHosts, "max-hosts", 100, "maximum number of hosts to scan")
 	f.StringVar(&c.IP, "ip", "", "remote server ip")
 	f.StringVar(&c.CABundleFile, "ca-bundle", "", "path to root certificate store")
 	f.IntVar(&log.Level, "loglevel", log.LevelInfo, "Log level")


### PR DESCRIPTION
This resolves #462 and allows scan to be used for large sets of hosts (e.g. the entire Alexa top 1 million)