### PR TITLE
Remove data race in initca (fixed #571).

### DIFF
--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -95,20 +95,24 @@ func TestInitCA(t *testing.T) {
 			}
 		}
 
-		// Start a signer
-		var CAPolicy = &config.Signing{
-			Default: &config.SigningProfile{
-				Usage:        []string{"cert sign", "crl sign"},
-				ExpiryString: "300s",
-				Expiry:       300 * time.Second,
-				CA:           true,
-			},
+		// Replace the default CAPolicy with a test (short expiry) version.
+		CAPolicy = func() *config.Signing {
+			return &config.Signing{
+				Default: &config.SigningProfile{
+					Usage:        []string{"cert sign", "crl sign"},
+					ExpiryString: "300s",
+					Expiry:       300 * time.Second,
+					CA:           true,
+				},
+			}
 		}
+
+		// Start a signer
 		s, err := local.NewSigner(key, cert, signer.DefaultSigAlgo(key), nil)
 		if err != nil {
 			t.Fatal("Signer Creation error:", err)
 		}
-		s.SetPolicy(CAPolicy)
+		s.SetPolicy(CAPolicy())
 
 		// Sign RSA and ECDSA customer CSRs.
 		for _, csrFile := range csrFiles {

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -222,6 +222,7 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 		notBefore       time.Time
 		notAfter        time.Time
 		crlURL, ocspURL string
+		issuerURL       = profile.IssuerURL
 	)
 
 	// The third value returned from Usages is a list of unknown key usages.
@@ -229,7 +230,7 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 	// here.
 	ku, eku, _ = profile.Usages()
 	if profile.IssuerURL == nil {
-		profile.IssuerURL = defaultProfile.IssuerURL
+		issuerURL = defaultProfile.IssuerURL
 	}
 
 	if ku == 0 && len(eku) == 0 {
@@ -279,8 +280,8 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 		template.CRLDistributionPoints = []string{crlURL}
 	}
 
-	if len(profile.IssuerURL) != 0 {
-		template.IssuingCertificateURL = profile.IssuerURL
+	if len(issuerURL) != 0 {
+		template.IssuingCertificateURL = issuerURL
 	}
 	if len(profile.Policies) != 0 {
 		err = addPolicies(template, profile.Policies)

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,7 @@ COVPROFILES=""
 for package in $(go list -f '{{if len .TestGoFiles}}{{.ImportPath}}{{end}}' $PACKAGES)
 do
     profile="$GOPATH/src/$package/.coverprofile"
-    go test -tags "$BUILD_TAGS" --coverprofile=$profile $package
+    go test -race -tags "$BUILD_TAGS" --coverprofile=$profile $package
     [ -s $profile ] && COVPROFILES="$COVPROFILES $profile"
 done
 cat $COVPROFILES > coverprofile.txt


### PR DESCRIPTION
The default policy was previously a global variable, which caused
issues when multiple CAs were being initialised in parallel (such
as in testing, e.g. [1]).

This change causes the default policy to be a function returning a
default policy. The function can still be swapped out in testing as
needed, but the functions now operate on local copies of the default
policy. A change to the default policy (which is only used in testing)
can now be accomplished by changing the function itself.

[1] https://github.com/cloudflare/cfssl/issues/571