### PR TITLE
Rely on sqlx for driver independent bind vars

### DIFF
--- a/certdb/certdb.go
+++ b/certdb/certdb.go
@@ -7,23 +7,23 @@ import (
 // CertificateRecord encodes a certificate and its metadata
 // that will be recorded in a database.
 type CertificateRecord struct {
-	Serial    string    `sql:"serial_number"`
-	AKI       string    `sql:"authority_key_identifier"`
-	CALabel   string    `sql:"ca_label"`
-	Status    string    `sql:"status"`
-	Reason    int       `sql:"reason"`
-	Expiry    time.Time `sql:"expiry"`
-	RevokedAt time.Time `sql:"revoked_at"`
-	PEM       string    `sql:"pem"`
+	Serial    string    `db:"serial_number"`
+	AKI       string    `db:"authority_key_identifier"`
+	CALabel   string    `db:"ca_label"`
+	Status    string    `db:"status"`
+	Reason    int       `db:"reason"`
+	Expiry    time.Time `db:"expiry"`
+	RevokedAt time.Time `db:"revoked_at"`
+	PEM       string    `db:"pem"`
 }
 
 // OCSPRecord encodes a OCSP response body and its metadata
 // that will be recorded in a database.
 type OCSPRecord struct {
-	Serial string    `sql:"serial_number"`
-	AKI    string    `sql:"authority_key_identifier"`
-	Body   string    `sql:"body"`
-	Expiry time.Time `sql:"expiry"`
+	Serial string    `db:"serial_number"`
+	AKI    string    `db:"authority_key_identifier"`
+	Body   string    `db:"body"`
+	Expiry time.Time `db:"expiry"`
 }
 
 // Accessor abstracts the CRUD of certdb objects from a DB.

--- a/certdb/dbconf/db_config.go
+++ b/certdb/dbconf/db_config.go
@@ -1,13 +1,14 @@
 package dbconf
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
 
 	cferr "github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // DBConfig contains the database driver name and configuration to be passed to Open
@@ -45,12 +46,12 @@ func LoadFile(path string) (cfg *DBConfig, err error) {
 }
 
 // DBFromConfig opens a sql.DB from settings in a db config file
-func DBFromConfig(path string) (db *sql.DB, err error) {
+func DBFromConfig(path string) (db *sqlx.DB, err error) {
 	var dbCfg *DBConfig
 	dbCfg, err = LoadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return sql.Open(dbCfg.DriverName, dbCfg.DataSourceName)
+	return sqlx.Open(dbCfg.DriverName, dbCfg.DataSourceName)
 }

--- a/certdb/sql/sql_pq_test.go
+++ b/certdb/sql/sql_pq_test.go
@@ -10,6 +10,9 @@ import (
 
 func TestPostgreSQL(t *testing.T) {
 	db := testdb.PostgreSQLDB()
-	dba := NewAccessor(db)
-	testEverything(dba, t)
+	ta := TestAccessor{
+		Accessor: NewAccessor(db),
+		DB:       db,
+	}
+	testEverything(ta, t)
 }

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -3,7 +3,6 @@ package serve
 
 import (
 	"crypto/tls"
-	"database/sql"
 	"errors"
 	"fmt"
 	"net"
@@ -36,6 +35,8 @@ import (
 	"github.com/cloudflare/cfssl/ocsp"
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/ubiquity"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // Usage text of 'cfssl serve'
@@ -59,7 +60,7 @@ var (
 	conf       cli.Config
 	s          signer.Signer
 	ocspSigner ocsp.Signer
-	db         *sql.DB
+	db         *sqlx.DB
 )
 
 // V1APIPrefix is the prefix of all CFSSL V1 API Endpoints.

--- a/cli/sign/sign.go
+++ b/cli/sign/sign.go
@@ -2,7 +2,6 @@
 package sign
 
 import (
-	"database/sql"
 	"encoding/json"
 	"io/ioutil"
 
@@ -13,6 +12,8 @@ import (
 	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/universal"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // Usage text of 'cfssl sign'
@@ -37,7 +38,7 @@ var signerFlags = []string{"hostname", "csr", "ca", "ca-key", "config", "profile
 
 // SignerFromConfigAndDB takes the Config and creates the appropriate
 // signer.Signer object with a specified db
-func SignerFromConfigAndDB(c cli.Config, db *sql.DB) (signer.Signer, error) {
+func SignerFromConfigAndDB(c cli.Config, db *sqlx.DB) (signer.Signer, error) {
 	// If there is a config, use its signing policy. Otherwise create a default policy.
 	var policy *config.Signing
 	if c.CFG != nil {
@@ -74,7 +75,7 @@ func SignerFromConfigAndDB(c cli.Config, db *sql.DB) (signer.Signer, error) {
 // SignerFromConfig takes the Config and creates the appropriate
 // signer.Signer object
 func SignerFromConfig(c cli.Config) (s signer.Signer, err error) {
-	var db *sql.DB
+	var db *sqlx.DB
 	if c.DBConfigFile != "" {
 		db, err = dbconf.DBFromConfig(c.DBConfigFile)
 		if err != nil {

--- a/multiroot/config/config.go
+++ b/multiroot/config/config.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"crypto"
 	"crypto/x509"
-	"database/sql"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/cloudflare/redoctober/client"
 	"github.com/cloudflare/redoctober/core"
+	"github.com/jmoiron/sqlx"
 )
 
 // RawMap is shorthand for the type used as a map from string to raw Root struct.
@@ -104,7 +104,7 @@ type Root struct {
 	Certificate *x509.Certificate
 	Config      *config.Signing
 	ACL         whitelist.NetACL
-	DB          *sql.DB
+	DB          *sqlx.DB
 }
 
 // LoadRoot parses a config structure into a Root structure

--- a/vendor/github.com/jmoiron/sqlx/LICENSE
+++ b/vendor/github.com/jmoiron/sqlx/LICENSE
@@ -1,0 +1,23 @@
+ Copyright (c) 2013, Jason Moiron
+
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/jmoiron/sqlx/README.md
+++ b/vendor/github.com/jmoiron/sqlx/README.md
@@ -1,0 +1,185 @@
+#sqlx
+
+[![Build Status](https://drone.io/github.com/jmoiron/sqlx/status.png)](https://drone.io/github.com/jmoiron/sqlx/latest) [![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/jmoiron/sqlx) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/jmoiron/sqlx/master/LICENSE)
+
+sqlx is a library which provides a set of extensions on go's standard
+`database/sql` library.  The sqlx versions of `sql.DB`, `sql.TX`, `sql.Stmt`,
+et al. all leave the underlying interfaces untouched, so that their interfaces
+are a superset on the standard ones.  This makes it relatively painless to
+integrate existing codebases using database/sql with sqlx.
+
+Major additional concepts are:
+
+* Marshal rows into structs (with embedded struct support), maps, and slices
+* Named parameter support including prepared statements
+* `Get` and `Select` to go quickly from query to struct/slice
+
+In addition to the [godoc API documentation](http://godoc.org/github.com/jmoiron/sqlx),
+there is also some [standard documentation](http://jmoiron.github.io/sqlx/) that
+explains how to use `database/sql` along with sqlx.
+
+## Recent Changes
+
+* sqlx/types.JsonText has been renamed to JSONText to follow Go naming conventions.
+
+This breaks backwards compatibility, but it's in a way that is trivially fixable
+(`s/JsonText/JSONText/g`).  The `types` package is both experimental and not in
+active development currently.
+
+More importantly, [golang bug #13905](https://github.com/golang/go/issues/13905)
+makes `types.JSONText` and `types.GzippedText` _potentially unsafe_, **especially**
+when used with common auto-scan sqlx idioms like `Select` and `Get`.
+
+### Backwards Compatibility
+
+There is no Go1-like promise of absolute stability, but I take the issue seriously
+and will maintain the library in a compatible state unless vital bugs prevent me 
+from doing so.  Since [#59](https://github.com/jmoiron/sqlx/issues/59) and 
+[#60](https://github.com/jmoiron/sqlx/issues/60) necessitated breaking behavior, 
+a wider API cleanup was done at the time of fixing.  It's possible this will happen
+in future;  if it does, a git tag will be provided for users requiring the old
+behavior to continue to use it until such a time as they can migrate.
+
+## install
+
+    go get github.com/jmoiron/sqlx
+
+## issues
+
+Row headers can be ambiguous (`SELECT 1 AS a, 2 AS a`), and the result of
+`Columns()` does not fully qualify column names in queries like:
+
+```sql
+SELECT a.id, a.name, b.id, b.name FROM foos AS a JOIN foos AS b ON a.parent = b.id;
+```
+
+making a struct or map destination ambiguous.  Use `AS` in your queries
+to give columns distinct names, `rows.Scan` to scan them manually, or 
+`SliceScan` to get a slice of results.
+
+## usage
+
+Below is an example which shows some common use cases for sqlx.  Check 
+[sqlx_test.go](https://github.com/jmoiron/sqlx/blob/master/sqlx_test.go) for more
+usage.
+
+
+```go
+package main
+
+import (
+    _ "github.com/lib/pq"
+    "database/sql"
+    "github.com/jmoiron/sqlx"
+    "log"
+)
+
+var schema = `
+CREATE TABLE person (
+    first_name text,
+    last_name text,
+    email text
+);
+
+CREATE TABLE place (
+    country text,
+    city text NULL,
+    telcode integer
+)`
+
+type Person struct {
+    FirstName string `db:"first_name"`
+    LastName  string `db:"last_name"`
+    Email     string
+}
+
+type Place struct {
+    Country string
+    City    sql.NullString
+    TelCode int
+}
+
+func main() {
+    // this Pings the database trying to connect, panics on error
+    // use sqlx.Open() for sql.Open() semantics
+    db, err := sqlx.Connect("postgres", "user=foo dbname=bar sslmode=disable")
+    if err != nil {
+        log.Fatalln(err)
+    }
+
+    // exec the schema or fail; multi-statement Exec behavior varies between
+    // database drivers;  pq will exec them all, sqlite3 won't, ymmv
+    db.MustExec(schema)
+    
+    tx := db.MustBegin()
+    tx.MustExec("INSERT INTO person (first_name, last_name, email) VALUES ($1, $2, $3)", "Jason", "Moiron", "jmoiron@jmoiron.net")
+    tx.MustExec("INSERT INTO person (first_name, last_name, email) VALUES ($1, $2, $3)", "John", "Doe", "johndoeDNE@gmail.net")
+    tx.MustExec("INSERT INTO place (country, city, telcode) VALUES ($1, $2, $3)", "United States", "New York", "1")
+    tx.MustExec("INSERT INTO place (country, telcode) VALUES ($1, $2)", "Hong Kong", "852")
+    tx.MustExec("INSERT INTO place (country, telcode) VALUES ($1, $2)", "Singapore", "65")
+    // Named queries can use structs, so if you have an existing struct (i.e. person := &Person{}) that you have populated, you can pass it in as &person
+    tx.NamedExec("INSERT INTO person (first_name, last_name, email) VALUES (:first_name, :last_name, :email)", &Person{"Jane", "Citizen", "jane.citzen@example.com"})
+    tx.Commit()
+
+    // Query the database, storing results in a []Person (wrapped in []interface{})
+    people := []Person{}
+    db.Select(&people, "SELECT * FROM person ORDER BY first_name ASC")
+    jason, john := people[0], people[1]
+
+    fmt.Printf("%#v\n%#v", jason, john)
+    // Person{FirstName:"Jason", LastName:"Moiron", Email:"jmoiron@jmoiron.net"}
+    // Person{FirstName:"John", LastName:"Doe", Email:"johndoeDNE@gmail.net"}
+
+    // You can also get a single result, a la QueryRow
+    jason = Person{}
+    err = db.Get(&jason, "SELECT * FROM person WHERE first_name=$1", "Jason")
+    fmt.Printf("%#v\n", jason)
+    // Person{FirstName:"Jason", LastName:"Moiron", Email:"jmoiron@jmoiron.net"}
+
+    // if you have null fields and use SELECT *, you must use sql.Null* in your struct
+    places := []Place{}
+    err = db.Select(&places, "SELECT * FROM place ORDER BY telcode ASC")
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    usa, singsing, honkers := places[0], places[1], places[2]
+    
+    fmt.Printf("%#v\n%#v\n%#v\n", usa, singsing, honkers)
+    // Place{Country:"United States", City:sql.NullString{String:"New York", Valid:true}, TelCode:1}
+    // Place{Country:"Singapore", City:sql.NullString{String:"", Valid:false}, TelCode:65}
+    // Place{Country:"Hong Kong", City:sql.NullString{String:"", Valid:false}, TelCode:852}
+
+    // Loop through rows using only one struct
+    place := Place{}
+    rows, err := db.Queryx("SELECT * FROM place")
+    for rows.Next() {
+        err := rows.StructScan(&place)
+        if err != nil {
+            log.Fatalln(err)
+        } 
+        fmt.Printf("%#v\n", place)
+    }
+    // Place{Country:"United States", City:sql.NullString{String:"New York", Valid:true}, TelCode:1}
+    // Place{Country:"Hong Kong", City:sql.NullString{String:"", Valid:false}, TelCode:852}
+    // Place{Country:"Singapore", City:sql.NullString{String:"", Valid:false}, TelCode:65}
+
+    // Named queries, using `:name` as the bindvar.  Automatic bindvar support
+    // which takes into account the dbtype based on the driverName on sqlx.Open/Connect
+    _, err = db.NamedExec(`INSERT INTO person (first_name,last_name,email) VALUES (:first,:last,:email)`, 
+        map[string]interface{}{
+            "first": "Bin",
+            "last": "Smuth",
+            "email": "bensmith@allblacks.nz",
+    })
+
+    // Selects Mr. Smith from the database
+    rows, err = db.NamedQuery(`SELECT * FROM person WHERE first_name=:fn`, map[string]interface{}{"fn": "Bin"})
+
+    // Named queries can also use structs.  Their bind names follow the same rules
+    // as the name -> db mapping, so struct fields are lowercased and the `db` tag
+    // is taken into consideration.
+    rows, err = db.NamedQuery(`SELECT * FROM person WHERE first_name=:first_name`, jason)
+}
+```
+

--- a/vendor/github.com/jmoiron/sqlx/bind.go
+++ b/vendor/github.com/jmoiron/sqlx/bind.go
@@ -1,0 +1,186 @@
+package sqlx
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/jmoiron/sqlx/reflectx"
+)
+
+// Bindvar types supported by Rebind, BindMap and BindStruct.
+const (
+	UNKNOWN = iota
+	QUESTION
+	DOLLAR
+	NAMED
+)
+
+// BindType returns the bindtype for a given database given a drivername.
+func BindType(driverName string) int {
+	switch driverName {
+	case "postgres", "pgx":
+		return DOLLAR
+	case "mysql":
+		return QUESTION
+	case "sqlite3":
+		return QUESTION
+	case "oci8":
+		return NAMED
+	}
+	return UNKNOWN
+}
+
+// FIXME: this should be able to be tolerant of escaped ?'s in queries without
+// losing much speed, and should be to avoid confusion.
+
+// Rebind a query from the default bindtype (QUESTION) to the target bindtype.
+func Rebind(bindType int, query string) string {
+	switch bindType {
+	case QUESTION, UNKNOWN:
+		return query
+	}
+
+	qb := []byte(query)
+	// Add space enough for 10 params before we have to allocate
+	rqb := make([]byte, 0, len(qb)+10)
+	j := 1
+	for _, b := range qb {
+		if b == '?' {
+			switch bindType {
+			case DOLLAR:
+				rqb = append(rqb, '$')
+			case NAMED:
+				rqb = append(rqb, ':', 'a', 'r', 'g')
+			}
+			for _, b := range strconv.Itoa(j) {
+				rqb = append(rqb, byte(b))
+			}
+			j++
+		} else {
+			rqb = append(rqb, b)
+		}
+	}
+	return string(rqb)
+}
+
+// Experimental implementation of Rebind which uses a bytes.Buffer.  The code is
+// much simpler and should be more resistant to odd unicode, but it is twice as
+// slow.  Kept here for benchmarking purposes and to possibly replace Rebind if
+// problems arise with its somewhat naive handling of unicode.
+func rebindBuff(bindType int, query string) string {
+	if bindType != DOLLAR {
+		return query
+	}
+
+	b := make([]byte, 0, len(query))
+	rqb := bytes.NewBuffer(b)
+	j := 1
+	for _, r := range query {
+		if r == '?' {
+			rqb.WriteRune('$')
+			rqb.WriteString(strconv.Itoa(j))
+			j++
+		} else {
+			rqb.WriteRune(r)
+		}
+	}
+
+	return rqb.String()
+}
+
+// In expands slice values in args, returning the modified query string
+// and a new arg list that can be executed by a database. The `query` should
+// use the `?` bindVar.  The return value uses the `?` bindVar.
+func In(query string, args ...interface{}) (string, []interface{}, error) {
+	// argMeta stores reflect.Value and length for slices and
+	// the value itself for non-slice arguments
+	type argMeta struct {
+		v      reflect.Value
+		i      interface{}
+		length int
+	}
+
+	var flatArgsCount int
+	var anySlices bool
+
+	meta := make([]argMeta, len(args))
+
+	for i, arg := range args {
+		v := reflect.ValueOf(arg)
+		t := reflectx.Deref(v.Type())
+
+		if t.Kind() == reflect.Slice {
+			meta[i].length = v.Len()
+			meta[i].v = v
+
+			anySlices = true
+			flatArgsCount += meta[i].length
+
+			if meta[i].length == 0 {
+				return "", nil, errors.New("empty slice passed to 'in' query")
+			}
+		} else {
+			meta[i].i = arg
+			flatArgsCount++
+		}
+	}
+
+	// don't do any parsing if there aren't any slices;  note that this means
+	// some errors that we might have caught below will not be returned.
+	if !anySlices {
+		return query, args, nil
+	}
+
+	newArgs := make([]interface{}, 0, flatArgsCount)
+
+	var arg, offset int
+	var buf bytes.Buffer
+
+	for i := strings.IndexByte(query[offset:], '?'); i != -1; i = strings.IndexByte(query[offset:], '?') {
+		if arg >= len(meta) {
+			// if an argument wasn't passed, lets return an error;  this is
+			// not actually how database/sql Exec/Query works, but since we are
+			// creating an argument list programmatically, we want to be able
+			// to catch these programmer errors earlier.
+			return "", nil, errors.New("number of bindVars exceeds arguments")
+		}
+
+		argMeta := meta[arg]
+		arg++
+
+		// not a slice, continue.
+		// our questionmark will either be written before the next expansion
+		// of a slice or after the loop when writing the rest of the query
+		if argMeta.length == 0 {
+			offset = offset + i + 1
+			newArgs = append(newArgs, argMeta.i)
+			continue
+		}
+
+		// write everything up to and including our ? character
+		buf.WriteString(query[:offset+i+1])
+
+		newArgs = append(newArgs, argMeta.v.Index(0).Interface())
+
+		for si := 1; si < argMeta.length; si++ {
+			buf.WriteString(", ?")
+			newArgs = append(newArgs, argMeta.v.Index(si).Interface())
+		}
+
+		// slice the query and reset the offset. this avoids some bookkeeping for
+		// the write after the loop
+		query = query[offset+i+1:]
+		offset = 0
+	}
+
+	buf.WriteString(query)
+
+	if arg < len(meta) {
+		return "", nil, errors.New("number of bindVars less than number arguments")
+	}
+
+	return buf.String(), newArgs, nil
+}

--- a/vendor/github.com/jmoiron/sqlx/doc.go
+++ b/vendor/github.com/jmoiron/sqlx/doc.go
@@ -1,0 +1,12 @@
+// Package sqlx provides general purpose extensions to database/sql.
+//
+// It is intended to seamlessly wrap database/sql and provide convenience
+// methods which are useful in the development of database driven applications.
+// None of the underlying database/sql methods are changed.  Instead all extended
+// behavior is implemented through new methods defined on wrapper types.
+//
+// Additions include scanning into structs, named query support, rebinding
+// queries for different drivers, convenient shorthands for common error handling
+// and more.
+//
+package sqlx

--- a/vendor/github.com/jmoiron/sqlx/named.go
+++ b/vendor/github.com/jmoiron/sqlx/named.go
@@ -1,0 +1,336 @@
+package sqlx
+
+// Named Query Support
+//
+//  * BindMap - bind query bindvars to map/struct args
+//	* NamedExec, NamedQuery - named query w/ struct or map
+//  * NamedStmt - a pre-compiled named query which is a prepared statement
+//
+// Internal Interfaces:
+//
+//  * compileNamedQuery - rebind a named query, returning a query and list of names
+//  * bindArgs, bindMapArgs, bindAnyArgs - given a list of names, return an arglist
+//
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"unicode"
+
+	"github.com/jmoiron/sqlx/reflectx"
+)
+
+// NamedStmt is a prepared statement that executes named queries.  Prepare it
+// how you would execute a NamedQuery, but pass in a struct or map when executing.
+type NamedStmt struct {
+	Params      []string
+	QueryString string
+	Stmt        *Stmt
+}
+
+// Close closes the named statement.
+func (n *NamedStmt) Close() error {
+	return n.Stmt.Close()
+}
+
+// Exec executes a named statement using the struct passed.
+func (n *NamedStmt) Exec(arg interface{}) (sql.Result, error) {
+	args, err := bindAnyArgs(n.Params, arg, n.Stmt.Mapper)
+	if err != nil {
+		return *new(sql.Result), err
+	}
+	return n.Stmt.Exec(args...)
+}
+
+// Query executes a named statement using the struct argument, returning rows.
+func (n *NamedStmt) Query(arg interface{}) (*sql.Rows, error) {
+	args, err := bindAnyArgs(n.Params, arg, n.Stmt.Mapper)
+	if err != nil {
+		return nil, err
+	}
+	return n.Stmt.Query(args...)
+}
+
+// QueryRow executes a named statement against the database.  Because sqlx cannot
+// create a *sql.Row with an error condition pre-set for binding errors, sqlx
+// returns a *sqlx.Row instead.
+func (n *NamedStmt) QueryRow(arg interface{}) *Row {
+	args, err := bindAnyArgs(n.Params, arg, n.Stmt.Mapper)
+	if err != nil {
+		return &Row{err: err}
+	}
+	return n.Stmt.QueryRowx(args...)
+}
+
+// MustExec execs a NamedStmt, panicing on error
+func (n *NamedStmt) MustExec(arg interface{}) sql.Result {
+	res, err := n.Exec(arg)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+// Queryx using this NamedStmt
+func (n *NamedStmt) Queryx(arg interface{}) (*Rows, error) {
+	r, err := n.Query(arg)
+	if err != nil {
+		return nil, err
+	}
+	return &Rows{Rows: r, Mapper: n.Stmt.Mapper, unsafe: isUnsafe(n)}, err
+}
+
+// QueryRowx this NamedStmt.  Because of limitations with QueryRow, this is
+// an alias for QueryRow.
+func (n *NamedStmt) QueryRowx(arg interface{}) *Row {
+	return n.QueryRow(arg)
+}
+
+// Select using this NamedStmt
+func (n *NamedStmt) Select(dest interface{}, arg interface{}) error {
+	rows, err := n.Queryx(arg)
+	if err != nil {
+		return err
+	}
+	// if something happens here, we want to make sure the rows are Closed
+	defer rows.Close()
+	return scanAll(rows, dest, false)
+}
+
+// Get using this NamedStmt
+func (n *NamedStmt) Get(dest interface{}, arg interface{}) error {
+	r := n.QueryRowx(arg)
+	return r.scanAny(dest, false)
+}
+
+// Unsafe creates an unsafe version of the NamedStmt
+func (n *NamedStmt) Unsafe() *NamedStmt {
+	r := &NamedStmt{Params: n.Params, Stmt: n.Stmt, QueryString: n.QueryString}
+	r.Stmt.unsafe = true
+	return r
+}
+
+// A union interface of preparer and binder, required to be able to prepare
+// named statements (as the bindtype must be determined).
+type namedPreparer interface {
+	Preparer
+	binder
+}
+
+func prepareNamed(p namedPreparer, query string) (*NamedStmt, error) {
+	bindType := BindType(p.DriverName())
+	q, args, err := compileNamedQuery([]byte(query), bindType)
+	if err != nil {
+		return nil, err
+	}
+	stmt, err := Preparex(p, q)
+	if err != nil {
+		return nil, err
+	}
+	return &NamedStmt{
+		QueryString: q,
+		Params:      args,
+		Stmt:        stmt,
+	}, nil
+}
+
+func bindAnyArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interface{}, error) {
+	if maparg, ok := arg.(map[string]interface{}); ok {
+		return bindMapArgs(names, maparg)
+	}
+	return bindArgs(names, arg, m)
+}
+
+// private interface to generate a list of interfaces from a given struct
+// type, given a list of names to pull out of the struct.  Used by public
+// BindStruct interface.
+func bindArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interface{}, error) {
+	arglist := make([]interface{}, 0, len(names))
+
+	// grab the indirected value of arg
+	v := reflect.ValueOf(arg)
+	for v = reflect.ValueOf(arg); v.Kind() == reflect.Ptr; {
+		v = v.Elem()
+	}
+
+	fields := m.TraversalsByName(v.Type(), names)
+	for i, t := range fields {
+		if len(t) == 0 {
+			return arglist, fmt.Errorf("could not find name %s in %#v", names[i], arg)
+		}
+		val := reflectx.FieldByIndexesReadOnly(v, t)
+		arglist = append(arglist, val.Interface())
+	}
+
+	return arglist, nil
+}
+
+// like bindArgs, but for maps.
+func bindMapArgs(names []string, arg map[string]interface{}) ([]interface{}, error) {
+	arglist := make([]interface{}, 0, len(names))
+
+	for _, name := range names {
+		val, ok := arg[name]
+		if !ok {
+			return arglist, fmt.Errorf("could not find name %s in %#v", name, arg)
+		}
+		arglist = append(arglist, val)
+	}
+	return arglist, nil
+}
+
+// bindStruct binds a named parameter query with fields from a struct argument.
+// The rules for binding field names to parameter names follow the same
+// conventions as for StructScan, including obeying the `db` struct tags.
+func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper) (string, []interface{}, error) {
+	bound, names, err := compileNamedQuery([]byte(query), bindType)
+	if err != nil {
+		return "", []interface{}{}, err
+	}
+
+	arglist, err := bindArgs(names, arg, m)
+	if err != nil {
+		return "", []interface{}{}, err
+	}
+
+	return bound, arglist, nil
+}
+
+// bindMap binds a named parameter query with a map of arguments.
+func bindMap(bindType int, query string, args map[string]interface{}) (string, []interface{}, error) {
+	bound, names, err := compileNamedQuery([]byte(query), bindType)
+	if err != nil {
+		return "", []interface{}{}, err
+	}
+
+	arglist, err := bindMapArgs(names, args)
+	return bound, arglist, err
+}
+
+// -- Compilation of Named Queries
+
+// Allow digits and letters in bind params;  additionally runes are
+// checked against underscores, meaning that bind params can have be
+// alphanumeric with underscores.  Mind the difference between unicode
+// digits and numbers, where '5' is a digit but '五' is not.
+var allowedBindRunes = []*unicode.RangeTable{unicode.Letter, unicode.Digit}
+
+// FIXME: this function isn't safe for unicode named params, as a failing test
+// can testify.  This is not a regression but a failure of the original code
+// as well.  It should be modified to range over runes in a string rather than
+// bytes, even though this is less convenient and slower.  Hopefully the
+// addition of the prepared NamedStmt (which will only do this once) will make
+// up for the slightly slower ad-hoc NamedExec/NamedQuery.
+
+// compile a NamedQuery into an unbound query (using the '?' bindvar) and
+// a list of names.
+func compileNamedQuery(qs []byte, bindType int) (query string, names []string, err error) {
+	names = make([]string, 0, 10)
+	rebound := make([]byte, 0, len(qs))
+
+	inName := false
+	last := len(qs) - 1
+	currentVar := 1
+	name := make([]byte, 0, 10)
+
+	for i, b := range qs {
+		// a ':' while we're in a name is an error
+		if b == ':' {
+			// if this is the second ':' in a '::' escape sequence, append a ':'
+			if inName && i > 0 && qs[i-1] == ':' {
+				rebound = append(rebound, ':')
+				inName = false
+				continue
+			} else if inName {
+				err = errors.New("unexpected `:` while reading named param at " + strconv.Itoa(i))
+				return query, names, err
+			}
+			inName = true
+			name = []byte{}
+			// if we're in a name, and this is an allowed character, continue
+		} else if inName && (unicode.IsOneOf(allowedBindRunes, rune(b)) || b == '_') && i != last {
+			// append the byte to the name if we are in a name and not on the last byte
+			name = append(name, b)
+			// if we're in a name and it's not an allowed character, the name is done
+		} else if inName {
+			inName = false
+			// if this is the final byte of the string and it is part of the name, then
+			// make sure to add it to the name
+			if i == last && unicode.IsOneOf(allowedBindRunes, rune(b)) {
+				name = append(name, b)
+			}
+			// add the string representation to the names list
+			names = append(names, string(name))
+			// add a proper bindvar for the bindType
+			switch bindType {
+			// oracle only supports named type bind vars even for positional
+			case NAMED:
+				rebound = append(rebound, ':')
+				rebound = append(rebound, name...)
+			case QUESTION, UNKNOWN:
+				rebound = append(rebound, '?')
+			case DOLLAR:
+				rebound = append(rebound, '$')
+				for _, b := range strconv.Itoa(currentVar) {
+					rebound = append(rebound, byte(b))
+				}
+				currentVar++
+			}
+			// add this byte to string unless it was not part of the name
+			if i != last {
+				rebound = append(rebound, b)
+			} else if !unicode.IsOneOf(allowedBindRunes, rune(b)) {
+				rebound = append(rebound, b)
+			}
+		} else {
+			// this is a normal byte and should just go onto the rebound query
+			rebound = append(rebound, b)
+		}
+	}
+
+	return string(rebound), names, err
+}
+
+// BindNamed binds a struct or a map to a query with named parameters.
+// DEPRECATED: use sqlx.Named` instead of this, it may be removed in future.
+func BindNamed(bindType int, query string, arg interface{}) (string, []interface{}, error) {
+	return bindNamedMapper(bindType, query, arg, mapper())
+}
+
+// Named takes a query using named parameters and an argument and
+// returns a new query with a list of args that can be executed by
+// a database.  The return value uses the `?` bindvar.
+func Named(query string, arg interface{}) (string, []interface{}, error) {
+	return bindNamedMapper(QUESTION, query, arg, mapper())
+}
+
+func bindNamedMapper(bindType int, query string, arg interface{}, m *reflectx.Mapper) (string, []interface{}, error) {
+	if maparg, ok := arg.(map[string]interface{}); ok {
+		return bindMap(bindType, query, maparg)
+	}
+	return bindStruct(bindType, query, arg, m)
+}
+
+// NamedQuery binds a named query and then runs Query on the result using the
+// provided Ext (sqlx.Tx, sqlx.Db).  It works with both structs and with
+// map[string]interface{} types.
+func NamedQuery(e Ext, query string, arg interface{}) (*Rows, error) {
+	q, args, err := bindNamedMapper(BindType(e.DriverName()), query, arg, mapperFor(e))
+	if err != nil {
+		return nil, err
+	}
+	return e.Queryx(q, args...)
+}
+
+// NamedExec uses BindStruct to get a query executable by the driver and
+// then runs Exec on the result.  Returns an error from the binding
+// or the query excution itself.
+func NamedExec(e Ext, query string, arg interface{}) (sql.Result, error) {
+	q, args, err := bindNamedMapper(BindType(e.DriverName()), query, arg, mapperFor(e))
+	if err != nil {
+		return nil, err
+	}
+	return e.Exec(q, args...)
+}

--- a/vendor/github.com/jmoiron/sqlx/named_test.go
+++ b/vendor/github.com/jmoiron/sqlx/named_test.go
@@ -1,0 +1,227 @@
+package sqlx
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestCompileQuery(t *testing.T) {
+	table := []struct {
+		Q, R, D, N string
+		V          []string
+	}{
+		// basic test for named parameters, invalid char ',' terminating
+		{
+			Q: `INSERT INTO foo (a,b,c,d) VALUES (:name, :age, :first, :last)`,
+			R: `INSERT INTO foo (a,b,c,d) VALUES (?, ?, ?, ?)`,
+			D: `INSERT INTO foo (a,b,c,d) VALUES ($1, $2, $3, $4)`,
+			N: `INSERT INTO foo (a,b,c,d) VALUES (:name, :age, :first, :last)`,
+			V: []string{"name", "age", "first", "last"},
+		},
+		// This query tests a named parameter ending the string as well as numbers
+		{
+			Q: `SELECT * FROM a WHERE first_name=:name1 AND last_name=:name2`,
+			R: `SELECT * FROM a WHERE first_name=? AND last_name=?`,
+			D: `SELECT * FROM a WHERE first_name=$1 AND last_name=$2`,
+			N: `SELECT * FROM a WHERE first_name=:name1 AND last_name=:name2`,
+			V: []string{"name1", "name2"},
+		},
+		{
+			Q: `SELECT "::foo" FROM a WHERE first_name=:name1 AND last_name=:name2`,
+			R: `SELECT ":foo" FROM a WHERE first_name=? AND last_name=?`,
+			D: `SELECT ":foo" FROM a WHERE first_name=$1 AND last_name=$2`,
+			N: `SELECT ":foo" FROM a WHERE first_name=:name1 AND last_name=:name2`,
+			V: []string{"name1", "name2"},
+		},
+		{
+			Q: `SELECT 'a::b::c' || first_name, '::::ABC::_::' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
+			R: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=? AND last_name=?`,
+			D: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=$1 AND last_name=$2`,
+			N: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
+			V: []string{"first_name", "last_name"},
+		},
+		/* This unicode awareness test sadly fails, because of our byte-wise worldview.
+		 * We could certainly iterate by Rune instead, though it's a great deal slower,
+		 * it's probably the RightWay(tm)
+		{
+			Q: `INSERT INTO foo (a,b,c,d) VALUES (:あ, :b, :キコ, :名前)`,
+			R: `INSERT INTO foo (a,b,c,d) VALUES (?, ?, ?, ?)`,
+			D: `INSERT INTO foo (a,b,c,d) VALUES ($1, $2, $3, $4)`,
+			N: []string{"name", "age", "first", "last"},
+		},
+		*/
+	}
+
+	for _, test := range table {
+		qr, names, err := compileNamedQuery([]byte(test.Q), QUESTION)
+		if err != nil {
+			t.Error(err)
+		}
+		if qr != test.R {
+			t.Errorf("expected %s, got %s", test.R, qr)
+		}
+		if len(names) != len(test.V) {
+			t.Errorf("expected %#v, got %#v", test.V, names)
+		} else {
+			for i, name := range names {
+				if name != test.V[i] {
+					t.Errorf("expected %dth name to be %s, got %s", i+1, test.V[i], name)
+				}
+			}
+		}
+		qd, _, _ := compileNamedQuery([]byte(test.Q), DOLLAR)
+		if qd != test.D {
+			t.Errorf("\nexpected: `%s`\ngot:      `%s`", test.D, qd)
+		}
+
+		qq, _, _ := compileNamedQuery([]byte(test.Q), NAMED)
+		if qq != test.N {
+			t.Errorf("\nexpected: `%s`\ngot:      `%s`\n(len: %d vs %d)", test.N, qq, len(test.N), len(qq))
+		}
+	}
+}
+
+type Test struct {
+	t *testing.T
+}
+
+func (t Test) Error(err error, msg ...interface{}) {
+	if err != nil {
+		if len(msg) == 0 {
+			t.t.Error(err)
+		} else {
+			t.t.Error(msg...)
+		}
+	}
+}
+
+func (t Test) Errorf(err error, format string, args ...interface{}) {
+	if err != nil {
+		t.t.Errorf(format, args...)
+	}
+}
+
+func TestNamedQueries(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		test := Test{t}
+		var ns *NamedStmt
+		var err error
+
+		// Check that invalid preparations fail
+		ns, err = db.PrepareNamed("SELECT * FROM person WHERE first_name=:first:name")
+		if err == nil {
+			t.Error("Expected an error with invalid prepared statement.")
+		}
+
+		ns, err = db.PrepareNamed("invalid sql")
+		if err == nil {
+			t.Error("Expected an error with invalid prepared statement.")
+		}
+
+		// Check closing works as anticipated
+		ns, err = db.PrepareNamed("SELECT * FROM person WHERE first_name=:first_name")
+		test.Error(err)
+		err = ns.Close()
+		test.Error(err)
+
+		ns, err = db.PrepareNamed(`
+			SELECT first_name, last_name, email 
+			FROM person WHERE first_name=:first_name AND email=:email`)
+		test.Error(err)
+
+		// test Queryx w/ uses Query
+		p := Person{FirstName: "Jason", LastName: "Moiron", Email: "jmoiron@jmoiron.net"}
+
+		rows, err := ns.Queryx(p)
+		test.Error(err)
+		for rows.Next() {
+			var p2 Person
+			rows.StructScan(&p2)
+			if p.FirstName != p2.FirstName {
+				t.Errorf("got %s, expected %s", p.FirstName, p2.FirstName)
+			}
+			if p.LastName != p2.LastName {
+				t.Errorf("got %s, expected %s", p.LastName, p2.LastName)
+			}
+			if p.Email != p2.Email {
+				t.Errorf("got %s, expected %s", p.Email, p2.Email)
+			}
+		}
+
+		// test Select
+		people := make([]Person, 0, 5)
+		err = ns.Select(&people, p)
+		test.Error(err)
+
+		if len(people) != 1 {
+			t.Errorf("got %d results, expected %d", len(people), 1)
+		}
+		if p.FirstName != people[0].FirstName {
+			t.Errorf("got %s, expected %s", p.FirstName, people[0].FirstName)
+		}
+		if p.LastName != people[0].LastName {
+			t.Errorf("got %s, expected %s", p.LastName, people[0].LastName)
+		}
+		if p.Email != people[0].Email {
+			t.Errorf("got %s, expected %s", p.Email, people[0].Email)
+		}
+
+		// test Exec
+		ns, err = db.PrepareNamed(`
+			INSERT INTO person (first_name, last_name, email)
+			VALUES (:first_name, :last_name, :email)`)
+		test.Error(err)
+
+		js := Person{
+			FirstName: "Julien",
+			LastName:  "Savea",
+			Email:     "jsavea@ab.co.nz",
+		}
+		_, err = ns.Exec(js)
+		test.Error(err)
+
+		// Make sure we can pull him out again
+		p2 := Person{}
+		db.Get(&p2, db.Rebind("SELECT * FROM person WHERE email=?"), js.Email)
+		if p2.Email != js.Email {
+			t.Errorf("expected %s, got %s", js.Email, p2.Email)
+		}
+
+		// test Txn NamedStmts
+		tx := db.MustBegin()
+		txns := tx.NamedStmt(ns)
+
+		// We're going to add Steven in this txn
+		sl := Person{
+			FirstName: "Steven",
+			LastName:  "Luatua",
+			Email:     "sluatua@ab.co.nz",
+		}
+
+		_, err = txns.Exec(sl)
+		test.Error(err)
+		// then rollback...
+		tx.Rollback()
+		// looking for Steven after a rollback should fail
+		err = db.Get(&p2, db.Rebind("SELECT * FROM person WHERE email=?"), sl.Email)
+		if err != sql.ErrNoRows {
+			t.Errorf("expected no rows error, got %v", err)
+		}
+
+		// now do the same, but commit
+		tx = db.MustBegin()
+		txns = tx.NamedStmt(ns)
+		_, err = txns.Exec(sl)
+		test.Error(err)
+		tx.Commit()
+
+		// looking for Steven after a Commit should succeed
+		err = db.Get(&p2, db.Rebind("SELECT * FROM person WHERE email=?"), sl.Email)
+		test.Error(err)
+		if p2.Email != sl.Email {
+			t.Errorf("expected %s, got %s", sl.Email, p2.Email)
+		}
+
+	})
+}

--- a/vendor/github.com/jmoiron/sqlx/reflectx/README.md
+++ b/vendor/github.com/jmoiron/sqlx/reflectx/README.md
@@ -1,0 +1,17 @@
+# reflectx
+
+The sqlx package has special reflect needs.  In particular, it needs to:
+
+* be able to map a name to a field
+* understand embedded structs
+* understand mapping names to fields by a particular tag
+* user specified name -> field mapping functions
+
+These behaviors mimic the behaviors by the standard library marshallers and also the
+behavior of standard Go accessors.
+
+The first two are amply taken care of by `Reflect.Value.FieldByName`, and the third is
+addressed by `Reflect.Value.FieldByNameFunc`, but these don't quite understand struct
+tags in the ways that are vital to most marshalers, and they are slow.
+
+This reflectx package extends reflect to achieve these goals.

--- a/vendor/github.com/jmoiron/sqlx/reflectx/reflect.go
+++ b/vendor/github.com/jmoiron/sqlx/reflectx/reflect.go
@@ -1,0 +1,371 @@
+// Package reflectx implements extensions to the standard reflect lib suitable
+// for implementing marshaling and unmarshaling packages.  The main Mapper type
+// allows for Go-compatible named attribute access, including accessing embedded
+// struct attributes and the ability to use  functions and struct tags to
+// customize field names.
+//
+package reflectx
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// A FieldInfo is a collection of metadata about a struct field.
+type FieldInfo struct {
+	Index    []int
+	Path     string
+	Field    reflect.StructField
+	Zero     reflect.Value
+	Name     string
+	Options  map[string]string
+	Embedded bool
+	Children []*FieldInfo
+	Parent   *FieldInfo
+}
+
+// A StructMap is an index of field metadata for a struct.
+type StructMap struct {
+	Tree  *FieldInfo
+	Index []*FieldInfo
+	Paths map[string]*FieldInfo
+	Names map[string]*FieldInfo
+}
+
+// GetByPath returns a *FieldInfo for a given string path.
+func (f StructMap) GetByPath(path string) *FieldInfo {
+	return f.Paths[path]
+}
+
+// GetByTraversal returns a *FieldInfo for a given integer path.  It is
+// analogous to reflect.FieldByIndex.
+func (f StructMap) GetByTraversal(index []int) *FieldInfo {
+	if len(index) == 0 {
+		return nil
+	}
+
+	tree := f.Tree
+	for _, i := range index {
+		if i >= len(tree.Children) || tree.Children[i] == nil {
+			return nil
+		}
+		tree = tree.Children[i]
+	}
+	return tree
+}
+
+// Mapper is a general purpose mapper of names to struct fields.  A Mapper
+// behaves like most marshallers, optionally obeying a field tag for name
+// mapping and a function to provide a basic mapping of fields to names.
+type Mapper struct {
+	cache      map[reflect.Type]*StructMap
+	tagName    string
+	tagMapFunc func(string) string
+	mapFunc    func(string) string
+	mutex      sync.Mutex
+}
+
+// NewMapper returns a new mapper which optionally obeys the field tag given
+// by tagName.  If tagName is the empty string, it is ignored.
+func NewMapper(tagName string) *Mapper {
+	return &Mapper{
+		cache:   make(map[reflect.Type]*StructMap),
+		tagName: tagName,
+	}
+}
+
+// NewMapperTagFunc returns a new mapper which contains a mapper for field names
+// AND a mapper for tag values.  This is useful for tags like json which can
+// have values like "name,omitempty".
+func NewMapperTagFunc(tagName string, mapFunc, tagMapFunc func(string) string) *Mapper {
+	return &Mapper{
+		cache:      make(map[reflect.Type]*StructMap),
+		tagName:    tagName,
+		mapFunc:    mapFunc,
+		tagMapFunc: tagMapFunc,
+	}
+}
+
+// NewMapperFunc returns a new mapper which optionally obeys a field tag and
+// a struct field name mapper func given by f.  Tags will take precedence, but
+// for any other field, the mapped name will be f(field.Name)
+func NewMapperFunc(tagName string, f func(string) string) *Mapper {
+	return &Mapper{
+		cache:   make(map[reflect.Type]*StructMap),
+		tagName: tagName,
+		mapFunc: f,
+	}
+}
+
+// TypeMap returns a mapping of field strings to int slices representing
+// the traversal down the struct to reach the field.
+func (m *Mapper) TypeMap(t reflect.Type) *StructMap {
+	m.mutex.Lock()
+	mapping, ok := m.cache[t]
+	if !ok {
+		mapping = getMapping(t, m.tagName, m.mapFunc, m.tagMapFunc)
+		m.cache[t] = mapping
+	}
+	m.mutex.Unlock()
+	return mapping
+}
+
+// FieldMap returns the mapper's mapping of field names to reflect values.  Panics
+// if v's Kind is not Struct, or v is not Indirectable to a struct kind.
+func (m *Mapper) FieldMap(v reflect.Value) map[string]reflect.Value {
+	v = reflect.Indirect(v)
+	mustBe(v, reflect.Struct)
+
+	r := map[string]reflect.Value{}
+	tm := m.TypeMap(v.Type())
+	for tagName, fi := range tm.Names {
+		r[tagName] = FieldByIndexes(v, fi.Index)
+	}
+	return r
+}
+
+// FieldByName returns a field by the its mapped name as a reflect.Value.
+// Panics if v's Kind is not Struct or v is not Indirectable to a struct Kind.
+// Returns zero Value if the name is not found.
+func (m *Mapper) FieldByName(v reflect.Value, name string) reflect.Value {
+	v = reflect.Indirect(v)
+	mustBe(v, reflect.Struct)
+
+	tm := m.TypeMap(v.Type())
+	fi, ok := tm.Names[name]
+	if !ok {
+		return v
+	}
+	return FieldByIndexes(v, fi.Index)
+}
+
+// FieldsByName returns a slice of values corresponding to the slice of names
+// for the value.  Panics if v's Kind is not Struct or v is not Indirectable
+// to a struct Kind.  Returns zero Value for each name not found.
+func (m *Mapper) FieldsByName(v reflect.Value, names []string) []reflect.Value {
+	v = reflect.Indirect(v)
+	mustBe(v, reflect.Struct)
+
+	tm := m.TypeMap(v.Type())
+	vals := make([]reflect.Value, 0, len(names))
+	for _, name := range names {
+		fi, ok := tm.Names[name]
+		if !ok {
+			vals = append(vals, *new(reflect.Value))
+		} else {
+			vals = append(vals, FieldByIndexes(v, fi.Index))
+		}
+	}
+	return vals
+}
+
+// TraversalsByName returns a slice of int slices which represent the struct
+// traversals for each mapped name.  Panics if t is not a struct or Indirectable
+// to a struct.  Returns empty int slice for each name not found.
+func (m *Mapper) TraversalsByName(t reflect.Type, names []string) [][]int {
+	t = Deref(t)
+	mustBe(t, reflect.Struct)
+	tm := m.TypeMap(t)
+
+	r := make([][]int, 0, len(names))
+	for _, name := range names {
+		fi, ok := tm.Names[name]
+		if !ok {
+			r = append(r, []int{})
+		} else {
+			r = append(r, fi.Index)
+		}
+	}
+	return r
+}
+
+// FieldByIndexes returns a value for a particular struct traversal.
+func FieldByIndexes(v reflect.Value, indexes []int) reflect.Value {
+	for _, i := range indexes {
+		v = reflect.Indirect(v).Field(i)
+		// if this is a pointer, it's possible it is nil
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			alloc := reflect.New(Deref(v.Type()))
+			v.Set(alloc)
+		}
+		if v.Kind() == reflect.Map && v.IsNil() {
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+	}
+	return v
+}
+
+// FieldByIndexesReadOnly returns a value for a particular struct traversal,
+// but is not concerned with allocating nil pointers because the value is
+// going to be used for reading and not setting.
+func FieldByIndexesReadOnly(v reflect.Value, indexes []int) reflect.Value {
+	for _, i := range indexes {
+		v = reflect.Indirect(v).Field(i)
+	}
+	return v
+}
+
+// Deref is Indirect for reflect.Types
+func Deref(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+// -- helpers & utilities --
+
+type kinder interface {
+	Kind() reflect.Kind
+}
+
+// mustBe checks a value against a kind, panicing with a reflect.ValueError
+// if the kind isn't that which is required.
+func mustBe(v kinder, expected reflect.Kind) {
+	k := v.Kind()
+	if k != expected {
+		panic(&reflect.ValueError{Method: methodName(), Kind: k})
+	}
+}
+
+// methodName is returns the caller of the function calling methodName
+func methodName() string {
+	pc, _, _, _ := runtime.Caller(2)
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return "unknown method"
+	}
+	return f.Name()
+}
+
+type typeQueue struct {
+	t  reflect.Type
+	fi *FieldInfo
+	pp string // Parent path
+}
+
+// A copying append that creates a new slice each time.
+func apnd(is []int, i int) []int {
+	x := make([]int, len(is)+1)
+	for p, n := range is {
+		x[p] = n
+	}
+	x[len(x)-1] = i
+	return x
+}
+
+// getMapping returns a mapping for the t type, using the tagName, mapFunc and
+// tagMapFunc to determine the canonical names of fields.
+func getMapping(t reflect.Type, tagName string, mapFunc, tagMapFunc func(string) string) *StructMap {
+	m := []*FieldInfo{}
+
+	root := &FieldInfo{}
+	queue := []typeQueue{}
+	queue = append(queue, typeQueue{Deref(t), root, ""})
+
+	for len(queue) != 0 {
+		// pop the first item off of the queue
+		tq := queue[0]
+		queue = queue[1:]
+		nChildren := 0
+		if tq.t.Kind() == reflect.Struct {
+			nChildren = tq.t.NumField()
+		}
+		tq.fi.Children = make([]*FieldInfo, nChildren)
+
+		// iterate through all of its fields
+		for fieldPos := 0; fieldPos < nChildren; fieldPos++ {
+			f := tq.t.Field(fieldPos)
+
+			fi := FieldInfo{}
+			fi.Field = f
+			fi.Zero = reflect.New(f.Type).Elem()
+			fi.Options = map[string]string{}
+
+			var tag, name string
+			if tagName != "" && strings.Contains(string(f.Tag), tagName+":") {
+				tag = f.Tag.Get(tagName)
+				name = tag
+			} else {
+				if mapFunc != nil {
+					name = mapFunc(f.Name)
+				}
+			}
+
+			parts := strings.Split(name, ",")
+			if len(parts) > 1 {
+				name = parts[0]
+				for _, opt := range parts[1:] {
+					kv := strings.Split(opt, "=")
+					if len(kv) > 1 {
+						fi.Options[kv[0]] = kv[1]
+					} else {
+						fi.Options[kv[0]] = ""
+					}
+				}
+			}
+
+			if tagMapFunc != nil {
+				tag = tagMapFunc(tag)
+			}
+
+			fi.Name = name
+
+			if tq.pp == "" || (tq.pp == "" && tag == "") {
+				fi.Path = fi.Name
+			} else {
+				fi.Path = fmt.Sprintf("%s.%s", tq.pp, fi.Name)
+			}
+
+			// if the name is "-", disabled via a tag, skip it
+			if name == "-" {
+				continue
+			}
+
+			// skip unexported fields
+			if len(f.PkgPath) != 0 && !f.Anonymous {
+				continue
+			}
+
+			// bfs search of anonymous embedded structs
+			if f.Anonymous {
+				pp := tq.pp
+				if tag != "" {
+					pp = fi.Path
+				}
+
+				fi.Embedded = true
+				fi.Index = apnd(tq.fi.Index, fieldPos)
+				nChildren := 0
+				ft := Deref(f.Type)
+				if ft.Kind() == reflect.Struct {
+					nChildren = ft.NumField()
+				}
+				fi.Children = make([]*FieldInfo, nChildren)
+				queue = append(queue, typeQueue{Deref(f.Type), &fi, pp})
+			} else if fi.Zero.Kind() == reflect.Struct || (fi.Zero.Kind() == reflect.Ptr && fi.Zero.Type().Elem().Kind() == reflect.Struct) {
+				fi.Index = apnd(tq.fi.Index, fieldPos)
+				fi.Children = make([]*FieldInfo, Deref(f.Type).NumField())
+				queue = append(queue, typeQueue{Deref(f.Type), &fi, fi.Path})
+			}
+
+			fi.Index = apnd(tq.fi.Index, fieldPos)
+			fi.Parent = tq.fi
+			tq.fi.Children[fieldPos] = &fi
+			m = append(m, &fi)
+		}
+	}
+
+	flds := &StructMap{Index: m, Tree: root, Paths: map[string]*FieldInfo{}, Names: map[string]*FieldInfo{}}
+	for _, fi := range flds.Index {
+		flds.Paths[fi.Path] = fi
+		if fi.Name != "" && !fi.Embedded {
+			flds.Names[fi.Path] = fi
+		}
+	}
+
+	return flds
+}

--- a/vendor/github.com/jmoiron/sqlx/reflectx/reflect_test.go
+++ b/vendor/github.com/jmoiron/sqlx/reflectx/reflect_test.go
@@ -1,0 +1,587 @@
+package reflectx
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func ival(v reflect.Value) int {
+	return v.Interface().(int)
+}
+
+func TestBasic(t *testing.T) {
+	type Foo struct {
+		A int
+		B int
+		C int
+	}
+
+	f := Foo{1, 2, 3}
+	fv := reflect.ValueOf(f)
+	m := NewMapperFunc("", func(s string) string { return s })
+
+	v := m.FieldByName(fv, "A")
+	if ival(v) != f.A {
+		t.Errorf("Expecting %d, got %d", ival(v), f.A)
+	}
+	v = m.FieldByName(fv, "B")
+	if ival(v) != f.B {
+		t.Errorf("Expecting %d, got %d", f.B, ival(v))
+	}
+	v = m.FieldByName(fv, "C")
+	if ival(v) != f.C {
+		t.Errorf("Expecting %d, got %d", f.C, ival(v))
+	}
+}
+
+func TestBasicEmbedded(t *testing.T) {
+	type Foo struct {
+		A int
+	}
+
+	type Bar struct {
+		Foo // `db:""` is implied for an embedded struct
+		B   int
+		C   int `db:"-"`
+	}
+
+	type Baz struct {
+		A   int
+		Bar `db:"Bar"`
+	}
+
+	m := NewMapperFunc("db", func(s string) string { return s })
+
+	z := Baz{}
+	z.A = 1
+	z.B = 2
+	z.C = 4
+	z.Bar.Foo.A = 3
+
+	zv := reflect.ValueOf(z)
+	fields := m.TypeMap(reflect.TypeOf(z))
+
+	if len(fields.Index) != 5 {
+		t.Errorf("Expecting 5 fields")
+	}
+
+	// for _, fi := range fields.Index {
+	// 	log.Println(fi)
+	// }
+
+	v := m.FieldByName(zv, "A")
+	if ival(v) != z.A {
+		t.Errorf("Expecting %d, got %d", z.A, ival(v))
+	}
+	v = m.FieldByName(zv, "Bar.B")
+	if ival(v) != z.Bar.B {
+		t.Errorf("Expecting %d, got %d", z.Bar.B, ival(v))
+	}
+	v = m.FieldByName(zv, "Bar.A")
+	if ival(v) != z.Bar.Foo.A {
+		t.Errorf("Expecting %d, got %d", z.Bar.Foo.A, ival(v))
+	}
+	v = m.FieldByName(zv, "Bar.C")
+	if _, ok := v.Interface().(int); ok {
+		t.Errorf("Expecting Bar.C to not exist")
+	}
+
+	fi := fields.GetByPath("Bar.C")
+	if fi != nil {
+		t.Errorf("Bar.C should not exist")
+	}
+}
+
+func TestEmbeddedSimple(t *testing.T) {
+	type UUID [16]byte
+	type MyID struct {
+		UUID
+	}
+	type Item struct {
+		ID MyID
+	}
+	z := Item{}
+
+	m := NewMapper("db")
+	m.TypeMap(reflect.TypeOf(z))
+}
+
+func TestBasicEmbeddedWithTags(t *testing.T) {
+	type Foo struct {
+		A int `db:"a"`
+	}
+
+	type Bar struct {
+		Foo     // `db:""` is implied for an embedded struct
+		B   int `db:"b"`
+	}
+
+	type Baz struct {
+		A   int `db:"a"`
+		Bar     // `db:""` is implied for an embedded struct
+	}
+
+	m := NewMapper("db")
+
+	z := Baz{}
+	z.A = 1
+	z.B = 2
+	z.Bar.Foo.A = 3
+
+	zv := reflect.ValueOf(z)
+	fields := m.TypeMap(reflect.TypeOf(z))
+
+	if len(fields.Index) != 5 {
+		t.Errorf("Expecting 5 fields")
+	}
+
+	// for _, fi := range fields.index {
+	// 	log.Println(fi)
+	// }
+
+	v := m.FieldByName(zv, "a")
+	if ival(v) != z.Bar.Foo.A { // the dominant field
+		t.Errorf("Expecting %d, got %d", z.Bar.Foo.A, ival(v))
+	}
+	v = m.FieldByName(zv, "b")
+	if ival(v) != z.B {
+		t.Errorf("Expecting %d, got %d", z.B, ival(v))
+	}
+}
+
+func TestFlatTags(t *testing.T) {
+	m := NewMapper("db")
+
+	type Asset struct {
+		Title string `db:"title"`
+	}
+	type Post struct {
+		Author string `db:"author,required"`
+		Asset  Asset  `db:""`
+	}
+	// Post columns: (author title)
+
+	post := Post{Author: "Joe", Asset: Asset{Title: "Hello"}}
+	pv := reflect.ValueOf(post)
+
+	v := m.FieldByName(pv, "author")
+	if v.Interface().(string) != post.Author {
+		t.Errorf("Expecting %s, got %s", post.Author, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "title")
+	if v.Interface().(string) != post.Asset.Title {
+		t.Errorf("Expecting %s, got %s", post.Asset.Title, v.Interface().(string))
+	}
+}
+
+func TestNestedStruct(t *testing.T) {
+	m := NewMapper("db")
+
+	type Details struct {
+		Active bool `db:"active"`
+	}
+	type Asset struct {
+		Title   string  `db:"title"`
+		Details Details `db:"details"`
+	}
+	type Post struct {
+		Author string `db:"author,required"`
+		Asset  `db:"asset"`
+	}
+	// Post columns: (author asset.title asset.details.active)
+
+	post := Post{
+		Author: "Joe",
+		Asset:  Asset{Title: "Hello", Details: Details{Active: true}},
+	}
+	pv := reflect.ValueOf(post)
+
+	v := m.FieldByName(pv, "author")
+	if v.Interface().(string) != post.Author {
+		t.Errorf("Expecting %s, got %s", post.Author, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "title")
+	if _, ok := v.Interface().(string); ok {
+		t.Errorf("Expecting field to not exist")
+	}
+	v = m.FieldByName(pv, "asset.title")
+	if v.Interface().(string) != post.Asset.Title {
+		t.Errorf("Expecting %s, got %s", post.Asset.Title, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "asset.details.active")
+	if v.Interface().(bool) != post.Asset.Details.Active {
+		t.Errorf("Expecting %v, got %v", post.Asset.Details.Active, v.Interface().(bool))
+	}
+}
+
+func TestInlineStruct(t *testing.T) {
+	m := NewMapperTagFunc("db", strings.ToLower, nil)
+
+	type Employee struct {
+		Name string
+		ID   int
+	}
+	type Boss Employee
+	type person struct {
+		Employee `db:"employee"`
+		Boss     `db:"boss"`
+	}
+	// employees columns: (employee.name employee.id boss.name boss.id)
+
+	em := person{Employee: Employee{Name: "Joe", ID: 2}, Boss: Boss{Name: "Dick", ID: 1}}
+	ev := reflect.ValueOf(em)
+
+	fields := m.TypeMap(reflect.TypeOf(em))
+	if len(fields.Index) != 6 {
+		t.Errorf("Expecting 6 fields")
+	}
+
+	v := m.FieldByName(ev, "employee.name")
+	if v.Interface().(string) != em.Employee.Name {
+		t.Errorf("Expecting %s, got %s", em.Employee.Name, v.Interface().(string))
+	}
+	v = m.FieldByName(ev, "boss.id")
+	if ival(v) != em.Boss.ID {
+		t.Errorf("Expecting %v, got %v", em.Boss.ID, ival(v))
+	}
+}
+
+func TestFieldsEmbedded(t *testing.T) {
+	m := NewMapper("db")
+
+	type Person struct {
+		Name string `db:"name"`
+	}
+	type Place struct {
+		Name string `db:"name"`
+	}
+	type Article struct {
+		Title string `db:"title"`
+	}
+	type PP struct {
+		Person  `db:"person,required"`
+		Place   `db:",someflag"`
+		Article `db:",required"`
+	}
+	// PP columns: (person.name name title)
+
+	pp := PP{}
+	pp.Person.Name = "Peter"
+	pp.Place.Name = "Toronto"
+	pp.Article.Title = "Best city ever"
+
+	fields := m.TypeMap(reflect.TypeOf(pp))
+	// for i, f := range fields {
+	// 	log.Println(i, f)
+	// }
+
+	ppv := reflect.ValueOf(pp)
+
+	v := m.FieldByName(ppv, "person.name")
+	if v.Interface().(string) != pp.Person.Name {
+		t.Errorf("Expecting %s, got %s", pp.Person.Name, v.Interface().(string))
+	}
+
+	v = m.FieldByName(ppv, "name")
+	if v.Interface().(string) != pp.Place.Name {
+		t.Errorf("Expecting %s, got %s", pp.Place.Name, v.Interface().(string))
+	}
+
+	v = m.FieldByName(ppv, "title")
+	if v.Interface().(string) != pp.Article.Title {
+		t.Errorf("Expecting %s, got %s", pp.Article.Title, v.Interface().(string))
+	}
+
+	fi := fields.GetByPath("person")
+	if _, ok := fi.Options["required"]; !ok {
+		t.Errorf("Expecting required option to be set")
+	}
+	if !fi.Embedded {
+		t.Errorf("Expecting field to be embedded")
+	}
+	if len(fi.Index) != 1 || fi.Index[0] != 0 {
+		t.Errorf("Expecting index to be [0]")
+	}
+
+	fi = fields.GetByPath("person.name")
+	if fi == nil {
+		t.Errorf("Expecting person.name to exist")
+	}
+	if fi.Path != "person.name" {
+		t.Errorf("Expecting %s, got %s", "person.name", fi.Path)
+	}
+
+	fi = fields.GetByTraversal([]int{1, 0})
+	if fi == nil {
+		t.Errorf("Expecting traveral to exist")
+	}
+	if fi.Path != "name" {
+		t.Errorf("Expecting %s, got %s", "name", fi.Path)
+	}
+
+	fi = fields.GetByTraversal([]int{2})
+	if fi == nil {
+		t.Errorf("Expecting traversal to exist")
+	}
+	if _, ok := fi.Options["required"]; !ok {
+		t.Errorf("Expecting required option to be set")
+	}
+
+	trs := m.TraversalsByName(reflect.TypeOf(pp), []string{"person.name", "name", "title"})
+	if !reflect.DeepEqual(trs, [][]int{{0, 0}, {1, 0}, {2, 0}}) {
+		t.Errorf("Expecting traversal: %v", trs)
+	}
+}
+
+func TestPtrFields(t *testing.T) {
+	m := NewMapperTagFunc("db", strings.ToLower, nil)
+	type Asset struct {
+		Title string
+	}
+	type Post struct {
+		*Asset `db:"asset"`
+		Author string
+	}
+
+	post := &Post{Author: "Joe", Asset: &Asset{Title: "Hiyo"}}
+	pv := reflect.ValueOf(post)
+
+	fields := m.TypeMap(reflect.TypeOf(post))
+	if len(fields.Index) != 3 {
+		t.Errorf("Expecting 3 fields")
+	}
+
+	v := m.FieldByName(pv, "asset.title")
+	if v.Interface().(string) != post.Asset.Title {
+		t.Errorf("Expecting %s, got %s", post.Asset.Title, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "author")
+	if v.Interface().(string) != post.Author {
+		t.Errorf("Expecting %s, got %s", post.Author, v.Interface().(string))
+	}
+}
+
+func TestNamedPtrFields(t *testing.T) {
+	m := NewMapperTagFunc("db", strings.ToLower, nil)
+
+	type User struct {
+		Name string
+	}
+
+	type Asset struct {
+		Title string
+
+		Owner *User `db:"owner"`
+	}
+	type Post struct {
+		Author string
+
+		Asset1 *Asset `db:"asset1"`
+		Asset2 *Asset `db:"asset2"`
+	}
+
+	post := &Post{Author: "Joe", Asset1: &Asset{Title: "Hiyo", Owner: &User{"Username"}}} // Let Asset2 be nil
+	pv := reflect.ValueOf(post)
+
+	fields := m.TypeMap(reflect.TypeOf(post))
+	if len(fields.Index) != 9 {
+		t.Errorf("Expecting 9 fields")
+	}
+
+	v := m.FieldByName(pv, "asset1.title")
+	if v.Interface().(string) != post.Asset1.Title {
+		t.Errorf("Expecting %s, got %s", post.Asset1.Title, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "asset1.owner.name")
+	if v.Interface().(string) != post.Asset1.Owner.Name {
+		t.Errorf("Expecting %s, got %s", post.Asset1.Owner.Name, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "asset2.title")
+	if v.Interface().(string) != post.Asset2.Title {
+		t.Errorf("Expecting %s, got %s", post.Asset2.Title, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "asset2.owner.name")
+	if v.Interface().(string) != post.Asset2.Owner.Name {
+		t.Errorf("Expecting %s, got %s", post.Asset2.Owner.Name, v.Interface().(string))
+	}
+	v = m.FieldByName(pv, "author")
+	if v.Interface().(string) != post.Author {
+		t.Errorf("Expecting %s, got %s", post.Author, v.Interface().(string))
+	}
+}
+
+func TestFieldMap(t *testing.T) {
+	type Foo struct {
+		A int
+		B int
+		C int
+	}
+
+	f := Foo{1, 2, 3}
+	m := NewMapperFunc("db", strings.ToLower)
+
+	fm := m.FieldMap(reflect.ValueOf(f))
+
+	if len(fm) != 3 {
+		t.Errorf("Expecting %d keys, got %d", 3, len(fm))
+	}
+	if fm["a"].Interface().(int) != 1 {
+		t.Errorf("Expecting %d, got %d", 1, ival(fm["a"]))
+	}
+	if fm["b"].Interface().(int) != 2 {
+		t.Errorf("Expecting %d, got %d", 2, ival(fm["b"]))
+	}
+	if fm["c"].Interface().(int) != 3 {
+		t.Errorf("Expecting %d, got %d", 3, ival(fm["c"]))
+	}
+}
+
+func TestTagNameMapping(t *testing.T) {
+	type Strategy struct {
+		StrategyID   string `protobuf:"bytes,1,opt,name=strategy_id" json:"strategy_id,omitempty"`
+		StrategyName string
+	}
+
+	m := NewMapperTagFunc("json", strings.ToUpper, func(value string) string {
+		if strings.Contains(value, ",") {
+			return strings.Split(value, ",")[0]
+		}
+		return value
+	})
+	strategy := Strategy{"1", "Alpah"}
+	mapping := m.TypeMap(reflect.TypeOf(strategy))
+
+	for _, key := range []string{"strategy_id", "STRATEGYNAME"} {
+		if fi := mapping.GetByPath(key); fi == nil {
+			t.Errorf("Expecting to find key %s in mapping but did not.", key)
+		}
+	}
+}
+
+func TestMapping(t *testing.T) {
+	type Person struct {
+		ID           int
+		Name         string
+		WearsGlasses bool `db:"wears_glasses"`
+	}
+
+	m := NewMapperFunc("db", strings.ToLower)
+	p := Person{1, "Jason", true}
+	mapping := m.TypeMap(reflect.TypeOf(p))
+
+	for _, key := range []string{"id", "name", "wears_glasses"} {
+		if fi := mapping.GetByPath(key); fi == nil {
+			t.Errorf("Expecting to find key %s in mapping but did not.", key)
+		}
+	}
+
+	type SportsPerson struct {
+		Weight int
+		Age    int
+		Person
+	}
+	s := SportsPerson{Weight: 100, Age: 30, Person: p}
+	mapping = m.TypeMap(reflect.TypeOf(s))
+	for _, key := range []string{"id", "name", "wears_glasses", "weight", "age"} {
+		if fi := mapping.GetByPath(key); fi == nil {
+			t.Errorf("Expecting to find key %s in mapping but did not.", key)
+		}
+	}
+
+	type RugbyPlayer struct {
+		Position   int
+		IsIntense  bool `db:"is_intense"`
+		IsAllBlack bool `db:"-"`
+		SportsPerson
+	}
+	r := RugbyPlayer{12, true, false, s}
+	mapping = m.TypeMap(reflect.TypeOf(r))
+	for _, key := range []string{"id", "name", "wears_glasses", "weight", "age", "position", "is_intense"} {
+		if fi := mapping.GetByPath(key); fi == nil {
+			t.Errorf("Expecting to find key %s in mapping but did not.", key)
+		}
+	}
+
+	if fi := mapping.GetByPath("isallblack"); fi != nil {
+		t.Errorf("Expecting to ignore `IsAllBlack` field")
+	}
+}
+
+type E1 struct {
+	A int
+}
+type E2 struct {
+	E1
+	B int
+}
+type E3 struct {
+	E2
+	C int
+}
+type E4 struct {
+	E3
+	D int
+}
+
+func BenchmarkFieldNameL1(b *testing.B) {
+	e4 := E4{D: 1}
+	for i := 0; i < b.N; i++ {
+		v := reflect.ValueOf(e4)
+		f := v.FieldByName("D")
+		if f.Interface().(int) != 1 {
+			b.Fatal("Wrong value.")
+		}
+	}
+}
+
+func BenchmarkFieldNameL4(b *testing.B) {
+	e4 := E4{}
+	e4.A = 1
+	for i := 0; i < b.N; i++ {
+		v := reflect.ValueOf(e4)
+		f := v.FieldByName("A")
+		if f.Interface().(int) != 1 {
+			b.Fatal("Wrong value.")
+		}
+	}
+}
+
+func BenchmarkFieldPosL1(b *testing.B) {
+	e4 := E4{D: 1}
+	for i := 0; i < b.N; i++ {
+		v := reflect.ValueOf(e4)
+		f := v.Field(1)
+		if f.Interface().(int) != 1 {
+			b.Fatal("Wrong value.")
+		}
+	}
+}
+
+func BenchmarkFieldPosL4(b *testing.B) {
+	e4 := E4{}
+	e4.A = 1
+	for i := 0; i < b.N; i++ {
+		v := reflect.ValueOf(e4)
+		f := v.Field(0)
+		f = f.Field(0)
+		f = f.Field(0)
+		f = f.Field(0)
+		if f.Interface().(int) != 1 {
+			b.Fatal("Wrong value.")
+		}
+	}
+}
+
+func BenchmarkFieldByIndexL4(b *testing.B) {
+	e4 := E4{}
+	e4.A = 1
+	idx := []int{0, 0, 0, 0}
+	for i := 0; i < b.N; i++ {
+		v := reflect.ValueOf(e4)
+		f := FieldByIndexes(v, idx)
+		if f.Interface().(int) != 1 {
+			b.Fatal("Wrong value.")
+		}
+	}
+}

--- a/vendor/github.com/jmoiron/sqlx/sqlx.go
+++ b/vendor/github.com/jmoiron/sqlx/sqlx.go
@@ -1,0 +1,992 @@
+package sqlx
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/jmoiron/sqlx/reflectx"
+)
+
+// Although the NameMapper is convenient, in practice it should not
+// be relied on except for application code.  If you are writing a library
+// that uses sqlx, you should be aware that the name mappings you expect
+// can be overridded by your user's application.
+
+// NameMapper is used to map column names to struct field names.  By default,
+// it uses strings.ToLower to lowercase struct field names.  It can be set
+// to whatever you want, but it is encouraged to be set before sqlx is used
+// as name-to-field mappings are cached after first use on a type.
+var NameMapper = strings.ToLower
+var origMapper = reflect.ValueOf(NameMapper)
+
+// Rather than creating on init, this is created when necessary so that
+// importers have time to customize the NameMapper.
+var mpr *reflectx.Mapper
+
+// mapper returns a valid mapper using the configured NameMapper func.
+func mapper() *reflectx.Mapper {
+	if mpr == nil {
+		mpr = reflectx.NewMapperFunc("db", NameMapper)
+	} else if origMapper != reflect.ValueOf(NameMapper) {
+		// if NameMapper has changed, create a new mapper
+		mpr = reflectx.NewMapperFunc("db", NameMapper)
+		origMapper = reflect.ValueOf(NameMapper)
+	}
+	return mpr
+}
+
+// isScannable takes the reflect.Type and the actual dest value and returns
+// whether or not it's Scannable.  Something is scannable if:
+//   * it is not a struct
+//   * it implements sql.Scanner
+//   * it has no exported fields
+func isScannable(t reflect.Type) bool {
+	if reflect.PtrTo(t).Implements(_scannerInterface) {
+		return true
+	}
+	if t.Kind() != reflect.Struct {
+		return true
+	}
+
+	// it's not important that we use the right mapper for this particular object,
+	// we're only concerned on how many exported fields this struct has
+	m := mapper()
+	if len(m.TypeMap(t).Index) == 0 {
+		return true
+	}
+	return false
+}
+
+// ColScanner is an interface used by MapScan and SliceScan
+type ColScanner interface {
+	Columns() ([]string, error)
+	Scan(dest ...interface{}) error
+	Err() error
+}
+
+// Queryer is an interface used by Get and Select
+type Queryer interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	Queryx(query string, args ...interface{}) (*Rows, error)
+	QueryRowx(query string, args ...interface{}) *Row
+}
+
+// Execer is an interface used by MustExec and LoadFile
+type Execer interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
+// Binder is an interface for something which can bind queries (Tx, DB)
+type binder interface {
+	DriverName() string
+	Rebind(string) string
+	BindNamed(string, interface{}) (string, []interface{}, error)
+}
+
+// Ext is a union interface which can bind, query, and exec, used by
+// NamedQuery and NamedExec.
+type Ext interface {
+	binder
+	Queryer
+	Execer
+}
+
+// Preparer is an interface used by Preparex.
+type Preparer interface {
+	Prepare(query string) (*sql.Stmt, error)
+}
+
+// determine if any of our extensions are unsafe
+func isUnsafe(i interface{}) bool {
+	switch v := i.(type) {
+	case Row:
+		return v.unsafe
+	case *Row:
+		return v.unsafe
+	case Rows:
+		return v.unsafe
+	case *Rows:
+		return v.unsafe
+	case NamedStmt:
+		return v.Stmt.unsafe
+	case *NamedStmt:
+		return v.Stmt.unsafe
+	case Stmt:
+		return v.unsafe
+	case *Stmt:
+		return v.unsafe
+	case qStmt:
+		return v.unsafe
+	case *qStmt:
+		return v.unsafe
+	case DB:
+		return v.unsafe
+	case *DB:
+		return v.unsafe
+	case Tx:
+		return v.unsafe
+	case *Tx:
+		return v.unsafe
+	case sql.Rows, *sql.Rows:
+		return false
+	default:
+		return false
+	}
+}
+
+func mapperFor(i interface{}) *reflectx.Mapper {
+	switch i.(type) {
+	case DB:
+		return i.(DB).Mapper
+	case *DB:
+		return i.(*DB).Mapper
+	case Tx:
+		return i.(Tx).Mapper
+	case *Tx:
+		return i.(*Tx).Mapper
+	default:
+		return mapper()
+	}
+}
+
+var _scannerInterface = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
+var _valuerInterface = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
+
+// Row is a reimplementation of sql.Row in order to gain access to the underlying
+// sql.Rows.Columns() data, necessary for StructScan.
+type Row struct {
+	err    error
+	unsafe bool
+	rows   *sql.Rows
+	Mapper *reflectx.Mapper
+}
+
+// Scan is a fixed implementation of sql.Row.Scan, which does not discard the
+// underlying error from the internal rows object if it exists.
+func (r *Row) Scan(dest ...interface{}) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	// TODO(bradfitz): for now we need to defensively clone all
+	// []byte that the driver returned (not permitting
+	// *RawBytes in Rows.Scan), since we're about to close
+	// the Rows in our defer, when we return from this function.
+	// the contract with the driver.Next(...) interface is that it
+	// can return slices into read-only temporary memory that's
+	// only valid until the next Scan/Close.  But the TODO is that
+	// for a lot of drivers, this copy will be unnecessary.  We
+	// should provide an optional interface for drivers to
+	// implement to say, "don't worry, the []bytes that I return
+	// from Next will not be modified again." (for instance, if
+	// they were obtained from the network anyway) But for now we
+	// don't care.
+	defer r.rows.Close()
+	for _, dp := range dest {
+		if _, ok := dp.(*sql.RawBytes); ok {
+			return errors.New("sql: RawBytes isn't allowed on Row.Scan")
+		}
+	}
+
+	if !r.rows.Next() {
+		if err := r.rows.Err(); err != nil {
+			return err
+		}
+		return sql.ErrNoRows
+	}
+	err := r.rows.Scan(dest...)
+	if err != nil {
+		return err
+	}
+	// Make sure the query can be processed to completion with no errors.
+	if err := r.rows.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Columns returns the underlying sql.Rows.Columns(), or the deferred error usually
+// returned by Row.Scan()
+func (r *Row) Columns() ([]string, error) {
+	if r.err != nil {
+		return []string{}, r.err
+	}
+	return r.rows.Columns()
+}
+
+// Err returns the error encountered while scanning.
+func (r *Row) Err() error {
+	return r.err
+}
+
+// DB is a wrapper around sql.DB which keeps track of the driverName upon Open,
+// used mostly to automatically bind named queries using the right bindvars.
+type DB struct {
+	*sql.DB
+	driverName string
+	unsafe     bool
+	Mapper     *reflectx.Mapper
+}
+
+// NewDb returns a new sqlx DB wrapper for a pre-existing *sql.DB.  The
+// driverName of the original database is required for named query support.
+func NewDb(db *sql.DB, driverName string) *DB {
+	return &DB{DB: db, driverName: driverName, Mapper: mapper()}
+}
+
+// DriverName returns the driverName passed to the Open function for this DB.
+func (db *DB) DriverName() string {
+	return db.driverName
+}
+
+// Open is the same as sql.Open, but returns an *sqlx.DB instead.
+func Open(driverName, dataSourceName string) (*DB, error) {
+	db, err := sql.Open(driverName, dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{DB: db, driverName: driverName, Mapper: mapper()}, err
+}
+
+// MustOpen is the same as sql.Open, but returns an *sqlx.DB instead and panics on error.
+func MustOpen(driverName, dataSourceName string) *DB {
+	db, err := Open(driverName, dataSourceName)
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
+// MapperFunc sets a new mapper for this db using the default sqlx struct tag
+// and the provided mapper function.
+func (db *DB) MapperFunc(mf func(string) string) {
+	db.Mapper = reflectx.NewMapperFunc("db", mf)
+}
+
+// Rebind transforms a query from QUESTION to the DB driver's bindvar type.
+func (db *DB) Rebind(query string) string {
+	return Rebind(BindType(db.driverName), query)
+}
+
+// Unsafe returns a version of DB which will silently succeed to scan when
+// columns in the SQL result have no fields in the destination struct.
+// sqlx.Stmt and sqlx.Tx which are created from this DB will inherit its
+// safety behavior.
+func (db *DB) Unsafe() *DB {
+	return &DB{DB: db.DB, driverName: db.driverName, unsafe: true, Mapper: db.Mapper}
+}
+
+// BindNamed binds a query using the DB driver's bindvar type.
+func (db *DB) BindNamed(query string, arg interface{}) (string, []interface{}, error) {
+	return bindNamedMapper(BindType(db.driverName), query, arg, db.Mapper)
+}
+
+// NamedQuery using this DB.
+func (db *DB) NamedQuery(query string, arg interface{}) (*Rows, error) {
+	return NamedQuery(db, query, arg)
+}
+
+// NamedExec using this DB.
+func (db *DB) NamedExec(query string, arg interface{}) (sql.Result, error) {
+	return NamedExec(db, query, arg)
+}
+
+// Select using this DB.
+func (db *DB) Select(dest interface{}, query string, args ...interface{}) error {
+	return Select(db, dest, query, args...)
+}
+
+// Get using this DB.
+func (db *DB) Get(dest interface{}, query string, args ...interface{}) error {
+	return Get(db, dest, query, args...)
+}
+
+// MustBegin starts a transaction, and panics on error.  Returns an *sqlx.Tx instead
+// of an *sql.Tx.
+func (db *DB) MustBegin() *Tx {
+	tx, err := db.Beginx()
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+// Beginx begins a transaction and returns an *sqlx.Tx instead of an *sql.Tx.
+func (db *DB) Beginx() (*Tx, error) {
+	tx, err := db.DB.Begin()
+	if err != nil {
+		return nil, err
+	}
+	return &Tx{Tx: tx, driverName: db.driverName, unsafe: db.unsafe, Mapper: db.Mapper}, err
+}
+
+// Queryx queries the database and returns an *sqlx.Rows.
+func (db *DB) Queryx(query string, args ...interface{}) (*Rows, error) {
+	r, err := db.DB.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &Rows{Rows: r, unsafe: db.unsafe, Mapper: db.Mapper}, err
+}
+
+// QueryRowx queries the database and returns an *sqlx.Row.
+func (db *DB) QueryRowx(query string, args ...interface{}) *Row {
+	rows, err := db.DB.Query(query, args...)
+	return &Row{rows: rows, err: err, unsafe: db.unsafe, Mapper: db.Mapper}
+}
+
+// MustExec (panic) runs MustExec using this database.
+func (db *DB) MustExec(query string, args ...interface{}) sql.Result {
+	return MustExec(db, query, args...)
+}
+
+// Preparex returns an sqlx.Stmt instead of a sql.Stmt
+func (db *DB) Preparex(query string) (*Stmt, error) {
+	return Preparex(db, query)
+}
+
+// PrepareNamed returns an sqlx.NamedStmt
+func (db *DB) PrepareNamed(query string) (*NamedStmt, error) {
+	return prepareNamed(db, query)
+}
+
+// Tx is an sqlx wrapper around sql.Tx with extra functionality
+type Tx struct {
+	*sql.Tx
+	driverName string
+	unsafe     bool
+	Mapper     *reflectx.Mapper
+}
+
+// DriverName returns the driverName used by the DB which began this transaction.
+func (tx *Tx) DriverName() string {
+	return tx.driverName
+}
+
+// Rebind a query within a transaction's bindvar type.
+func (tx *Tx) Rebind(query string) string {
+	return Rebind(BindType(tx.driverName), query)
+}
+
+// Unsafe returns a version of Tx which will silently succeed to scan when
+// columns in the SQL result have no fields in the destination struct.
+func (tx *Tx) Unsafe() *Tx {
+	return &Tx{Tx: tx.Tx, driverName: tx.driverName, unsafe: true, Mapper: tx.Mapper}
+}
+
+// BindNamed binds a query within a transaction's bindvar type.
+func (tx *Tx) BindNamed(query string, arg interface{}) (string, []interface{}, error) {
+	return bindNamedMapper(BindType(tx.driverName), query, arg, tx.Mapper)
+}
+
+// NamedQuery within a transaction.
+func (tx *Tx) NamedQuery(query string, arg interface{}) (*Rows, error) {
+	return NamedQuery(tx, query, arg)
+}
+
+// NamedExec a named query within a transaction.
+func (tx *Tx) NamedExec(query string, arg interface{}) (sql.Result, error) {
+	return NamedExec(tx, query, arg)
+}
+
+// Select within a transaction.
+func (tx *Tx) Select(dest interface{}, query string, args ...interface{}) error {
+	return Select(tx, dest, query, args...)
+}
+
+// Queryx within a transaction.
+func (tx *Tx) Queryx(query string, args ...interface{}) (*Rows, error) {
+	r, err := tx.Tx.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &Rows{Rows: r, unsafe: tx.unsafe, Mapper: tx.Mapper}, err
+}
+
+// QueryRowx within a transaction.
+func (tx *Tx) QueryRowx(query string, args ...interface{}) *Row {
+	rows, err := tx.Tx.Query(query, args...)
+	return &Row{rows: rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
+}
+
+// Get within a transaction.
+func (tx *Tx) Get(dest interface{}, query string, args ...interface{}) error {
+	return Get(tx, dest, query, args...)
+}
+
+// MustExec runs MustExec within a transaction.
+func (tx *Tx) MustExec(query string, args ...interface{}) sql.Result {
+	return MustExec(tx, query, args...)
+}
+
+// Preparex  a statement within a transaction.
+func (tx *Tx) Preparex(query string) (*Stmt, error) {
+	return Preparex(tx, query)
+}
+
+// Stmtx returns a version of the prepared statement which runs within a transaction.  Provided
+// stmt can be either *sql.Stmt or *sqlx.Stmt.
+func (tx *Tx) Stmtx(stmt interface{}) *Stmt {
+	var s *sql.Stmt
+	switch v := stmt.(type) {
+	case Stmt:
+		s = v.Stmt
+	case *Stmt:
+		s = v.Stmt
+	case sql.Stmt:
+		s = &v
+	case *sql.Stmt:
+		s = v
+	default:
+		panic(fmt.Sprintf("non-statement type %v passed to Stmtx", reflect.ValueOf(stmt).Type()))
+	}
+	return &Stmt{Stmt: tx.Stmt(s), Mapper: tx.Mapper}
+}
+
+// NamedStmt returns a version of the prepared statement which runs within a transaction.
+func (tx *Tx) NamedStmt(stmt *NamedStmt) *NamedStmt {
+	return &NamedStmt{
+		QueryString: stmt.QueryString,
+		Params:      stmt.Params,
+		Stmt:        tx.Stmtx(stmt.Stmt),
+	}
+}
+
+// PrepareNamed returns an sqlx.NamedStmt
+func (tx *Tx) PrepareNamed(query string) (*NamedStmt, error) {
+	return prepareNamed(tx, query)
+}
+
+// Stmt is an sqlx wrapper around sql.Stmt with extra functionality
+type Stmt struct {
+	*sql.Stmt
+	unsafe bool
+	Mapper *reflectx.Mapper
+}
+
+// Unsafe returns a version of Stmt which will silently succeed to scan when
+// columns in the SQL result have no fields in the destination struct.
+func (s *Stmt) Unsafe() *Stmt {
+	return &Stmt{Stmt: s.Stmt, unsafe: true, Mapper: s.Mapper}
+}
+
+// Select using the prepared statement.
+func (s *Stmt) Select(dest interface{}, args ...interface{}) error {
+	return Select(&qStmt{s}, dest, "", args...)
+}
+
+// Get using the prepared statement.
+func (s *Stmt) Get(dest interface{}, args ...interface{}) error {
+	return Get(&qStmt{s}, dest, "", args...)
+}
+
+// MustExec (panic) using this statement.  Note that the query portion of the error
+// output will be blank, as Stmt does not expose its query.
+func (s *Stmt) MustExec(args ...interface{}) sql.Result {
+	return MustExec(&qStmt{s}, "", args...)
+}
+
+// QueryRowx using this statement.
+func (s *Stmt) QueryRowx(args ...interface{}) *Row {
+	qs := &qStmt{s}
+	return qs.QueryRowx("", args...)
+}
+
+// Queryx using this statement.
+func (s *Stmt) Queryx(args ...interface{}) (*Rows, error) {
+	qs := &qStmt{s}
+	return qs.Queryx("", args...)
+}
+
+// qStmt is an unexposed wrapper which lets you use a Stmt as a Queryer & Execer by
+// implementing those interfaces and ignoring the `query` argument.
+type qStmt struct{ *Stmt }
+
+func (q *qStmt) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	return q.Stmt.Query(args...)
+}
+
+func (q *qStmt) Queryx(query string, args ...interface{}) (*Rows, error) {
+	r, err := q.Stmt.Query(args...)
+	if err != nil {
+		return nil, err
+	}
+	return &Rows{Rows: r, unsafe: q.Stmt.unsafe, Mapper: q.Stmt.Mapper}, err
+}
+
+func (q *qStmt) QueryRowx(query string, args ...interface{}) *Row {
+	rows, err := q.Stmt.Query(args...)
+	return &Row{rows: rows, err: err, unsafe: q.Stmt.unsafe, Mapper: q.Stmt.Mapper}
+}
+
+func (q *qStmt) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return q.Stmt.Exec(args...)
+}
+
+// Rows is a wrapper around sql.Rows which caches costly reflect operations
+// during a looped StructScan
+type Rows struct {
+	*sql.Rows
+	unsafe bool
+	Mapper *reflectx.Mapper
+	// these fields cache memory use for a rows during iteration w/ structScan
+	started bool
+	fields  [][]int
+	values  []interface{}
+}
+
+// SliceScan using this Rows.
+func (r *Rows) SliceScan() ([]interface{}, error) {
+	return SliceScan(r)
+}
+
+// MapScan using this Rows.
+func (r *Rows) MapScan(dest map[string]interface{}) error {
+	return MapScan(r, dest)
+}
+
+// StructScan is like sql.Rows.Scan, but scans a single Row into a single Struct.
+// Use this and iterate over Rows manually when the memory load of Select() might be
+// prohibitive.  *Rows.StructScan caches the reflect work of matching up column
+// positions to fields to avoid that overhead per scan, which means it is not safe
+// to run StructScan on the same Rows instance with different struct types.
+func (r *Rows) StructScan(dest interface{}) error {
+	v := reflect.ValueOf(dest)
+
+	if v.Kind() != reflect.Ptr {
+		return errors.New("must pass a pointer, not a value, to StructScan destination")
+	}
+
+	v = reflect.Indirect(v)
+
+	if !r.started {
+		columns, err := r.Columns()
+		if err != nil {
+			return err
+		}
+		m := r.Mapper
+
+		r.fields = m.TraversalsByName(v.Type(), columns)
+		// if we are not unsafe and are missing fields, return an error
+		if f, err := missingFields(r.fields); err != nil && !r.unsafe {
+			return fmt.Errorf("missing destination name %s", columns[f])
+		}
+		r.values = make([]interface{}, len(columns))
+		r.started = true
+	}
+
+	err := fieldsByTraversal(v, r.fields, r.values, true)
+	if err != nil {
+		return err
+	}
+	// scan into the struct field pointers and append to our results
+	err = r.Scan(r.values...)
+	if err != nil {
+		return err
+	}
+	return r.Err()
+}
+
+// Connect to a database and verify with a ping.
+func Connect(driverName, dataSourceName string) (*DB, error) {
+	db, err := Open(driverName, dataSourceName)
+	if err != nil {
+		return db, err
+	}
+	err = db.Ping()
+	return db, err
+}
+
+// MustConnect connects to a database and panics on error.
+func MustConnect(driverName, dataSourceName string) *DB {
+	db, err := Connect(driverName, dataSourceName)
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
+// Preparex prepares a statement.
+func Preparex(p Preparer, query string) (*Stmt, error) {
+	s, err := p.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	return &Stmt{Stmt: s, unsafe: isUnsafe(p), Mapper: mapperFor(p)}, err
+}
+
+// Select executes a query using the provided Queryer, and StructScans each row
+// into dest, which must be a slice.  If the slice elements are scannable, then
+// the result set must have only one column.  Otherwise, StructScan is used.
+// The *sql.Rows are closed automatically.
+func Select(q Queryer, dest interface{}, query string, args ...interface{}) error {
+	rows, err := q.Queryx(query, args...)
+	if err != nil {
+		return err
+	}
+	// if something happens here, we want to make sure the rows are Closed
+	defer rows.Close()
+	return scanAll(rows, dest, false)
+}
+
+// Get does a QueryRow using the provided Queryer, and scans the resulting row
+// to dest.  If dest is scannable, the result must only have one column.  Otherwise,
+// StructScan is used.  Get will return sql.ErrNoRows like row.Scan would.
+func Get(q Queryer, dest interface{}, query string, args ...interface{}) error {
+	r := q.QueryRowx(query, args...)
+	return r.scanAny(dest, false)
+}
+
+// LoadFile exec's every statement in a file (as a single call to Exec).
+// LoadFile may return a nil *sql.Result if errors are encountered locating or
+// reading the file at path.  LoadFile reads the entire file into memory, so it
+// is not suitable for loading large data dumps, but can be useful for initializing
+// schemas or loading indexes.
+//
+// FIXME: this does not really work with multi-statement files for mattn/go-sqlite3
+// or the go-mysql-driver/mysql drivers;  pq seems to be an exception here.  Detecting
+// this by requiring something with DriverName() and then attempting to split the
+// queries will be difficult to get right, and its current driver-specific behavior
+// is deemed at least not complex in its incorrectness.
+func LoadFile(e Execer, path string) (*sql.Result, error) {
+	realpath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	contents, err := ioutil.ReadFile(realpath)
+	if err != nil {
+		return nil, err
+	}
+	res, err := e.Exec(string(contents))
+	return &res, err
+}
+
+// MustExec execs the query using e and panics if there was an error.
+func MustExec(e Execer, query string, args ...interface{}) sql.Result {
+	res, err := e.Exec(query, args...)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+// SliceScan using this Rows.
+func (r *Row) SliceScan() ([]interface{}, error) {
+	return SliceScan(r)
+}
+
+// MapScan using this Rows.
+func (r *Row) MapScan(dest map[string]interface{}) error {
+	return MapScan(r, dest)
+}
+
+func (r *Row) scanAny(dest interface{}, structOnly bool) error {
+	if r.err != nil {
+		return r.err
+	}
+	defer r.rows.Close()
+
+	v := reflect.ValueOf(dest)
+	if v.Kind() != reflect.Ptr {
+		return errors.New("must pass a pointer, not a value, to StructScan destination")
+	}
+	if v.IsNil() {
+		return errors.New("nil pointer passed to StructScan destination")
+	}
+
+	base := reflectx.Deref(v.Type())
+	scannable := isScannable(base)
+
+	if structOnly && scannable {
+		return structOnlyError(base)
+	}
+
+	columns, err := r.Columns()
+	if err != nil {
+		return err
+	}
+
+	if scannable && len(columns) > 1 {
+		return fmt.Errorf("scannable dest type %s with >1 columns (%d) in result", base.Kind(), len(columns))
+	}
+
+	if scannable {
+		return r.Scan(dest)
+	}
+
+	m := r.Mapper
+
+	fields := m.TraversalsByName(v.Type(), columns)
+	// if we are not unsafe and are missing fields, return an error
+	if f, err := missingFields(fields); err != nil && !r.unsafe {
+		return fmt.Errorf("missing destination name %s", columns[f])
+	}
+	values := make([]interface{}, len(columns))
+
+	err = fieldsByTraversal(v, fields, values, true)
+	if err != nil {
+		return err
+	}
+	// scan into the struct field pointers and append to our results
+	return r.Scan(values...)
+}
+
+// StructScan a single Row into dest.
+func (r *Row) StructScan(dest interface{}) error {
+	return r.scanAny(dest, true)
+}
+
+// SliceScan a row, returning a []interface{} with values similar to MapScan.
+// This function is primarily intended for use where the number of columns
+// is not known.  Because you can pass an []interface{} directly to Scan,
+// it's recommended that you do that as it will not have to allocate new
+// slices per row.
+func SliceScan(r ColScanner) ([]interface{}, error) {
+	// ignore r.started, since we needn't use reflect for anything.
+	columns, err := r.Columns()
+	if err != nil {
+		return []interface{}{}, err
+	}
+
+	values := make([]interface{}, len(columns))
+	for i := range values {
+		values[i] = new(interface{})
+	}
+
+	err = r.Scan(values...)
+
+	if err != nil {
+		return values, err
+	}
+
+	for i := range columns {
+		values[i] = *(values[i].(*interface{}))
+	}
+
+	return values, r.Err()
+}
+
+// MapScan scans a single Row into the dest map[string]interface{}.
+// Use this to get results for SQL that might not be under your control
+// (for instance, if you're building an interface for an SQL server that
+// executes SQL from input).  Please do not use this as a primary interface!
+// This will modify the map sent to it in place, so reuse the same map with
+// care.  Columns which occur more than once in the result will overwrite
+// eachother!
+func MapScan(r ColScanner, dest map[string]interface{}) error {
+	// ignore r.started, since we needn't use reflect for anything.
+	columns, err := r.Columns()
+	if err != nil {
+		return err
+	}
+
+	values := make([]interface{}, len(columns))
+	for i := range values {
+		values[i] = new(interface{})
+	}
+
+	err = r.Scan(values...)
+	if err != nil {
+		return err
+	}
+
+	for i, column := range columns {
+		dest[column] = *(values[i].(*interface{}))
+	}
+
+	return r.Err()
+}
+
+type rowsi interface {
+	Close() error
+	Columns() ([]string, error)
+	Err() error
+	Next() bool
+	Scan(...interface{}) error
+}
+
+// structOnlyError returns an error appropriate for type when a non-scannable
+// struct is expected but something else is given
+func structOnlyError(t reflect.Type) error {
+	isStruct := t.Kind() == reflect.Struct
+	isScanner := reflect.PtrTo(t).Implements(_scannerInterface)
+	if !isStruct {
+		return fmt.Errorf("expected %s but got %s", reflect.Struct, t.Kind())
+	}
+	if isScanner {
+		return fmt.Errorf("structscan expects a struct dest but the provided struct type %s implements scanner", t.Name())
+	}
+	return fmt.Errorf("expected a struct, but struct %s has no exported fields", t.Name())
+}
+
+// scanAll scans all rows into a destination, which must be a slice of any
+// type.  If the destination slice type is a Struct, then StructScan will be
+// used on each row.  If the destination is some other kind of base type, then
+// each row must only have one column which can scan into that type.  This
+// allows you to do something like:
+//
+//    rows, _ := db.Query("select id from people;")
+//    var ids []int
+//    scanAll(rows, &ids, false)
+//
+// and ids will be a list of the id results.  I realize that this is a desirable
+// interface to expose to users, but for now it will only be exposed via changes
+// to `Get` and `Select`.  The reason that this has been implemented like this is
+// this is the only way to not duplicate reflect work in the new API while
+// maintaining backwards compatibility.
+func scanAll(rows rowsi, dest interface{}, structOnly bool) error {
+	var v, vp reflect.Value
+
+	value := reflect.ValueOf(dest)
+
+	// json.Unmarshal returns errors for these
+	if value.Kind() != reflect.Ptr {
+		return errors.New("must pass a pointer, not a value, to StructScan destination")
+	}
+	if value.IsNil() {
+		return errors.New("nil pointer passed to StructScan destination")
+	}
+	direct := reflect.Indirect(value)
+
+	slice, err := baseType(value.Type(), reflect.Slice)
+	if err != nil {
+		return err
+	}
+
+	isPtr := slice.Elem().Kind() == reflect.Ptr
+	base := reflectx.Deref(slice.Elem())
+	scannable := isScannable(base)
+
+	if structOnly && scannable {
+		return structOnlyError(base)
+	}
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+
+	// if it's a base type make sure it only has 1 column;  if not return an error
+	if scannable && len(columns) > 1 {
+		return fmt.Errorf("non-struct dest type %s with >1 columns (%d)", base.Kind(), len(columns))
+	}
+
+	if !scannable {
+		var values []interface{}
+		var m *reflectx.Mapper
+
+		switch rows.(type) {
+		case *Rows:
+			m = rows.(*Rows).Mapper
+		default:
+			m = mapper()
+		}
+
+		fields := m.TraversalsByName(base, columns)
+		// if we are not unsafe and are missing fields, return an error
+		if f, err := missingFields(fields); err != nil && !isUnsafe(rows) {
+			return fmt.Errorf("missing destination name %s", columns[f])
+		}
+		values = make([]interface{}, len(columns))
+
+		for rows.Next() {
+			// create a new struct type (which returns PtrTo) and indirect it
+			vp = reflect.New(base)
+			v = reflect.Indirect(vp)
+
+			err = fieldsByTraversal(v, fields, values, true)
+
+			// scan into the struct field pointers and append to our results
+			err = rows.Scan(values...)
+			if err != nil {
+				return err
+			}
+
+			if isPtr {
+				direct.Set(reflect.Append(direct, vp))
+			} else {
+				direct.Set(reflect.Append(direct, v))
+			}
+		}
+	} else {
+		for rows.Next() {
+			vp = reflect.New(base)
+			err = rows.Scan(vp.Interface())
+			// append
+			if isPtr {
+				direct.Set(reflect.Append(direct, vp))
+			} else {
+				direct.Set(reflect.Append(direct, reflect.Indirect(vp)))
+			}
+		}
+	}
+
+	return rows.Err()
+}
+
+// FIXME: StructScan was the very first bit of API in sqlx, and now unfortunately
+// it doesn't really feel like it's named properly.  There is an incongruency
+// between this and the way that StructScan (which might better be ScanStruct
+// anyway) works on a rows object.
+
+// StructScan all rows from an sql.Rows or an sqlx.Rows into the dest slice.
+// StructScan will scan in the entire rows result, so if you need do not want to
+// allocate structs for the entire result, use Queryx and see sqlx.Rows.StructScan.
+// If rows is sqlx.Rows, it will use its mapper, otherwise it will use the default.
+func StructScan(rows rowsi, dest interface{}) error {
+	return scanAll(rows, dest, true)
+
+}
+
+// reflect helpers
+
+func baseType(t reflect.Type, expected reflect.Kind) (reflect.Type, error) {
+	t = reflectx.Deref(t)
+	if t.Kind() != expected {
+		return nil, fmt.Errorf("expected %s but got %s", expected, t.Kind())
+	}
+	return t, nil
+}
+
+// fieldsByName fills a values interface with fields from the passed value based
+// on the traversals in int.  If ptrs is true, return addresses instead of values.
+// We write this instead of using FieldsByName to save allocations and map lookups
+// when iterating over many rows.  Empty traversals will get an interface pointer.
+// Because of the necessity of requesting ptrs or values, it's considered a bit too
+// specialized for inclusion in reflectx itself.
+func fieldsByTraversal(v reflect.Value, traversals [][]int, values []interface{}, ptrs bool) error {
+	v = reflect.Indirect(v)
+	if v.Kind() != reflect.Struct {
+		return errors.New("argument not a struct")
+	}
+
+	for i, traversal := range traversals {
+		if len(traversal) == 0 {
+			values[i] = new(interface{})
+			continue
+		}
+		f := reflectx.FieldByIndexes(v, traversal)
+		if ptrs {
+			values[i] = f.Addr().Interface()
+		} else {
+			values[i] = f.Interface()
+		}
+	}
+	return nil
+}
+
+func missingFields(transversals [][]int) (field int, err error) {
+	for i, t := range transversals {
+		if len(t) == 0 {
+			return i, errors.New("missing field")
+		}
+	}
+	return 0, nil
+}

--- a/vendor/github.com/jmoiron/sqlx/sqlx_test.go
+++ b/vendor/github.com/jmoiron/sqlx/sqlx_test.go
@@ -1,0 +1,1674 @@
+// The following environment variables, if set, will be used:
+//
+//	* SQLX_SQLITE_DSN
+//	* SQLX_POSTGRES_DSN
+//	* SQLX_MYSQL_DSN
+//
+// Set any of these variables to 'skip' to skip them.  Note that for MySQL,
+// the string '?parseTime=True' will be appended to the DSN if it's not there
+// already.
+//
+package sqlx
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx/reflectx"
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+/* compile time checks that Db, Tx, Stmt (qStmt) implement expected interfaces */
+var _, _ Ext = &DB{}, &Tx{}
+var _, _ ColScanner = &Row{}, &Rows{}
+var _ Queryer = &qStmt{}
+var _ Execer = &qStmt{}
+
+var TestPostgres = true
+var TestSqlite = true
+var TestMysql = true
+
+var sldb *DB
+var pgdb *DB
+var mysqldb *DB
+var active = []*DB{}
+
+func init() {
+	ConnectAll()
+}
+
+func ConnectAll() {
+	var err error
+
+	pgdsn := os.Getenv("SQLX_POSTGRES_DSN")
+	mydsn := os.Getenv("SQLX_MYSQL_DSN")
+	sqdsn := os.Getenv("SQLX_SQLITE_DSN")
+
+	TestPostgres = pgdsn != "skip"
+	TestMysql = mydsn != "skip"
+	TestSqlite = sqdsn != "skip"
+
+	if !strings.Contains(mydsn, "parseTime=true") {
+		mydsn += "?parseTime=true"
+	}
+
+	if TestPostgres {
+		pgdb, err = Connect("postgres", pgdsn)
+		if err != nil {
+			fmt.Printf("Disabling PG tests:\n    %v\n", err)
+			TestPostgres = false
+		}
+	} else {
+		fmt.Println("Disabling Postgres tests.")
+	}
+
+	if TestMysql {
+		mysqldb, err = Connect("mysql", mydsn)
+		if err != nil {
+			fmt.Printf("Disabling MySQL tests:\n    %v", err)
+			TestMysql = false
+		}
+	} else {
+		fmt.Println("Disabling MySQL tests.")
+	}
+
+	if TestSqlite {
+		sldb, err = Connect("sqlite3", sqdsn)
+		if err != nil {
+			fmt.Printf("Disabling SQLite:\n    %v", err)
+			TestSqlite = false
+		}
+	} else {
+		fmt.Println("Disabling SQLite tests.")
+	}
+}
+
+type Schema struct {
+	create string
+	drop   string
+}
+
+func (s Schema) Postgres() (string, string) {
+	return s.create, s.drop
+}
+
+func (s Schema) MySQL() (string, string) {
+	return strings.Replace(s.create, `"`, "`", -1), s.drop
+}
+
+func (s Schema) Sqlite3() (string, string) {
+	return strings.Replace(s.create, `now()`, `CURRENT_TIMESTAMP`, -1), s.drop
+}
+
+var defaultSchema = Schema{
+	create: `
+CREATE TABLE person (
+	first_name text,
+	last_name text,
+	email text,
+	added_at timestamp default now()
+);
+
+CREATE TABLE place (
+	country text,
+	city text NULL,
+	telcode integer
+);
+
+CREATE TABLE capplace (
+	"COUNTRY" text,
+	"CITY" text NULL,
+	"TELCODE" integer
+);
+
+CREATE TABLE nullperson (
+    first_name text NULL,
+    last_name text NULL,
+    email text NULL
+);
+
+CREATE TABLE employees (
+	name text,
+	id integer,
+	boss_id integer
+);
+
+`,
+	drop: `
+drop table person;
+drop table place;
+drop table capplace;
+drop table nullperson;
+drop table employees;
+`,
+}
+
+type Person struct {
+	FirstName string `db:"first_name"`
+	LastName  string `db:"last_name"`
+	Email     string
+	AddedAt   time.Time `db:"added_at"`
+}
+
+type Person2 struct {
+	FirstName sql.NullString `db:"first_name"`
+	LastName  sql.NullString `db:"last_name"`
+	Email     sql.NullString
+}
+
+type Place struct {
+	Country string
+	City    sql.NullString
+	TelCode int
+}
+
+type PlacePtr struct {
+	Country string
+	City    *string
+	TelCode int
+}
+
+type PersonPlace struct {
+	Person
+	Place
+}
+
+type PersonPlacePtr struct {
+	*Person
+	*Place
+}
+
+type EmbedConflict struct {
+	FirstName string `db:"first_name"`
+	Person
+}
+
+type SliceMember struct {
+	Country   string
+	City      sql.NullString
+	TelCode   int
+	People    []Person `db:"-"`
+	Addresses []Place  `db:"-"`
+}
+
+// Note that because of field map caching, we need a new type here
+// if we've used Place already somewhere in sqlx
+type CPlace Place
+
+func MultiExec(e Execer, query string) {
+	stmts := strings.Split(query, ";\n")
+	if len(strings.Trim(stmts[len(stmts)-1], " \n\t\r")) == 0 {
+		stmts = stmts[:len(stmts)-1]
+	}
+	for _, s := range stmts {
+		_, err := e.Exec(s)
+		if err != nil {
+			fmt.Println(err, s)
+		}
+	}
+}
+
+func RunWithSchema(schema Schema, t *testing.T, test func(db *DB, t *testing.T)) {
+	runner := func(db *DB, t *testing.T, create, drop string) {
+		defer func() {
+			MultiExec(db, drop)
+		}()
+
+		MultiExec(db, create)
+		test(db, t)
+	}
+
+	if TestPostgres {
+		create, drop := schema.Postgres()
+		runner(pgdb, t, create, drop)
+	}
+	if TestSqlite {
+		create, drop := schema.Sqlite3()
+		runner(sldb, t, create, drop)
+	}
+	if TestMysql {
+		create, drop := schema.MySQL()
+		runner(mysqldb, t, create, drop)
+	}
+}
+
+func loadDefaultFixture(db *DB, t *testing.T) {
+	tx := db.MustBegin()
+	tx.MustExec(tx.Rebind("INSERT INTO person (first_name, last_name, email) VALUES (?, ?, ?)"), "Jason", "Moiron", "jmoiron@jmoiron.net")
+	tx.MustExec(tx.Rebind("INSERT INTO person (first_name, last_name, email) VALUES (?, ?, ?)"), "John", "Doe", "johndoeDNE@gmail.net")
+	tx.MustExec(tx.Rebind("INSERT INTO place (country, city, telcode) VALUES (?, ?, ?)"), "United States", "New York", "1")
+	tx.MustExec(tx.Rebind("INSERT INTO place (country, telcode) VALUES (?, ?)"), "Hong Kong", "852")
+	tx.MustExec(tx.Rebind("INSERT INTO place (country, telcode) VALUES (?, ?)"), "Singapore", "65")
+	if db.DriverName() == "mysql" {
+		tx.MustExec(tx.Rebind("INSERT INTO capplace (`COUNTRY`, `TELCODE`) VALUES (?, ?)"), "Sarf Efrica", "27")
+	} else {
+		tx.MustExec(tx.Rebind("INSERT INTO capplace (\"COUNTRY\", \"TELCODE\") VALUES (?, ?)"), "Sarf Efrica", "27")
+	}
+	tx.MustExec(tx.Rebind("INSERT INTO employees (name, id) VALUES (?, ?)"), "Peter", "4444")
+	tx.MustExec(tx.Rebind("INSERT INTO employees (name, id, boss_id) VALUES (?, ?, ?)"), "Joe", "1", "4444")
+	tx.MustExec(tx.Rebind("INSERT INTO employees (name, id, boss_id) VALUES (?, ?, ?)"), "Martin", "2", "4444")
+	tx.Commit()
+}
+
+// Test a new backwards compatible feature, that missing scan destinations
+// will silently scan into sql.RawText rather than failing/panicing
+func TestMissingNames(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		type PersonPlus struct {
+			FirstName string `db:"first_name"`
+			LastName  string `db:"last_name"`
+			Email     string
+			//AddedAt time.Time `db:"added_at"`
+		}
+
+		// test Select first
+		pps := []PersonPlus{}
+		// pps lacks added_at destination
+		err := db.Select(&pps, "SELECT * FROM person")
+		if err == nil {
+			t.Error("Expected missing name from Select to fail, but it did not.")
+		}
+
+		// test Get
+		pp := PersonPlus{}
+		err = db.Get(&pp, "SELECT * FROM person LIMIT 1")
+		if err == nil {
+			t.Error("Expected missing name Get to fail, but it did not.")
+		}
+
+		// test naked StructScan
+		pps = []PersonPlus{}
+		rows, err := db.Query("SELECT * FROM person LIMIT 1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows.Next()
+		err = StructScan(rows, &pps)
+		if err == nil {
+			t.Error("Expected missing name in StructScan to fail, but it did not.")
+		}
+		rows.Close()
+
+		// now try various things with unsafe set.
+		db = db.Unsafe()
+		pps = []PersonPlus{}
+		err = db.Select(&pps, "SELECT * FROM person")
+		if err != nil {
+			t.Error(err)
+		}
+
+		// test Get
+		pp = PersonPlus{}
+		err = db.Get(&pp, "SELECT * FROM person LIMIT 1")
+		if err != nil {
+			t.Error(err)
+		}
+
+		// test naked StructScan
+		pps = []PersonPlus{}
+		rowsx, err := db.Queryx("SELECT * FROM person LIMIT 1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		rowsx.Next()
+		err = StructScan(rowsx, &pps)
+		if err != nil {
+			t.Error(err)
+		}
+		rowsx.Close()
+
+		// test Named stmt
+		if !isUnsafe(db) {
+			t.Error("Expected db to be unsafe, but it isn't")
+		}
+		nstmt, err := db.PrepareNamed(`SELECT * FROM person WHERE first_name != :name`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// its internal stmt should be marked unsafe
+		if !nstmt.Stmt.unsafe {
+			t.Error("expected NamedStmt to be unsafe but its underlying stmt did not inherit safety")
+		}
+		pps = []PersonPlus{}
+		err = nstmt.Select(&pps, map[string]interface{}{"name": "Jason"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(pps) != 1 {
+			t.Errorf("Expected 1 person back, got %d", len(pps))
+		}
+
+		// test it with a safe db
+		db.unsafe = false
+		if isUnsafe(db) {
+			t.Error("expected db to be safe but it isn't")
+		}
+		nstmt, err = db.PrepareNamed(`SELECT * FROM person WHERE first_name != :name`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// it should be safe
+		if isUnsafe(nstmt) {
+			t.Error("NamedStmt did not inherit safety")
+		}
+		nstmt.Unsafe()
+		if !isUnsafe(nstmt) {
+			t.Error("expected newly unsafed NamedStmt to be unsafe")
+		}
+		pps = []PersonPlus{}
+		err = nstmt.Select(&pps, map[string]interface{}{"name": "Jason"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(pps) != 1 {
+			t.Errorf("Expected 1 person back, got %d", len(pps))
+		}
+
+	})
+}
+
+func TestEmbeddedStructs(t *testing.T) {
+	type Loop1 struct{ Person }
+	type Loop2 struct{ Loop1 }
+	type Loop3 struct{ Loop2 }
+
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		peopleAndPlaces := []PersonPlace{}
+		err := db.Select(
+			&peopleAndPlaces,
+			`SELECT person.*, place.* FROM
+             person natural join place`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, pp := range peopleAndPlaces {
+			if len(pp.Person.FirstName) == 0 {
+				t.Errorf("Expected non zero lengthed first name.")
+			}
+			if len(pp.Place.Country) == 0 {
+				t.Errorf("Expected non zero lengthed country.")
+			}
+		}
+
+		// test embedded structs with StructScan
+		rows, err := db.Queryx(
+			`SELECT person.*, place.* FROM
+         person natural join place`)
+		if err != nil {
+			t.Error(err)
+		}
+
+		perp := PersonPlace{}
+		rows.Next()
+		err = rows.StructScan(&perp)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(perp.Person.FirstName) == 0 {
+			t.Errorf("Expected non zero lengthed first name.")
+		}
+		if len(perp.Place.Country) == 0 {
+			t.Errorf("Expected non zero lengthed country.")
+		}
+
+		rows.Close()
+
+		// test the same for embedded pointer structs
+		peopleAndPlacesPtrs := []PersonPlacePtr{}
+		err = db.Select(
+			&peopleAndPlacesPtrs,
+			`SELECT person.*, place.* FROM
+             person natural join place`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, pp := range peopleAndPlacesPtrs {
+			if len(pp.Person.FirstName) == 0 {
+				t.Errorf("Expected non zero lengthed first name.")
+			}
+			if len(pp.Place.Country) == 0 {
+				t.Errorf("Expected non zero lengthed country.")
+			}
+		}
+
+		// test "deep nesting"
+		l3s := []Loop3{}
+		err = db.Select(&l3s, `select * from person`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, l3 := range l3s {
+			if len(l3.Loop2.Loop1.Person.FirstName) == 0 {
+				t.Errorf("Expected non zero lengthed first name.")
+			}
+		}
+
+		// test "embed conflicts"
+		ec := []EmbedConflict{}
+		err = db.Select(&ec, `select * from person`)
+		// I'm torn between erroring here or having some kind of working behavior
+		// in order to allow for more flexibility in destination structs
+		if err != nil {
+			t.Errorf("Was not expecting an error on embed conflicts.")
+		}
+	})
+}
+
+func TestJoinQuery(t *testing.T) {
+	type Employee struct {
+		Name string
+		ID   int64
+		// BossID is an id into the employee table
+		BossID sql.NullInt64 `db:"boss_id"`
+	}
+	type Boss Employee
+
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+
+		var employees []struct {
+			Employee
+			Boss `db:"boss"`
+		}
+
+		err := db.Select(
+			&employees,
+			`SELECT employees.*, boss.id "boss.id", boss.name "boss.name" FROM employees
+			  JOIN employees AS boss ON employees.boss_id = boss.id`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, em := range employees {
+			if len(em.Employee.Name) == 0 {
+				t.Errorf("Expected non zero lengthed name.")
+			}
+			if em.Employee.BossID.Int64 != em.Boss.ID {
+				t.Errorf("Expected boss ids to match")
+			}
+		}
+	})
+}
+
+func TestJoinQueryNamedPointerStructs(t *testing.T) {
+	type Employee struct {
+		Name string
+		ID   int64
+		// BossID is an id into the employee table
+		BossID sql.NullInt64 `db:"boss_id"`
+	}
+	type Boss Employee
+
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+
+		var employees []struct {
+			Emp1  *Employee `db:"emp1"`
+			Emp2  *Employee `db:"emp2"`
+			*Boss `db:"boss"`
+		}
+
+		err := db.Select(
+			&employees,
+			`SELECT emp.name "emp1.name", emp.id "emp1.id", emp.boss_id "emp1.boss_id",
+			 emp.name "emp2.name", emp.id "emp2.id", emp.boss_id "emp2.boss_id",
+			 boss.id "boss.id", boss.name "boss.name" FROM employees AS emp
+			  JOIN employees AS boss ON emp.boss_id = boss.id
+			  `)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, em := range employees {
+			if len(em.Emp1.Name) == 0 || len(em.Emp2.Name) == 0 {
+				t.Errorf("Expected non zero lengthed name.")
+			}
+			if em.Emp1.BossID.Int64 != em.Boss.ID || em.Emp2.BossID.Int64 != em.Boss.ID {
+				t.Errorf("Expected boss ids to match")
+			}
+		}
+	})
+}
+
+func TestSelectSliceMapTime(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		rows, err := db.Queryx("SELECT * FROM person")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			_, err := rows.SliceScan()
+			if err != nil {
+				t.Error(err)
+			}
+		}
+
+		rows, err = db.Queryx("SELECT * FROM person")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			m := map[string]interface{}{}
+			err := rows.MapScan(m)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+
+	})
+}
+
+func TestNilReceiver(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		var p *Person
+		err := db.Get(p, "SELECT * FROM person LIMIT 1")
+		if err == nil {
+			t.Error("Expected error when getting into nil struct ptr.")
+		}
+		var pp *[]Person
+		err = db.Select(pp, "SELECT * FROM person")
+		if err == nil {
+			t.Error("Expected an error when selecting into nil slice ptr.")
+		}
+	})
+}
+
+func TestNamedQuery(t *testing.T) {
+	var schema = Schema{
+		create: `
+			CREATE TABLE person (
+				first_name text NULL,
+				last_name text NULL,
+				email text NULL
+			);
+			CREATE TABLE jsperson (
+				"FIRST" text NULL,
+				last_name text NULL,
+				"EMAIL" text NULL
+			);`,
+		drop: `
+			drop table person;
+			drop table jsperson;
+			`,
+	}
+
+	RunWithSchema(schema, t, func(db *DB, t *testing.T) {
+		type Person struct {
+			FirstName sql.NullString `db:"first_name"`
+			LastName  sql.NullString `db:"last_name"`
+			Email     sql.NullString
+		}
+
+		p := Person{
+			FirstName: sql.NullString{String: "ben", Valid: true},
+			LastName:  sql.NullString{String: "doe", Valid: true},
+			Email:     sql.NullString{String: "ben@doe.com", Valid: true},
+		}
+
+		q1 := `INSERT INTO person (first_name, last_name, email) VALUES (:first_name, :last_name, :email)`
+		_, err := db.NamedExec(q1, p)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		p2 := &Person{}
+		rows, err := db.NamedQuery("SELECT * FROM person WHERE first_name=:first_name", p)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for rows.Next() {
+			err = rows.StructScan(p2)
+			if err != nil {
+				t.Error(err)
+			}
+			if p2.FirstName.String != "ben" {
+				t.Error("Expected first name of `ben`, got " + p2.FirstName.String)
+			}
+			if p2.LastName.String != "doe" {
+				t.Error("Expected first name of `doe`, got " + p2.LastName.String)
+			}
+		}
+
+		// these are tests for #73;  they verify that named queries work if you've
+		// changed the db mapper.  This code checks both NamedQuery "ad-hoc" style
+		// queries and NamedStmt queries, which use different code paths internally.
+		old := *db.Mapper
+
+		type JSONPerson struct {
+			FirstName sql.NullString `json:"FIRST"`
+			LastName  sql.NullString `json:"last_name"`
+			Email     sql.NullString
+		}
+
+		jp := JSONPerson{
+			FirstName: sql.NullString{String: "ben", Valid: true},
+			LastName:  sql.NullString{String: "smith", Valid: true},
+			Email:     sql.NullString{String: "ben@smith.com", Valid: true},
+		}
+
+		db.Mapper = reflectx.NewMapperFunc("json", strings.ToUpper)
+
+		// prepare queries for case sensitivity to test our ToUpper function.
+		// postgres and sqlite accept "", but mysql uses ``;  since Go's multi-line
+		// strings are `` we use "" by default and swap out for MySQL
+		pdb := func(s string, db *DB) string {
+			if db.DriverName() == "mysql" {
+				return strings.Replace(s, `"`, "`", -1)
+			}
+			return s
+		}
+
+		q1 = `INSERT INTO jsperson ("FIRST", last_name, "EMAIL") VALUES (:FIRST, :last_name, :EMAIL)`
+		_, err = db.NamedExec(pdb(q1, db), jp)
+		if err != nil {
+			t.Fatal(err, db.DriverName())
+		}
+
+		// Checks that a person pulled out of the db matches the one we put in
+		check := func(t *testing.T, rows *Rows) {
+			jp = JSONPerson{}
+			for rows.Next() {
+				err = rows.StructScan(&jp)
+				if err != nil {
+					t.Error(err)
+				}
+				if jp.FirstName.String != "ben" {
+					t.Errorf("Expected first name of `ben`, got `%s` (%s) ", jp.FirstName.String, db.DriverName())
+				}
+				if jp.LastName.String != "smith" {
+					t.Errorf("Expected LastName of `smith`, got `%s` (%s)", jp.LastName.String, db.DriverName())
+				}
+				if jp.Email.String != "ben@smith.com" {
+					t.Errorf("Expected first name of `doe`, got `%s` (%s)", jp.Email.String, db.DriverName())
+				}
+			}
+		}
+
+		ns, err := db.PrepareNamed(pdb(`
+			SELECT * FROM jsperson
+			WHERE
+				"FIRST"=:FIRST AND
+				last_name=:last_name AND
+				"EMAIL"=:EMAIL
+		`, db))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows, err = ns.Queryx(jp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		check(t, rows)
+
+		// Check exactly the same thing, but with db.NamedQuery, which does not go
+		// through the PrepareNamed/NamedStmt path.
+		rows, err = db.NamedQuery(pdb(`
+			SELECT * FROM jsperson
+			WHERE
+				"FIRST"=:FIRST AND
+				last_name=:last_name AND
+				"EMAIL"=:EMAIL
+		`, db), jp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		check(t, rows)
+
+		db.Mapper = &old
+
+	})
+}
+
+func TestNilInserts(t *testing.T) {
+	var schema = Schema{
+		create: `
+			CREATE TABLE tt (
+				id integer,
+				value text NULL DEFAULT NULL
+			);`,
+		drop: "drop table tt;",
+	}
+
+	RunWithSchema(schema, t, func(db *DB, t *testing.T) {
+		type TT struct {
+			ID    int
+			Value *string
+		}
+		var v, v2 TT
+		r := db.Rebind
+
+		db.MustExec(r(`INSERT INTO tt (id) VALUES (1)`))
+		db.Get(&v, r(`SELECT * FROM tt`))
+		if v.ID != 1 {
+			t.Errorf("Expecting id of 1, got %v", v.ID)
+		}
+		if v.Value != nil {
+			t.Errorf("Expecting NULL to map to nil, got %s", *v.Value)
+		}
+
+		v.ID = 2
+		// NOTE: this incidentally uncovered a bug which was that named queries with
+		// pointer destinations would not work if the passed value here was not addressable,
+		// as reflectx.FieldByIndexes attempts to allocate nil pointer receivers for
+		// writing.  This was fixed by creating & using the reflectx.FieldByIndexesReadOnly
+		// function.  This next line is important as it provides the only coverage for this.
+		db.NamedExec(`INSERT INTO tt (id, value) VALUES (:id, :value)`, v)
+
+		db.Get(&v2, r(`SELECT * FROM tt WHERE id=2`))
+		if v.ID != v2.ID {
+			t.Errorf("%v != %v", v.ID, v2.ID)
+		}
+		if v2.Value != nil {
+			t.Errorf("Expecting NULL to map to nil, got %s", *v.Value)
+		}
+	})
+}
+
+func TestScanError(t *testing.T) {
+	var schema = Schema{
+		create: `
+			CREATE TABLE kv (
+				k text,
+				v integer
+			);`,
+		drop: `drop table kv;`,
+	}
+
+	RunWithSchema(schema, t, func(db *DB, t *testing.T) {
+		type WrongTypes struct {
+			K int
+			V string
+		}
+		_, err := db.Exec(db.Rebind("INSERT INTO kv (k, v) VALUES (?, ?)"), "hi", 1)
+		if err != nil {
+			t.Error(err)
+		}
+
+		rows, err := db.Queryx("SELECT * FROM kv")
+		if err != nil {
+			t.Error(err)
+		}
+		for rows.Next() {
+			var wt WrongTypes
+			err := rows.StructScan(&wt)
+			if err == nil {
+				t.Errorf("%s: Scanning wrong types into keys should have errored.", db.DriverName())
+			}
+		}
+	})
+}
+
+// FIXME: this function is kinda big but it slows things down to be constantly
+// loading and reloading the schema..
+
+func TestUsage(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		slicemembers := []SliceMember{}
+		err := db.Select(&slicemembers, "SELECT * FROM place ORDER BY telcode ASC")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		people := []Person{}
+
+		err = db.Select(&people, "SELECT * FROM person ORDER BY first_name ASC")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		jason, john := people[0], people[1]
+		if jason.FirstName != "Jason" {
+			t.Errorf("Expecting FirstName of Jason, got %s", jason.FirstName)
+		}
+		if jason.LastName != "Moiron" {
+			t.Errorf("Expecting LastName of Moiron, got %s", jason.LastName)
+		}
+		if jason.Email != "jmoiron@jmoiron.net" {
+			t.Errorf("Expecting Email of jmoiron@jmoiron.net, got %s", jason.Email)
+		}
+		if john.FirstName != "John" || john.LastName != "Doe" || john.Email != "johndoeDNE@gmail.net" {
+			t.Errorf("John Doe's person record not what expected:  Got %v\n", john)
+		}
+
+		jason = Person{}
+		err = db.Get(&jason, db.Rebind("SELECT * FROM person WHERE first_name=?"), "Jason")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		if jason.FirstName != "Jason" {
+			t.Errorf("Expecting to get back Jason, but got %v\n", jason.FirstName)
+		}
+
+		err = db.Get(&jason, db.Rebind("SELECT * FROM person WHERE first_name=?"), "Foobar")
+		if err == nil {
+			t.Errorf("Expecting an error, got nil\n")
+		}
+		if err != sql.ErrNoRows {
+			t.Errorf("Expected sql.ErrNoRows, got %v\n", err)
+		}
+
+		// The following tests check statement reuse, which was actually a problem
+		// due to copying being done when creating Stmt's which was eventually removed
+		stmt1, err := db.Preparex(db.Rebind("SELECT * FROM person WHERE first_name=?"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		jason = Person{}
+
+		row := stmt1.QueryRowx("DoesNotExist")
+		row.Scan(&jason)
+		row = stmt1.QueryRowx("DoesNotExist")
+		row.Scan(&jason)
+
+		err = stmt1.Get(&jason, "DoesNotExist User")
+		if err == nil {
+			t.Error("Expected an error")
+		}
+		err = stmt1.Get(&jason, "DoesNotExist User 2")
+
+		stmt2, err := db.Preparex(db.Rebind("SELECT * FROM person WHERE first_name=?"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		jason = Person{}
+		tx, err := db.Beginx()
+		if err != nil {
+			t.Fatal(err)
+		}
+		tstmt2 := tx.Stmtx(stmt2)
+		row2 := tstmt2.QueryRowx("Jason")
+		err = row2.StructScan(&jason)
+		if err != nil {
+			t.Error(err)
+		}
+		tx.Commit()
+
+		places := []*Place{}
+		err = db.Select(&places, "SELECT telcode FROM place ORDER BY telcode ASC")
+		usa, singsing, honkers := places[0], places[1], places[2]
+
+		if usa.TelCode != 1 || honkers.TelCode != 852 || singsing.TelCode != 65 {
+			t.Errorf("Expected integer telcodes to work, got %#v", places)
+		}
+
+		placesptr := []PlacePtr{}
+		err = db.Select(&placesptr, "SELECT * FROM place ORDER BY telcode ASC")
+		if err != nil {
+			t.Error(err)
+		}
+		//fmt.Printf("%#v\n%#v\n%#v\n", placesptr[0], placesptr[1], placesptr[2])
+
+		// if you have null fields and use SELECT *, you must use sql.Null* in your struct
+		// this test also verifies that you can use either a []Struct{} or a []*Struct{}
+		places2 := []Place{}
+		err = db.Select(&places2, "SELECT * FROM place ORDER BY telcode ASC")
+		usa, singsing, honkers = &places2[0], &places2[1], &places2[2]
+
+		// this should return a type error that &p is not a pointer to a struct slice
+		p := Place{}
+		err = db.Select(&p, "SELECT * FROM place ORDER BY telcode ASC")
+		if err == nil {
+			t.Errorf("Expected an error, argument to select should be a pointer to a struct slice")
+		}
+
+		// this should be an error
+		pl := []Place{}
+		err = db.Select(pl, "SELECT * FROM place ORDER BY telcode ASC")
+		if err == nil {
+			t.Errorf("Expected an error, argument to select should be a pointer to a struct slice, not a slice.")
+		}
+
+		if usa.TelCode != 1 || honkers.TelCode != 852 || singsing.TelCode != 65 {
+			t.Errorf("Expected integer telcodes to work, got %#v", places)
+		}
+
+		stmt, err := db.Preparex(db.Rebind("SELECT country, telcode FROM place WHERE telcode > ? ORDER BY telcode ASC"))
+		if err != nil {
+			t.Error(err)
+		}
+
+		places = []*Place{}
+		err = stmt.Select(&places, 10)
+		if len(places) != 2 {
+			t.Error("Expected 2 places, got 0.")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		singsing, honkers = places[0], places[1]
+		if singsing.TelCode != 65 || honkers.TelCode != 852 {
+			t.Errorf("Expected the right telcodes, got %#v", places)
+		}
+
+		rows, err := db.Queryx("SELECT * FROM place")
+		if err != nil {
+			t.Fatal(err)
+		}
+		place := Place{}
+		for rows.Next() {
+			err = rows.StructScan(&place)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		rows, err = db.Queryx("SELECT * FROM place")
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := map[string]interface{}{}
+		for rows.Next() {
+			err = rows.MapScan(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, ok := m["country"]
+			if !ok {
+				t.Errorf("Expected key `country` in map but could not find it (%#v)\n", m)
+			}
+		}
+
+		rows, err = db.Queryx("SELECT * FROM place")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			s, err := rows.SliceScan()
+			if err != nil {
+				t.Error(err)
+			}
+			if len(s) != 3 {
+				t.Errorf("Expected 3 columns in result, got %d\n", len(s))
+			}
+		}
+
+		// test advanced querying
+		// test that NamedExec works with a map as well as a struct
+		_, err = db.NamedExec("INSERT INTO person (first_name, last_name, email) VALUES (:first, :last, :email)", map[string]interface{}{
+			"first": "Bin",
+			"last":  "Smuth",
+			"email": "bensmith@allblacks.nz",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// ensure that if the named param happens right at the end it still works
+		// ensure that NamedQuery works with a map[string]interface{}
+		rows, err = db.NamedQuery("SELECT * FROM person WHERE first_name=:first", map[string]interface{}{"first": "Bin"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ben := &Person{}
+		for rows.Next() {
+			err = rows.StructScan(ben)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ben.FirstName != "Bin" {
+				t.Fatal("Expected first name of `Bin`, got " + ben.FirstName)
+			}
+			if ben.LastName != "Smuth" {
+				t.Fatal("Expected first name of `Smuth`, got " + ben.LastName)
+			}
+		}
+
+		ben.FirstName = "Ben"
+		ben.LastName = "Smith"
+		ben.Email = "binsmuth@allblacks.nz"
+
+		// Insert via a named query using the struct
+		_, err = db.NamedExec("INSERT INTO person (first_name, last_name, email) VALUES (:first_name, :last_name, :email)", ben)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rows, err = db.NamedQuery("SELECT * FROM person WHERE first_name=:first_name", ben)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			err = rows.StructScan(ben)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ben.FirstName != "Ben" {
+				t.Fatal("Expected first name of `Ben`, got " + ben.FirstName)
+			}
+			if ben.LastName != "Smith" {
+				t.Fatal("Expected first name of `Smith`, got " + ben.LastName)
+			}
+		}
+		// ensure that Get does not panic on emppty result set
+		person := &Person{}
+		err = db.Get(person, "SELECT * FROM person WHERE first_name=$1", "does-not-exist")
+		if err == nil {
+			t.Fatal("Should have got an error for Get on non-existant row.")
+		}
+
+		// lets test prepared statements some more
+
+		stmt, err = db.Preparex(db.Rebind("SELECT * FROM person WHERE first_name=?"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows, err = stmt.Queryx("Ben")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			err = rows.StructScan(ben)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ben.FirstName != "Ben" {
+				t.Fatal("Expected first name of `Ben`, got " + ben.FirstName)
+			}
+			if ben.LastName != "Smith" {
+				t.Fatal("Expected first name of `Smith`, got " + ben.LastName)
+			}
+		}
+
+		john = Person{}
+		stmt, err = db.Preparex(db.Rebind("SELECT * FROM person WHERE first_name=?"))
+		if err != nil {
+			t.Error(err)
+		}
+		err = stmt.Get(&john, "John")
+		if err != nil {
+			t.Error(err)
+		}
+
+		// test name mapping
+		// THIS USED TO WORK BUT WILL NO LONGER WORK.
+		db.MapperFunc(strings.ToUpper)
+		rsa := CPlace{}
+		err = db.Get(&rsa, "SELECT * FROM capplace;")
+		if err != nil {
+			t.Error(err, "in db:", db.DriverName())
+		}
+		db.MapperFunc(strings.ToLower)
+
+		// create a copy and change the mapper, then verify the copy behaves
+		// differently from the original.
+		dbCopy := NewDb(db.DB, db.DriverName())
+		dbCopy.MapperFunc(strings.ToUpper)
+		err = dbCopy.Get(&rsa, "SELECT * FROM capplace;")
+		if err != nil {
+			fmt.Println(db.DriverName())
+			t.Error(err)
+		}
+
+		err = db.Get(&rsa, "SELECT * FROM cappplace;")
+		if err == nil {
+			t.Error("Expected no error, got ", err)
+		}
+
+		// test base type slices
+		var sdest []string
+		rows, err = db.Queryx("SELECT email FROM person ORDER BY email ASC;")
+		if err != nil {
+			t.Error(err)
+		}
+		err = scanAll(rows, &sdest, false)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// test Get with base types
+		var count int
+		err = db.Get(&count, "SELECT count(*) FROM person;")
+		if err != nil {
+			t.Error(err)
+		}
+		if count != len(sdest) {
+			t.Errorf("Expected %d == %d (count(*) vs len(SELECT ..)", count, len(sdest))
+		}
+
+		// test Get and Select with time.Time, #84
+		var addedAt time.Time
+		err = db.Get(&addedAt, "SELECT added_at FROM person LIMIT 1;")
+		if err != nil {
+			t.Error(err)
+		}
+
+		var addedAts []time.Time
+		err = db.Select(&addedAts, "SELECT added_at FROM person;")
+		if err != nil {
+			t.Error(err)
+		}
+
+		// test it on a double pointer
+		var pcount *int
+		err = db.Get(&pcount, "SELECT count(*) FROM person;")
+		if err != nil {
+			t.Error(err)
+		}
+		if *pcount != count {
+			t.Errorf("expected %d = %d", *pcount, count)
+		}
+
+		// test Select...
+		sdest = []string{}
+		err = db.Select(&sdest, "SELECT first_name FROM person ORDER BY first_name ASC;")
+		if err != nil {
+			t.Error(err)
+		}
+		expected := []string{"Ben", "Bin", "Jason", "John"}
+		for i, got := range sdest {
+			if got != expected[i] {
+				t.Errorf("Expected %d result to be %s, but got %s", i, expected[i], got)
+			}
+		}
+
+		var nsdest []sql.NullString
+		err = db.Select(&nsdest, "SELECT city FROM place ORDER BY city ASC")
+		if err != nil {
+			t.Error(err)
+		}
+		for _, val := range nsdest {
+			if val.Valid && val.String != "New York" {
+				t.Errorf("expected single valid result to be `New York`, but got %s", val.String)
+			}
+		}
+	})
+}
+
+type Product struct {
+	ProductID int
+}
+
+// tests that sqlx will not panic when the wrong driver is passed because
+// of an automatic nil dereference in sqlx.Open(), which was fixed.
+func TestDoNotPanicOnConnect(t *testing.T) {
+	_, err := Connect("bogus", "hehe")
+	if err == nil {
+		t.Errorf("Should return error when using bogus driverName")
+	}
+}
+
+func TestRebind(t *testing.T) {
+	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	q2 := `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`
+
+	s1 := Rebind(DOLLAR, q1)
+	s2 := Rebind(DOLLAR, q2)
+
+	if s1 != `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)` {
+		t.Errorf("q1 failed")
+	}
+
+	if s2 != `INSERT INTO foo (a, b, c) VALUES ($1, $2, "foo"), ("Hi", $3, $4)` {
+		t.Errorf("q2 failed")
+	}
+
+	s1 = Rebind(NAMED, q1)
+	s2 = Rebind(NAMED, q2)
+
+	ex1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES ` +
+		`(:arg1, :arg2, :arg3, :arg4, :arg5, :arg6, :arg7, :arg8, :arg9, :arg10)`
+	if s1 != ex1 {
+		t.Error("q1 failed on Named params")
+	}
+
+	ex2 := `INSERT INTO foo (a, b, c) VALUES (:arg1, :arg2, "foo"), ("Hi", :arg3, :arg4)`
+	if s2 != ex2 {
+		t.Error("q2 failed on Named params")
+	}
+}
+
+func TestBindMap(t *testing.T) {
+	// Test that it works..
+	q1 := `INSERT INTO foo (a, b, c, d) VALUES (:name, :age, :first, :last)`
+	am := map[string]interface{}{
+		"name":  "Jason Moiron",
+		"age":   30,
+		"first": "Jason",
+		"last":  "Moiron",
+	}
+
+	bq, args, _ := bindMap(QUESTION, q1, am)
+	expect := `INSERT INTO foo (a, b, c, d) VALUES (?, ?, ?, ?)`
+	if bq != expect {
+		t.Errorf("Interpolation of query failed: got `%v`, expected `%v`\n", bq, expect)
+	}
+
+	if args[0].(string) != "Jason Moiron" {
+		t.Errorf("Expected `Jason Moiron`, got %v\n", args[0])
+	}
+
+	if args[1].(int) != 30 {
+		t.Errorf("Expected 30, got %v\n", args[1])
+	}
+
+	if args[2].(string) != "Jason" {
+		t.Errorf("Expected Jason, got %v\n", args[2])
+	}
+
+	if args[3].(string) != "Moiron" {
+		t.Errorf("Expected Moiron, got %v\n", args[3])
+	}
+}
+
+// Test for #117, embedded nil maps
+
+type Message struct {
+	Text       string      `db:"string"`
+	Properties PropertyMap // Stored as JSON in the database
+}
+type PropertyMap map[string]string
+
+// Implement driver.Valuer and sql.Scanner interfaces on PropertyMap
+func (p PropertyMap) Value() (driver.Value, error) {
+	if len(p) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(p)
+}
+
+func (p PropertyMap) Scan(src interface{}) error {
+	v := reflect.ValueOf(src)
+	if !v.IsValid() || v.IsNil() {
+		return nil
+	}
+	if data, ok := src.([]byte); ok {
+		return json.Unmarshal(data, &p)
+	}
+	return fmt.Errorf("Could not not decode type %T -> %T", src, p)
+}
+
+func TestEmbeddedMaps(t *testing.T) {
+	var schema = Schema{
+		create: `
+			CREATE TABLE message (
+				string text,
+				properties text
+			);`,
+		drop: `drop table message;`,
+	}
+
+	RunWithSchema(schema, t, func(db *DB, t *testing.T) {
+		messages := []Message{
+			{"Hello, World", PropertyMap{"one": "1", "two": "2"}},
+			{"Thanks, Joy", PropertyMap{"pull": "request"}},
+		}
+		q1 := `INSERT INTO message (string, properties) VALUES (:string, :properties)`
+		for _, m := range messages {
+			_, err := db.NamedExec(q1, m)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		var count int
+		err := db.Get(&count, "SELECT count(*) FROM message")
+		if err != nil {
+			t.Error(err)
+		}
+		if count != len(messages) {
+			t.Errorf("Expected %d messages in DB, found %d", len(messages), count)
+		}
+
+		var m Message
+		err = db.Get(&m, "SELECT * FROM message LIMIT 1")
+		if err != nil {
+			t.Error(err)
+		}
+		if m.Properties == nil {
+			t.Error("Expected m.Properties to not be nil, but it was.")
+		}
+	})
+}
+
+func TestIssue197(t *testing.T) {
+	// this test actually tests for a bug in database/sql:
+	//   https://github.com/golang/go/issues/13905
+	// this potentially makes _any_ named type that is an alias for []byte
+	// unsafe to use in a lot of different ways (basically, unsafe to hold
+	// onto after loading from the database).
+	t.Skip()
+
+	type mybyte []byte
+	type Var struct{ Raw json.RawMessage }
+	type Var2 struct{ Raw []byte }
+	type Var3 struct{ Raw mybyte }
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		var err error
+		var v, q Var
+		if err = db.Get(&v, `SELECT '{"a": "b"}' AS raw`); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Printf("%s: v %s\n", db.DriverName(), v.Raw)
+		if err = db.Get(&q, `SELECT 'null' AS raw`); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Printf("%s: v %s\n", db.DriverName(), v.Raw)
+
+		var v2, q2 Var2
+		if err = db.Get(&v2, `SELECT '{"a": "b"}' AS raw`); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Printf("%s: v2 %s\n", db.DriverName(), v2.Raw)
+		if err = db.Get(&q2, `SELECT 'null' AS raw`); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Printf("%s: v2 %s\n", db.DriverName(), v2.Raw)
+
+		var v3, q3 Var3
+		if err = db.QueryRow(`SELECT '{"a": "b"}' AS raw`).Scan(&v3.Raw); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Printf("v3 %s\n", v3.Raw)
+		if err = db.QueryRow(`SELECT '{"c": "d"}' AS raw`).Scan(&q3.Raw); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Printf("v3 %s\n", v3.Raw)
+		t.Fail()
+	})
+}
+
+func TestIn(t *testing.T) {
+	// some quite normal situations
+	type tr struct {
+		q    string
+		args []interface{}
+		c    int
+	}
+	tests := []tr{
+		{"SELECT * FROM foo WHERE x = ? AND v in (?) AND y = ?",
+			[]interface{}{"foo", []int{0, 5, 7, 2, 9}, "bar"},
+			7},
+		{"SELECT * FROM foo WHERE x in (?)",
+			[]interface{}{[]int{1, 2, 3, 4, 5, 6, 7, 8}},
+			8},
+	}
+	for _, test := range tests {
+		q, a, err := In(test.q, test.args...)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(a) != test.c {
+			t.Errorf("Expected %d args, but got %d (%+v)", test.c, len(a), a)
+		}
+		if strings.Count(q, "?") != test.c {
+			t.Errorf("Expected %d bindVars, got %d", test.c, strings.Count(q, "?"))
+		}
+	}
+
+	// too many bindVars, but no slices, so short circuits parsing
+	// i'm not sure if this is the right behavior;  this query/arg combo
+	// might not work, but we shouldn't parse if we don't need to
+	{
+		orig := "SELECT * FROM foo WHERE x = ? AND y = ?"
+		q, a, err := In(orig, "foo", "bar", "baz")
+		if err != nil {
+			t.Error(err)
+		}
+		if len(a) != 3 {
+			t.Errorf("Expected 3 args, but got %d (%+v)", len(a), a)
+		}
+		if q != orig {
+			t.Error("Expected unchanged query.")
+		}
+	}
+
+	tests = []tr{
+		// too many bindvars;  slice present so should return error during parse
+		{"SELECT * FROM foo WHERE x = ? and y = ?",
+			[]interface{}{"foo", []int{1, 2, 3}, "bar"},
+			0},
+		// empty slice, should return error before parse
+		{"SELECT * FROM foo WHERE x = ?",
+			[]interface{}{[]int{}},
+			0},
+		// too *few* bindvars, should return an error
+		{"SELECT * FROM foo WHERE x = ? AND y in (?)",
+			[]interface{}{[]int{1, 2, 3}},
+			0},
+	}
+	for _, test := range tests {
+		_, _, err := In(test.q, test.args...)
+		if err == nil {
+			t.Error("Expected an error, but got nil.")
+		}
+	}
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		//tx.MustExec(tx.Rebind("INSERT INTO place (country, city, telcode) VALUES (?, ?, ?)"), "United States", "New York", "1")
+		//tx.MustExec(tx.Rebind("INSERT INTO place (country, telcode) VALUES (?, ?)"), "Hong Kong", "852")
+		//tx.MustExec(tx.Rebind("INSERT INTO place (country, telcode) VALUES (?, ?)"), "Singapore", "65")
+		telcodes := []int{852, 65}
+		q := "SELECT * FROM place WHERE telcode IN(?) ORDER BY telcode"
+		query, args, err := In(q, telcodes)
+		if err != nil {
+			t.Error(err)
+		}
+		query = db.Rebind(query)
+		places := []Place{}
+		err = db.Select(&places, query, args...)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(places) != 2 {
+			t.Fatalf("Expecting 2 results, got %d", len(places))
+		}
+		if places[0].TelCode != 65 {
+			t.Errorf("Expecting singapore first, but got %#v", places[0])
+		}
+		if places[1].TelCode != 852 {
+			t.Errorf("Expecting hong kong second, but got %#v", places[1])
+		}
+	})
+}
+
+func TestBindStruct(t *testing.T) {
+	var err error
+
+	q1 := `INSERT INTO foo (a, b, c, d) VALUES (:name, :age, :first, :last)`
+
+	type tt struct {
+		Name  string
+		Age   int
+		First string
+		Last  string
+	}
+
+	type tt2 struct {
+		Field1 string `db:"field_1"`
+		Field2 string `db:"field_2"`
+	}
+
+	type tt3 struct {
+		tt2
+		Name string
+	}
+
+	am := tt{"Jason Moiron", 30, "Jason", "Moiron"}
+
+	bq, args, _ := bindStruct(QUESTION, q1, am, mapper())
+	expect := `INSERT INTO foo (a, b, c, d) VALUES (?, ?, ?, ?)`
+	if bq != expect {
+		t.Errorf("Interpolation of query failed: got `%v`, expected `%v`\n", bq, expect)
+	}
+
+	if args[0].(string) != "Jason Moiron" {
+		t.Errorf("Expected `Jason Moiron`, got %v\n", args[0])
+	}
+
+	if args[1].(int) != 30 {
+		t.Errorf("Expected 30, got %v\n", args[1])
+	}
+
+	if args[2].(string) != "Jason" {
+		t.Errorf("Expected Jason, got %v\n", args[2])
+	}
+
+	if args[3].(string) != "Moiron" {
+		t.Errorf("Expected Moiron, got %v\n", args[3])
+	}
+
+	am2 := tt2{"Hello", "World"}
+	bq, args, _ = bindStruct(QUESTION, "INSERT INTO foo (a, b) VALUES (:field_2, :field_1)", am2, mapper())
+	expect = `INSERT INTO foo (a, b) VALUES (?, ?)`
+	if bq != expect {
+		t.Errorf("Interpolation of query failed: got `%v`, expected `%v`\n", bq, expect)
+	}
+
+	if args[0].(string) != "World" {
+		t.Errorf("Expected 'World', got %s\n", args[0].(string))
+	}
+	if args[1].(string) != "Hello" {
+		t.Errorf("Expected 'Hello', got %s\n", args[1].(string))
+	}
+
+	am3 := tt3{Name: "Hello!"}
+	am3.Field1 = "Hello"
+	am3.Field2 = "World"
+
+	bq, args, err = bindStruct(QUESTION, "INSERT INTO foo (a, b, c) VALUES (:name, :field_1, :field_2)", am3, mapper())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect = `INSERT INTO foo (a, b, c) VALUES (?, ?, ?)`
+	if bq != expect {
+		t.Errorf("Interpolation of query failed: got `%v`, expected `%v`\n", bq, expect)
+	}
+
+	if args[0].(string) != "Hello!" {
+		t.Errorf("Expected 'Hello!', got %s\n", args[0].(string))
+	}
+	if args[1].(string) != "Hello" {
+		t.Errorf("Expected 'Hello', got %s\n", args[1].(string))
+	}
+	if args[2].(string) != "World" {
+		t.Errorf("Expected 'World', got %s\n", args[0].(string))
+	}
+}
+
+func TestEmbeddedLiterals(t *testing.T) {
+	var schema = Schema{
+		create: `
+			CREATE TABLE x (
+				k text
+			);`,
+		drop: `drop table x;`,
+	}
+
+	RunWithSchema(schema, t, func(db *DB, t *testing.T) {
+		type t1 struct {
+			K *string
+		}
+		type t2 struct {
+			Inline struct {
+				F string
+			}
+			K *string
+		}
+
+		db.MustExec(db.Rebind("INSERT INTO x (k) VALUES (?), (?), (?);"), "one", "two", "three")
+
+		target := t1{}
+		err := db.Get(&target, db.Rebind("SELECT * FROM x WHERE k=?"), "one")
+		if err != nil {
+			t.Error(err)
+		}
+		if *target.K != "one" {
+			t.Error("Expected target.K to be `one`, got ", target.K)
+		}
+
+		target2 := t2{}
+		err = db.Get(&target2, db.Rebind("SELECT * FROM x WHERE k=?"), "one")
+		if err != nil {
+			t.Error(err)
+		}
+		if *target2.K != "one" {
+			t.Errorf("Expected target2.K to be `one`, got `%v`", target2.K)
+		}
+	})
+}
+
+func BenchmarkBindStruct(b *testing.B) {
+	b.StopTimer()
+	q1 := `INSERT INTO foo (a, b, c, d) VALUES (:name, :age, :first, :last)`
+	type t struct {
+		Name  string
+		Age   int
+		First string
+		Last  string
+	}
+	am := t{"Jason Moiron", 30, "Jason", "Moiron"}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		bindStruct(DOLLAR, q1, am, mapper())
+	}
+}
+
+func BenchmarkBindMap(b *testing.B) {
+	b.StopTimer()
+	q1 := `INSERT INTO foo (a, b, c, d) VALUES (:name, :age, :first, :last)`
+	am := map[string]interface{}{
+		"name":  "Jason Moiron",
+		"age":   30,
+		"first": "Jason",
+		"last":  "Moiron",
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		bindMap(DOLLAR, q1, am)
+	}
+}
+
+func BenchmarkIn(b *testing.B) {
+	q := `SELECT * FROM foo WHERE x = ? AND v in (?) AND y = ?`
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = In(q, []interface{}{"foo", []int{0, 5, 7, 2, 9}, "bar"}...)
+	}
+}
+
+func BenchmarkRebind(b *testing.B) {
+	b.StopTimer()
+	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	q2 := `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		Rebind(DOLLAR, q1)
+		Rebind(DOLLAR, q2)
+	}
+}
+
+func BenchmarkRebindBuffer(b *testing.B) {
+	b.StopTimer()
+	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	q2 := `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		rebindBuff(DOLLAR, q1)
+		rebindBuff(DOLLAR, q2)
+	}
+}

--- a/vendor/github.com/jmoiron/sqlx/types/README.md
+++ b/vendor/github.com/jmoiron/sqlx/types/README.md
@@ -1,0 +1,5 @@
+# types
+
+The types package provides some useful types which implement the `sql.Scanner`
+and `driver.Valuer` interfaces, suitable for use as scan and value targets with
+database/sql.

--- a/vendor/github.com/jmoiron/sqlx/types/types.go
+++ b/vendor/github.com/jmoiron/sqlx/types/types.go
@@ -1,0 +1,106 @@
+package types
+
+import (
+	"bytes"
+	"compress/gzip"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+
+	"io/ioutil"
+)
+
+// GzippedText is a []byte which transparently gzips data being submitted to
+// a database and ungzips data being Scanned from a database.
+type GzippedText []byte
+
+// Value implements the driver.Valuer interface, gzipping the raw value of
+// this GzippedText.
+func (g GzippedText) Value() (driver.Value, error) {
+	b := make([]byte, 0, len(g))
+	buf := bytes.NewBuffer(b)
+	w := gzip.NewWriter(buf)
+	w.Write(g)
+	w.Close()
+	return buf.Bytes(), nil
+
+}
+
+// Scan implements the sql.Scanner interface, ungzipping the value coming off
+// the wire and storing the raw result in the GzippedText.
+func (g *GzippedText) Scan(src interface{}) error {
+	var source []byte
+	switch src.(type) {
+	case string:
+		source = []byte(src.(string))
+	case []byte:
+		source = src.([]byte)
+	default:
+		return errors.New("Incompatible type for GzippedText")
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(source))
+	defer reader.Close()
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	*g = GzippedText(b)
+	return nil
+}
+
+// JSONText is a json.RawMessage, which is a []byte underneath.
+// Value() validates the json format in the source, and returns an error if
+// the json is not valid.  Scan does no validation.  JSONText additionally
+// implements `Unmarshal`, which unmarshals the json within to an interface{}
+type JSONText json.RawMessage
+
+// MarshalJSON returns the *j as the JSON encoding of j.
+func (j *JSONText) MarshalJSON() ([]byte, error) {
+	return *j, nil
+}
+
+// UnmarshalJSON sets *j to a copy of data
+func (j *JSONText) UnmarshalJSON(data []byte) error {
+	if j == nil {
+		return errors.New("JSONText: UnmarshalJSON on nil pointer")
+	}
+	*j = append((*j)[0:0], data...)
+	return nil
+
+}
+
+// Value returns j as a value.  This does a validating unmarshal into another
+// RawMessage.  If j is invalid json, it returns an error.
+func (j JSONText) Value() (driver.Value, error) {
+	var m json.RawMessage
+	var err = j.Unmarshal(&m)
+	if err != nil {
+		return []byte{}, err
+	}
+	return []byte(j), nil
+}
+
+// Scan stores the src in *j.  No validation is done.
+func (j *JSONText) Scan(src interface{}) error {
+	var source []byte
+	switch src.(type) {
+	case string:
+		source = []byte(src.(string))
+	case []byte:
+		source = src.([]byte)
+	default:
+		return errors.New("Incompatible type for JSONText")
+	}
+	*j = JSONText(append((*j)[0:0], source...))
+	return nil
+}
+
+// Unmarshal unmarshal's the json in j to v, as in json.Unmarshal.
+func (j *JSONText) Unmarshal(v interface{}) error {
+	return json.Unmarshal([]byte(*j), v)
+}
+
+// Pretty printing for JSONText types
+func (j JSONText) String() string {
+	return string(j)
+}

--- a/vendor/github.com/jmoiron/sqlx/types/types_test.go
+++ b/vendor/github.com/jmoiron/sqlx/types/types_test.go
@@ -1,0 +1,42 @@
+package types
+
+import "testing"
+
+func TestGzipText(t *testing.T) {
+	g := GzippedText("Hello, world")
+	v, err := g.Value()
+	if err != nil {
+		t.Errorf("Was not expecting an error")
+	}
+	err = (&g).Scan(v)
+	if err != nil {
+		t.Errorf("Was not expecting an error")
+	}
+	if string(g) != "Hello, world" {
+		t.Errorf("Was expecting the string we sent in (Hello World), got %s", string(g))
+	}
+}
+
+func TestJSONText(t *testing.T) {
+	j := JSONText(`{"foo": 1, "bar": 2}`)
+	v, err := j.Value()
+	if err != nil {
+		t.Errorf("Was not expecting an error")
+	}
+	err = (&j).Scan(v)
+	if err != nil {
+		t.Errorf("Was not expecting an error")
+	}
+	m := map[string]interface{}{}
+	j.Unmarshal(&m)
+
+	if m["foo"].(float64) != 1 || m["bar"].(float64) != 2 {
+		t.Errorf("Expected valid json but got some garbage instead? %#v", m)
+	}
+
+	j = JSONText(`{"foo": 1, invalid, false}`)
+	v, err = j.Value()
+	if err == nil {
+		t.Errorf("Was expecting invalid json to fail!")
+	}
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -170,6 +170,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/jmoiron/sqlx",
+			"repository": "https://github.com/jmoiron/sqlx",
+			"revision": "398dd5876282499cdfd4cb8ea0f31a672abe9495",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/kardianos/osext",
 			"repository": "https://github.com/kardianos/osext",
 			"revision": "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc",


### PR DESCRIPTION
I'd like to add MySQL support and this uses `sqlx` which is a wrapper over `database/sql` that helps with handling driver-independent variables.