### PR TITLE
Responder caching refactor

### DIFF
--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -197,8 +197,8 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 		expiresIn := int(parsedResponse.NextUpdate.Sub(now) / time.Second)
 		maxAge = &expiresIn
 	} else {
-		zero := 0
-		maxAge = &zero
+		zero := 0      // XXX: we want max-age=0 but since this is technically an authorized OCSP response
+		maxAge = &zero //      (despite being stale) and 5019 forbids attaching no-cache we get a little tricky
 	}
 	response.WriteHeader(http.StatusOK)
 	response.Write(ocspResponse)

--- a/ocsp/responder_test.go
+++ b/ocsp/responder_test.go
@@ -92,9 +92,9 @@ func TestCacheHeaders(t *testing.T) {
 		header string
 		value  string
 	}{
-		{"Last-Modified", "Wed, 21 Oct 2015 20:55:00 UTC"},
+		{"Last-Modified", "Tue, 20 Oct 2015 00:00:00 UTC"},
 		{"Expires", "Sun, 20 Oct 2030 00:00:00 UTC"},
-		{"Cache-Control", "max-age=471398400"},
+		{"Cache-Control", "max-age=471398400, public, no-transform, must-revalidate"},
 	}
 	for _, tc := range testCases {
 		headers, ok := rw.HeaderMap[tc.header]


### PR DESCRIPTION
Always adds relevant `Cache-Control` headers instead of only when a valid response is returned to the client. Also adds the RFC 5019 specified `Cache-Control` modifiers to prevent intermediary proxies/caches from mangling responses and switches `ProducedAt` for `ThisUpdate` as specified in RFC 2560 for use in the `Last-Modified` header.

Finally this checks that the `NextUpdate` field is in the future before setting max-age as this previously allowed negative max-age parameters (In the case of a stale response the responder will return `max-age=0` for now, although stale responses should probably just not be returned, opened #530 to discuss).

Unblocks work on letsencrypt/boulder#1485.