### PR TITLE
Make CI work for forks

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,7 @@ fi
 
 for package in $PACKAGES
 do
-    fgt golint ${package##github.com/cloudflare/cfssl/}/*.go
+    fgt golint ${package}
 done
 
 # Build and install cfssl executable in PATH


### PR DESCRIPTION
Failure on master for a [fork](https://travis-ci.org/drcapulet/cfssl/builds/98568874) but just fine on [this repo](https://travis-ci.org/cloudflare/cfssl/builds/98459027).

[This build](https://travis-ci.org/drcapulet/cfssl/builds/98564106) added better logging, and a fixed build is [here](https://travis-ci.org/drcapulet/cfssl/builds/98566299).

Something about the `*.go` doesn't work, so this just uses the package name.