### PR TITLE
Unbreak ocspserve by providing a properly initialised Responder object

### DIFF
--- a/cli/ocspserve/ocspserve.go
+++ b/cli/ocspserve/ocspserve.go
@@ -41,7 +41,7 @@ func ocspServerMain(args []string, c cli.Config) error {
 	}
 
 	log.Info("Registering OCSP responder handler")
-	http.Handle(c.Path, ocsp.Responder{Source: src})
+	http.Handle(c.Path, ocsp.NewResponder(src))
 
 	addr := fmt.Sprintf("%s:%d", c.Address, c.Port)
 	log.Info("Now listening on ", addr)


### PR DESCRIPTION
ocspserve was crashing on a call to `rs.clk.Now()` because `rs.clk` was nil due to being initialised manually instead of using `ocsp.NewResponder()`.