### PR TITLE
Finish support for e-mail address SANs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ import (
 // mechanism.
 type CSRWhitelist struct {
 	Subject, PublicKeyAlgorithm, PublicKey, SignatureAlgorithm bool
-	DNSNames, IPAddresses                                      bool
+	DNSNames, IPAddresses, EmailAddresses                      bool
 }
 
 // OID is our own version of asn1's ObjectIdentifier, so we can define a custom

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -274,6 +274,9 @@ func getHosts(cert *x509.Certificate) []string {
 	for _, dns := range cert.DNSNames {
 		hosts = append(hosts, dns)
 	}
+	for _, email := range cert.EmailAddresses {
+		hosts = append(hosts, email)
+	}
 
 	return hosts
 }

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -386,6 +386,8 @@ func Generate(priv crypto.Signer, req *CertificateRequest) (csr []byte, err erro
 	for i := range req.Hosts {
 		if ip := net.ParseIP(req.Hosts[i]); ip != nil {
 			tpl.IPAddresses = append(tpl.IPAddresses, ip)
+		} else if email, err := mail.ParseAddress(req.Hosts[i]); err == nil && email != nil {
+			tpl.EmailAddresses = append(tpl.EmailAddresses, email.Address)
 		} else {
 			tpl.DNSNames = append(tpl.DNSNames, req.Hosts[i])
 		}

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"net"
+	"net/mail"
 	"strings"
 
 	cferr "github.com/cloudflare/cfssl/errors"
@@ -221,6 +222,8 @@ func ParseRequest(req *CertificateRequest) (csr, key []byte, err error) {
 	for i := range req.Hosts {
 		if ip := net.ParseIP(req.Hosts[i]); ip != nil {
 			tpl.IPAddresses = append(tpl.IPAddresses, ip)
+		} else if email, err := mail.ParseAddress(req.Hosts[i]); err == nil && email != nil {
+			tpl.EmailAddresses = append(tpl.EmailAddresses, req.Hosts[i])
 		} else {
 			tpl.DNSNames = append(tpl.DNSNames, req.Hosts[i])
 		}

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -107,7 +107,7 @@ func TestParseRequest(t *testing.T) {
 				OU: "Systems Engineering",
 			},
 		},
-		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1"},
+		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1", "jdoe@example.com"},
 		KeyRequest: NewBasicKeyRequest(),
 	}
 
@@ -221,7 +221,7 @@ func TestDefaultBasicKeyRequest(t *testing.T) {
 			},
 		},
 		CN:    "cloudflare.com",
-		Hosts: []string{"cloudflare.com", "www.cloudflare.com"},
+		Hosts: []string{"cloudflare.com", "www.cloudflare.com", "jdoe@example.com"},
 	}
 	_, priv, err := ParseRequest(req)
 	if err != nil {
@@ -261,7 +261,7 @@ func TestRSACertRequest(t *testing.T) {
 			},
 		},
 		CN:         "cloudflare.com",
-		Hosts:      []string{"cloudflare.com", "www.cloudflare.com"},
+		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "jdoe@example.com"},
 		KeyRequest: &BasicKeyRequest{"rsa", 2048},
 	}
 	_, _, err := ParseRequest(req)
@@ -318,7 +318,7 @@ func TestGenerator(t *testing.T) {
 			},
 		},
 		CN:         "cloudflare.com",
-		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1"},
+		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1", "jdoe@example.com"},
 		KeyRequest: &BasicKeyRequest{"rsa", 2048},
 	}
 
@@ -346,6 +346,10 @@ func TestGenerator(t *testing.T) {
 	}
 
 	if len(csr.IPAddresses) != 1 {
+		t.Fatal("SAN parsing error")
+	}
+
+	if len(csr.EmailAddresses) != 1 {
 		t.Fatal("SAN parsing error")
 	}
 
@@ -388,7 +392,7 @@ func TestWeakCSR(t *testing.T) {
 			},
 		},
 		CN:         "cloudflare.com",
-		Hosts:      []string{"cloudflare.com", "www.cloudflare.com"},
+		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "jdoe@example.com"},
 		KeyRequest: &BasicKeyRequest{"rsa", 1024},
 	}
 	g := &Generator{testValidator}
@@ -449,7 +453,7 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 		CN:         "cloudflare.com",
-		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1"},
+		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1", "jdoe@example.com"},
 		KeyRequest: &BasicKeyRequest{"ecdsa", 256},
 	}
 
@@ -468,9 +472,21 @@ func TestGenerate(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	_, _, err = helpers.ParseCSR(csrPEM)
+	csr, _, err := helpers.ParseCSR(csrPEM)
 	if err != nil {
 		t.Fatalf("%v", err)
+	}
+
+	if len(csr.DNSNames) != 2 {
+		t.Fatal("SAN parsing error")
+	}
+
+	if len(csr.IPAddresses) != 1 {
+		t.Fatal("SAN parsing error")
+	}
+
+	if len(csr.EmailAddresses) != 1 {
+		t.Fatal("SAN parsing error")
 	}
 }
 

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -174,6 +174,7 @@ func ParseCertificateRequest(s Signer, csrBytes []byte) (template *x509.Certific
 		SignatureAlgorithm: s.SigAlgo(),
 		DNSNames:           csr.DNSNames,
 		IPAddresses:        csr.IPAddresses,
+		EmailAddresses:     csr.EmailAddresses,
 	}
 
 	return


### PR DESCRIPTION
This pull request is to ensure that if e-mail addresses are provided in the CSR that they make it to the final certificate. Prior to this, e-mail addresses were being treated as dns names and weren't appearing in the SAN field as rfc822Name entities.