### PR TITLE
Read Subject SerialNumber attribute from certificate requests.

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -28,11 +28,12 @@ const (
 
 // A Name contains the SubjectInfo fields.
 type Name struct {
-	C  string // Country
-	ST string // State
-	L  string // Locality
-	O  string // OrganisationName
-	OU string // OrganisationalUnitName
+	C            string // Country
+	ST           string // State
+	L            string // Locality
+	O            string // OrganisationName
+	OU           string // OrganisationalUnitName
+	SerialNumber string
 }
 
 // A KeyRequest is a generic request for a new key.
@@ -135,11 +136,12 @@ type CAConfig struct {
 // A CertificateRequest encapsulates the API interface to the
 // certificate request functionality.
 type CertificateRequest struct {
-	CN         string
-	Names      []Name     `json:"names"`
-	Hosts      []string   `json:"hosts"`
-	KeyRequest KeyRequest `json:"key,omitempty"`
-	CA         *CAConfig  `json:"ca,omitempty"`
+	CN           string
+	Names        []Name     `json:"names"`
+	Hosts        []string   `json:"hosts"`
+	KeyRequest   KeyRequest `json:"key,omitempty"`
+	CA           *CAConfig  `json:"ca,omitempty"`
+	SerialNumber string     `json:"serialnumber,omitempty"`
 }
 
 // New returns a new, empty CertificateRequest with a
@@ -169,6 +171,7 @@ func (cr *CertificateRequest) Name() pkix.Name {
 		appendIf(n.O, &name.Organization)
 		appendIf(n.OU, &name.OrganizationalUnit)
 	}
+	name.SerialNumber = cr.SerialNumber
 	return name
 }
 
@@ -254,6 +257,7 @@ func ExtractCertificateRequest(cert *x509.Certificate) *CertificateRequest {
 	req.CN = cert.Subject.CommonName
 	req.Names = getNames(cert.Subject)
 	req.Hosts = getHosts(cert)
+	req.SerialNumber = cert.Subject.SerialNumber
 
 	if cert.IsCA {
 		req.CA = new(CAConfig)


### PR DESCRIPTION
Most of the implementation for the subject serialnumber was added in 3f3fa68e8d6ce6ceace60ea86461f8be41fa477b. This PR adds reading the subject serialnumber attribute from a json certificate request.
RFC 5280 4.1.2.4.

    {
        "CN": "Martin Client Cert",
        "SerialNumber": "000123456789",
        "names": [
            {
                "OU": "Martin"
            }
        ]
    }

![image](https://cloud.githubusercontent.com/assets/484002/13825870/fb7da25c-ebb4-11e5-844a-c8c684482a23.png)