### PR TITLE
add SerialNumber to signer.Subject

### DIFF
--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -80,10 +80,10 @@ func NewSignerFromFile(caFile, caKeyFile string, policy *config.Signing) (*Signe
 	if err != nil {
 		return nil, err
 	}
-	
+
 	strPassword := os.Getenv("CFSSL_CA_PK_PASSWORD")
 	password := []byte(strPassword)
-	if (strPassword == "") {
+	if strPassword == "" {
 		password = nil
 	}
 
@@ -163,7 +163,9 @@ func PopulateSubjectFromCSR(s *signer.Subject, req pkix.Name) pkix.Name {
 	replaceSliceIfEmpty(&name.Locality, &req.Locality)
 	replaceSliceIfEmpty(&name.Organization, &req.Organization)
 	replaceSliceIfEmpty(&name.OrganizationalUnit, &req.OrganizationalUnit)
-
+	if name.SerialNumber == "" {
+		name.SerialNumber = req.SerialNumber
+	}
 	return name
 }
 

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -501,6 +501,7 @@ func TestPopulateSubjectFromCSR(t *testing.T) {
 				OU: "OU",
 			},
 		},
+		SerialNumber: "deadbeef",
 	}
 
 	fullName := pkix.Name{
@@ -509,6 +510,7 @@ func TestPopulateSubjectFromCSR(t *testing.T) {
 		Province:           []string{"Province"},
 		Organization:       []string{"Organization"},
 		OrganizationalUnit: []string{"OrganizationalUnit"},
+		SerialNumber:       "SerialNumber",
 	}
 
 	noCN := *fullSubject
@@ -544,6 +546,13 @@ func TestPopulateSubjectFromCSR(t *testing.T) {
 	name = PopulateSubjectFromCSR(&noOU, fullName)
 	if !reflect.DeepEqual(name.OrganizationalUnit, fullName.OrganizationalUnit) {
 		t.Fatal("Failed to replace empty organizational unit")
+	}
+
+	noSerial := *fullSubject
+	noSerial.SerialNumber = ""
+	name = PopulateSubjectFromCSR(&noSerial, fullName)
+	if name.SerialNumber != fullName.SerialNumber {
+		t.Fatalf("Failed to replace empty serial number: want %#v, got %#v", fullName.SerialNumber, name.SerialNumber)
 	}
 
 }

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -29,8 +29,9 @@ var MaxPathLen = 2
 // Subject contains the information that should be used to override the
 // subject information when signing a certificate.
 type Subject struct {
-	CN    string
-	Names []csr.Name `json:"names"`
+	CN           string
+	Names        []csr.Name `json:"names"`
+	SerialNumber string
 }
 
 // Extension represents a raw extension to be included in the certificate.  The
@@ -77,6 +78,7 @@ func (s *Subject) Name() pkix.Name {
 		appendIf(n.O, &name.Organization)
 		appendIf(n.OU, &name.OrganizationalUnit)
 	}
+	name.SerialNumber = s.SerialNumber
 	return name
 }
 

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
 )
 
 func TestAppendIf(t *testing.T) {
@@ -104,4 +105,46 @@ func TestAddPoliciesWithQualifiers(t *testing.T) {
 		t.Fatal(fmt.Sprintf("Value didn't match expected bytes: %s vs %s",
 			hex.EncodeToString(ext.Value), hex.EncodeToString(expectedBytes)))
 	}
+}
+
+func TestName(t *testing.T) {
+	sub := &Subject{
+		CN: "foobar",
+		Names: []csr.Name{
+			{
+				C:  "US",
+				ST: "CA",
+				L:  "Cool Locality",
+				O:  "Cool Org",
+				OU: "Really Cool Sub Org",
+			},
+			{
+				L: "Another Cool Locality",
+			},
+		},
+		SerialNumber: "deadbeef",
+	}
+	name := sub.Name()
+	if name.CommonName != sub.CN {
+		t.Errorf("CommonName: want %#v, got %#v", sub.CN, name.CommonName)
+	}
+	if name.SerialNumber != sub.SerialNumber {
+		t.Errorf("SerialNumber: want %#v, got %#v", sub.SerialNumber, name.SerialNumber)
+	}
+	if !reflect.DeepEqual([]string{"US"}, name.Country) {
+		t.Errorf("Country: want %s, got %s", []string{"US"}, name.Country)
+	}
+	if !reflect.DeepEqual([]string{"CA"}, name.Province) {
+		t.Errorf("Province: want %s, got %s", []string{"CA"}, name.Province)
+	}
+	if !reflect.DeepEqual([]string{"Cool Org"}, name.Organization) {
+		t.Errorf("Organization: want %s, got %s", []string{"Cool Org"}, name.Organization)
+	}
+	if !reflect.DeepEqual([]string{"Really Cool Sub Org"}, name.OrganizationalUnit) {
+		t.Errorf("Province: want %s, got %s", []string{"Really Cool Sub Org"}, name.OrganizationalUnit)
+	}
+	if !reflect.DeepEqual([]string{"Cool Locality", "Another Cool Locality"}, name.Locality) {
+		t.Errorf("Locality: want %s, got %s", []string{"CA"}, name.Locality)
+	}
+
 }


### PR DESCRIPTION
This allows boulder and other clients to create certificates without CommonNames but with non-empty Subjects that might cause problems for clients.

Unlike in a certificate where its a number, RFC 5280 specify's a Subject's SerialNumber as a printable string. Hence, the Go `pkix.Name`'s type for its `SerialNumber`.