### PR TITLE
Add support for including OCSP extensions

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -93,19 +93,19 @@
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ocsp",
-			"Rev": "575fdbe86e5dd89229707ebec0575ce7d088a4a6"
+			"Rev": "3760e016850398b85094c4c99e955b8c3dea5711"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/pbkdf2",
-			"Rev": "575fdbe86e5dd89229707ebec0575ce7d088a4a6"
+			"Rev": "3760e016850398b85094c4c99e955b8c3dea5711"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/pkcs12",
-			"Rev": "575fdbe86e5dd89229707ebec0575ce7d088a4a6"
+			"Rev": "3760e016850398b85094c4c99e955b8c3dea5711"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/scrypt",
-			"Rev": "575fdbe86e5dd89229707ebec0575ce7d088a4a6"
+			"Rev": "3760e016850398b85094c4c99e955b8c3dea5711"
 		}
 	]
 }

--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -52,6 +53,7 @@ type SignRequest struct {
 	Status      string
 	Reason      int
 	RevokedAt   time.Time
+	Extensions  []pkix.Extension
 }
 
 // Signer represents a general signer of OCSP responses.  It is
@@ -176,11 +178,12 @@ func (s StandardSigner) Sign(req SignRequest) ([]byte, error) {
 	}
 
 	template := ocsp.Response{
-		Status:       status,
-		SerialNumber: req.Certificate.SerialNumber,
-		ThisUpdate:   thisUpdate,
-		NextUpdate:   nextUpdate,
-		Certificate:  certificate,
+		Status:          status,
+		SerialNumber:    req.Certificate.SerialNumber,
+		ThisUpdate:      thisUpdate,
+		NextUpdate:      nextUpdate,
+		Certificate:     certificate,
+		ExtraExtensions: req.Extensions,
 	}
 
 	if status == ocsp.Revoked {


### PR DESCRIPTION
Will be useful to be able to include extensions such as Signed Certificate Timestamps.

fixes #485 