### PR TITLE
Better fix of loglevel redefinition bug

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"sync"
 )
 
 // The following constants represent logging levels in increasing levels of seriousness.
@@ -64,12 +63,11 @@ func SetLogger(logger SyslogWriter) {
 	syslogWriter = logger
 }
 
-// once ensures that the loglevel flag isn't redefined
-// if multiple packages import "github.com/cloudflare/cfssl/log"
-var once sync.Once
-
 func init() {
-	once.Do(func() { flag.IntVar(&Level, "loglevel", LevelInfo, "Log level (0 = DEBUG, 5 = FATAL)") })
+	// Only define loglevel flag once.
+	if flag.Lookup("loglevel") == nil {
+		flag.IntVar(&Level, "loglevel", LevelInfo, "Log level (0 = DEBUG, 5 = FATAL)")
+	}
 }
 
 func print(l int, msg string) {


### PR DESCRIPTION
When vendoring, the `sync.Once` variable could be defined multiple times. Since `init` functions run in a single thread, we can simply check if the flag has already been defined before defining it.