### PR TITLE
Support using cfssl in appengine applications

### DIFF
--- a/crypto/pkcs11key/key.go
+++ b/crypto/pkcs11key/key.go
@@ -1,4 +1,4 @@
-// +build !nopkcs11
+// +build !nopkcs11,!appengine
 
 // Package pkcs11key implements crypto.Signer for PKCS #11 private
 // keys. Currently, only RSA keys are supported.

--- a/crypto/pkcs11key/key_test.go
+++ b/crypto/pkcs11key/key_test.go
@@ -1,4 +1,4 @@
-// +build !nopkcs11
+// +build !nopkcs11,!appengine
 
 package pkcs11key
 

--- a/crypto/pkcs11key/pkcs11key_bench_test.go
+++ b/crypto/pkcs11key/pkcs11key_bench_test.go
@@ -1,4 +1,4 @@
-// +build !nopkcs11
+// +build !nopkcs11,!appengine
 
 package pkcs11key
 

--- a/crypto/pkcs11key/pool.go
+++ b/crypto/pkcs11key/pool.go
@@ -1,4 +1,4 @@
-// +build !nopkcs11
+// +build !nopkcs11,!appengine
 
 package pkcs11key
 

--- a/ocsp/pkcs11/pkcs11.go
+++ b/ocsp/pkcs11/pkcs11.go
@@ -1,4 +1,4 @@
-// +build !nopkcs11
+// +build !nopkcs11,!appengine
 
 // Package pkcs11 in the ocsp directory provides a way to construct a
 // PKCS#11-based OCSP signer.

--- a/ocsp/pkcs11/pkcs11_stub.go
+++ b/ocsp/pkcs11/pkcs11_stub.go
@@ -1,4 +1,4 @@
-// +build nopkcs11
+// +build nopkcs11 appengine
 
 package pkcs11
 

--- a/signer/pkcs11/pkcs11.go
+++ b/signer/pkcs11/pkcs11.go
@@ -1,4 +1,4 @@
-// +build !nopkcs11
+// +build !nopkcs11,!appengine
 
 package pkcs11
 

--- a/signer/pkcs11/pkcs11_stub.go
+++ b/signer/pkcs11/pkcs11_stub.go
@@ -1,4 +1,4 @@
-// +build nopkcs11
+// +build nopkcs11 appengine
 
 package pkcs11
 


### PR DESCRIPTION
Appengine doesn't support pkcs11 and we can't use build tags when build and deploy gae apps. This patch simply add build tag to disable pkcs11 in appengine environment.