### PR TITLE
Test CI for PostgreSQL as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - 1.4
   - 1.5
+# Used by the certdb tests
+services:
+  - postgresql
 before_install:
   # CFSSL consists of multiple Go packages, which refer to each other by
   # their absolute GitHub path, e.g. github.com/cloudflare/crypto/pkcs11key.
@@ -35,6 +38,12 @@ before_script:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/modocache/gover
   - go get -v github.com/GeertJohan/fgt
+  # Setup DBs + run migrations
+  - go get bitbucket.org/liamstask/goose/cmd/goose
+  - if [[ $(uname -s) == 'Linux' ]]; then
+      psql -c 'create database certdb_development;' -U postgres;
+      goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/pg up;
+    fi
 script:
   - ./test.sh
 notifications:
@@ -51,12 +60,12 @@ env:
     - secure: "OmaaZ3jhU9VQ/0SYpenUJEfnmKy/MwExkefFRpDbkRSu/hTQpxxALAZV5WEHo7gxLRMRI0pytLo7w+lAd2FlX1CNcyY62MUicta/8P2twsxp+lR3v1bJ7dwk6qsDbO7Nvv3BKPCDQCHUkggbAEJaHEQGdLk4ursNEB1aGimuCEc="
     - GO15VENDOREXPERIMENT=1
   matrix:
-    - BUILD_FLAGS=
-    - BUILD_FLAGS="-tags nopkcs11"
+    - BUILD_TAGS="postgresql"
+    - BUILD_TAGS="nopkcs11 postgresql"
 matrix:
   include:
     - os: osx
       go: 1.5
-      env: BUILD_FLAGS=
+      env: BUILD_TAGS=
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f coverprofile.txt

--- a/certdb/pg/dbconf.yml
+++ b/certdb/pg/dbconf.yml
@@ -1,15 +1,15 @@
 development:
   driver: postgres
-  open: dbname=certdb_development sslmode=disable host=/var/run/postgresql
+  open: dbname=certdb_development sslmode=disable
 
 test:
   driver: postgres
-  open: dbname=certdb_test sslmode=disable host=/var/run/postgresql
+  open: dbname=certdb_test sslmode=disable
 
 staging:
   driver: postgres
-  open: dbname=certdb_staging sslmode=disable host=/var/run/postgresql
+  open: dbname=certdb_staging sslmode=disable
 
 production:
   driver: postgres
-  open: dbname=certdb_production sslmode=disable host=/var/run/postgresql
+  open: dbname=certdb_production sslmode=disable

--- a/certdb/testdb/testdb.go
+++ b/certdb/testdb/testdb.go
@@ -34,7 +34,7 @@ DELETE FROM ocsp_responses;
 
 // PostgreSQLDB returns a PostgreSQL db instance for certdb testing.
 func PostgreSQLDB() *sql.DB {
-	connStr := "dbname=certdb_development host=/var/run/postgresql sslmode=disable"
+	connStr := "dbname=certdb_development sslmode=disable"
 
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {

--- a/test.sh
+++ b/test.sh
@@ -23,13 +23,13 @@ do
 done
 
 # Build and install cfssl executable in PATH
-go install github.com/cloudflare/cfssl/cmd/cfssl
+go install -tags "$BUILD_TAGS" github.com/cloudflare/cfssl/cmd/cfssl
 
 COVPROFILES=""
 for package in $(go list -f '{{if len .TestGoFiles}}{{.ImportPath}}{{end}}' $PACKAGES)
 do
     profile="$GOPATH/src/$package/.coverprofile"
-    go test $BUILD_FLAGS --coverprofile=$profile $package
+    go test -tags "$BUILD_TAGS" --coverprofile=$profile $package
     [ -s $profile ] && COVPROFILES="$COVPROFILES $profile"
 done
 cat $COVPROFILES > coverprofile.txt


### PR DESCRIPTION
Travis doesn't properly start PostgreSQL on OS X, so I just don't run the tests there. Also, Travis has a problem with quotes in environment variables, hence the change from `BUILD_FLAGS` to `BUILD_TAGS`. 