### PR TITLE
Remove error return from log functions.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -45,12 +45,12 @@ var Level = LevelInfo
 //
 // SyslogWriter is satisfied by *syslog.Writer.
 type SyslogWriter interface {
-	Debug(string) error
-	Info(string) error
-	Warning(string) error
-	Err(string) error
-	Crit(string) error
-	Emerg(string) error
+	Debug(string)
+	Info(string)
+	Warning(string)
+	Err(string)
+	Crit(string)
+	Emerg(string)
 }
 
 // syslogWriter stores the SetLogger() parameter.
@@ -73,23 +73,19 @@ func init() {
 func print(l int, msg string) {
 	if l >= Level {
 		if syslogWriter != nil {
-			var err error
 			switch l {
 			case LevelDebug:
-				err = syslogWriter.Debug(msg)
+				syslogWriter.Debug(msg)
 			case LevelInfo:
-				err = syslogWriter.Info(msg)
+				syslogWriter.Info(msg)
 			case LevelWarning:
-				err = syslogWriter.Warning(msg)
+				syslogWriter.Warning(msg)
 			case LevelError:
-				err = syslogWriter.Err(msg)
+				syslogWriter.Err(msg)
 			case LevelCritical:
-				err = syslogWriter.Crit(msg)
+				syslogWriter.Crit(msg)
 			case LevelFatal:
-				err = syslogWriter.Emerg(msg)
-			}
-			if err != nil {
-				log.Printf("Unable to write syslog: %v for msg: %s\n", err, msg)
+				syslogWriter.Emerg(msg)
 			}
 		} else {
 			log.Printf("[%s] %s", levelPrefix[l], msg)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -141,40 +141,34 @@ type testSyslogger struct {
 	*bytes.Buffer
 }
 
-func (l testSyslogger) Debug(s string) error {
+func (l testSyslogger) Debug(s string) {
 	l.WriteString("[DEBUG] ")
-	_, err := l.WriteString(s)
-	return err
+	_, _ = l.WriteString(s)
 }
 
-func (l testSyslogger) Info(s string) error {
+func (l testSyslogger) Info(s string) {
 	l.WriteString("[INFO] ")
-	_, err := l.WriteString(s)
-	return err
+	_, _ = l.WriteString(s)
 }
 
-func (l testSyslogger) Warning(s string) error {
+func (l testSyslogger) Warning(s string) {
 	l.WriteString("[WARN] ")
-	_, err := l.WriteString(s)
-	return err
+	_, _ = l.WriteString(s)
 }
 
-func (l testSyslogger) Err(s string) error {
+func (l testSyslogger) Err(s string) {
 	l.WriteString("[ERROR] ")
-	_, err := l.WriteString(s)
-	return err
+	_, _ = l.WriteString(s)
 }
 
-func (l testSyslogger) Crit(s string) error {
+func (l testSyslogger) Crit(s string) {
 	l.WriteString("[CRIT] ")
-	_, err := l.WriteString(s)
-	return err
+	_, _ = l.WriteString(s)
 }
 
-func (l testSyslogger) Emerg(s string) error {
+func (l testSyslogger) Emerg(s string) {
 	l.WriteString("[FATAL] ")
-	_, err := l.WriteString(s)
-	return err
+	_, _ = l.WriteString(s)
 }
 
 func TestSetLogger(t *testing.T) {


### PR DESCRIPTION
These don't need to be an intrinsic part of the logging interface. In Boulder
we're removing the error returns from our logging interface, in favor of
handling internally any failures to write to syslog (by writing to stderr
instead).