### PR TITLE
gencert: take into account csr hosts for CAB host warning

### DIFF
--- a/cli/gencert/gencert.go
+++ b/cli/gencert/gencert.go
@@ -119,14 +119,14 @@ func gencertMain(args []string, c cli.Config) error {
 		}
 
 		var cert []byte
-		req := signer.SignRequest{
+		signReq := signer.SignRequest{
 			Request: string(csrBytes),
 			Hosts:   signer.SplitHosts(c.Hostname),
 			Profile: c.Profile,
 			Label:   c.Label,
 		}
 
-		cert, err = s.Sign(req)
+		cert, err = s.Sign(signReq)
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func gencertMain(args []string, c cli.Config) error {
 		// "Applicant information MUST include, but not be limited to, at least one
 		// Fully-Qualified Domain Name or IP address to be included in the Certificate’s
 		// SubjectAltName extension."
-		if len(req.Hosts) == 0 {
+		if len(signReq.Hosts) == 0 && len(req.Hosts) == 0 {
 			log.Warning(generator.CSRNoHostMessage)
 		}
 


### PR DESCRIPTION
When creating certificate through the CLI with a CSR that has `hosts` (like [testdata/csr.json](https://github.com/cloudflare/cfssl/blob/master/testdata/csr.json)) `cfssl` would incorrectly log the following warning:

```
This certificate lacks a "hosts" field. This makes it unsuitable for
websites. For more information see the Baseline Requirements for the Issuance and Management
of Publicly-Trusted Certificates, v.1.1.6, from the CA/Browser Forum (https://cabforum.org);
specifically, section 10.2.3 ("Information Requirements").
``` 

This PR corrects that by inspecting both the `-hostname` argument _and_ the `hosts` filed on the supplied CSR.