### PR TITLE
Add support for password encoded PEM private key

### DIFF
--- a/crl/crl.go
+++ b/crl/crl.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -55,9 +56,15 @@ func NewCRLFromFile(serialList, issuerFile, keyFile []byte, expiryTime string) (
 		}
 		revokedCerts = append(revokedCerts, tempCert)
 	}
+		
+	strPassword := os.Getenv("CFSSL_CA_PK_PASSWORD")
+	password := []byte(strPassword)
+	if (strPassword == "") {
+		password = nil
+	}
 
 	// Parse the key given
-	key, err := helpers.ParsePrivateKeyPEM(keyFile)
+	key, err := helpers.ParsePrivateKeyPEMWithPassword(keyFile, password)
 	if err != nil {
 		log.Debug("Malformed private key %v", err)
 		return nil, err

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -18,6 +18,7 @@ import (
 	"math/big"
 	"net"
 	"net/mail"
+	"os"
 
 	"github.com/cloudflare/cfssl/certdb"
 	"github.com/cloudflare/cfssl/config"
@@ -79,8 +80,14 @@ func NewSignerFromFile(caFile, caKeyFile string, policy *config.Signing) (*Signe
 	if err != nil {
 		return nil, err
 	}
+	
+	strPassword := os.Getenv("CFSSL_CA_PK_PASSWORD")
+	password := []byte(strPassword)
+	if (strPassword == "") {
+		password = nil
+	}
 
-	priv, err := helpers.ParsePrivateKeyPEM(cakey)
+	priv, err := helpers.ParsePrivateKeyPEMWithPassword(cakey, password)
 	if err != nil {
 		log.Debug("Malformed private key %v", err)
 		return nil, err


### PR DESCRIPTION
The CA private key I use to sign CSR and generate certificates must be encrypted because we have a requirement not to store it in clear text on the system.
This PR enables the use of such private keys by looking for a password in the "CFSSL_CA_PK_PASSWORD" environement variable.