### PR TITLE
Fix TLS Dialer Timeout

### DIFF
--- a/scan/connectivity.go
+++ b/scan/connectivity.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 )
 
 // Connectivity contains scanners testing basic connectivity to the host
@@ -79,7 +78,7 @@ func initOnCloudFlareScan() ([]*net.IPNet, error) {
 	}
 	defer v6resp.Body.Close()
 
-	scanner := bufio.NewScanner(io.MultiReader(v4resp.Body, strings.NewReader("\n"), v6resp.Body))
+	scanner := bufio.NewScanner(io.MultiReader(v4resp.Body, v6resp.Body))
 	for scanner.Scan() {
 		_, ipnet, err := net.ParseCIDR(scanner.Text())
 		if err != nil {

--- a/scan/tls_handshake.go
+++ b/scan/tls_handshake.go
@@ -86,11 +86,9 @@ func sayHello(addr, hostname string, ciphers []uint16, curves []tls.CurveID, ver
 	if sigAlgs == nil {
 		sigAlgs = tls.AllSignatureAndHashAlgorithms
 	}
-	tls.SetSupportedSKXSignatureAlgorithms(sigAlgs)
-	defer tls.ResetSupportedSKXSignatureAlgorithms()
 
 	conn := tls.Client(tcpConn, config)
-	serverCipher, serverCurveType, serverCurve, serverVersion, certificates, err := conn.SayHello()
+	serverCipher, serverCurveType, serverCurve, serverVersion, certificates, err := conn.SayHello(sigAlgs)
 	certs = certificates
 	conn.Close()
 	if err != nil {

--- a/scan/vendor/crypto/tls/cfsslscan_common.go
+++ b/scan/vendor/crypto/tls/cfsslscan_common.go
@@ -2,7 +2,6 @@ package tls
 
 import (
 	"fmt"
-	"sync"
 )
 
 type hashAlgID uint8
@@ -90,33 +89,12 @@ var defaultSignatureAndHashAlgorithms []signatureAndHash
 // hash algorithm pairs that the can be advertised in a TLS 1.2 ClientHello.
 var AllSignatureAndHashAlgorithms []SignatureAndHash
 
-// skxsLock prevents the concurrent modification of supportedSignatureAlgorithms.
-var skxsLock sync.RWMutex
-
 func init() {
 	defaultSignatureAndHashAlgorithms = supportedSignatureAlgorithms
 	for _, sighash := range supportedSignatureAlgorithms {
 		AllSignatureAndHashAlgorithms = append(AllSignatureAndHashAlgorithms,
 			SignatureAndHash{hashAlgID(sighash.hash), sigAlgID(sighash.signature)})
 	}
-}
-
-// SetSupportedSKXSignatureAlgorithms sets the supported signatures and hashes
-// to the given set.
-// ResetSupportedSKXSignatureAlgorithms() must be called afterwards to free.
-func SetSupportedSKXSignatureAlgorithms(newSigAls []SignatureAndHash) {
-	skxsLock.Lock()
-	supportedSignatureAlgorithms = make([]signatureAndHash, len(newSigAls))
-	for i := range newSigAls {
-		supportedSignatureAlgorithms[i] = newSigAls[i].internal()
-	}
-}
-
-// ResetSupportedSKXSignatureAlgorithms resets the supported signatures and
-// hashes to their default value.
-func ResetSupportedSKXSignatureAlgorithms() {
-	supportedSignatureAlgorithms = defaultSignatureAndHashAlgorithms
-	skxsLock.Unlock()
 }
 
 // TLSVersions is a list of the current SSL/TLS Versions implemented by Go

--- a/scan/vendor/crypto/tls/cfsslscan_handshake.go
+++ b/scan/vendor/crypto/tls/cfsslscan_handshake.go
@@ -2,9 +2,13 @@ package tls
 
 // SayHello constructs a simple Client Hello to a server, parses its serverHelloMsg response
 // and returns the negotiated ciphersuite ID, and, if an EC cipher suite, the curve ID
-func (c *Conn) SayHello() (cipherID, curveType uint16, curveID CurveID, version uint16, certs [][]byte, err error) {
-	skxsLock.RLock()
-	defer skxsLock.RUnlock()
+func (c *Conn) SayHello(newSigAls []SignatureAndHash) (cipherID, curveType uint16, curveID CurveID, version uint16, certs [][]byte, err error) {
+	// Set the supported signatures and hashes to the set `newSigAls`
+	supportedSignatureAlgorithms := make([]signatureAndHash, len(newSigAls))
+	for i := range newSigAls {
+		supportedSignatureAlgorithms[i] = newSigAls[i].internal()
+	}
+
 	hello := &clientHelloMsg{
 		vers:                c.config.maxVersion(),
 		compressionMethods:  []uint8{compressionNone},

--- a/scan/vendor/crypto/tls/handshake_client.go
+++ b/scan/vendor/crypto/tls/handshake_client.go
@@ -96,8 +96,6 @@ NextCipherSuite:
 	}
 
 	if hello.vers >= VersionTLS12 {
-		skxsLock.RLock()
-		defer skxsLock.RUnlock()
 		hello.signatureAndHashes = supportedSignatureAlgorithms
 	}
 


### PR DESCRIPTION
This request fixes and issue where `cfssl scan` consistently times out. (example at bottom of PR)

### Problem

The root cause of https://github.com/cloudflare/cfssl/issues/569 appears to be a sort of deadlock in the logic that controls access to the package-level `crypto/tls` resource [`supportedSignatureAlgorithms`](https://github.com/cloudflare/cfssl/blob/master/scan/vendor/crypto/tls/common.go#L147-L154).

Shared access to `supportedSignatureAlgorithms` is initialized by [creating a lock](https://github.com/cloudflare/cfssl/blob/master/scan/tls_handshake.go#L89) in the TLS handshake using the RWMutex [`skxsLock`](https://github.com/cloudflare/cfssl/blob/master/scan/vendor/crypto/tls/cfsslscan_common.go#L108). This allows the handshake to modify the global resource without adversely affecting the state of other goroutines.

However, immediately after this initial lock, a call is made to [SayHello](https://github.com/cloudflare/cfssl/blob/master/scan/tls_handshake.go#L93), which then attempts a read lock on [`skxsLock`](https://github.com/cloudflare/cfssl/blob/master/scan/vendor/crypto/tls/cfsslscan_handshake.go#L6), blocking the thread entirely, with no way to escape and reset the initial RWLock from above. This causes TLS dials to lock up until their timeout expires (`1 second` by default), while other routines lock up for a full 5 minute duration.

### Solution

Instead of using locks to serialize access to the global resource `supportedSignatureAlgorithms`, we can create a [thread-bound copy](https://github.com/APTy/cfssl/commit/15128c35db5fd0d615970ff94314ce33dd00ac31#diff-709eb609a0909b57d65143d2e983c323R7) of the data structure which is modified and read by each respective goroutine. Instead of modifying the package-level resource, we [inject `sigAlgs`](https://github.com/APTy/cfssl/commit/15128c35db5fd0d615970ff94314ce33dd00ac31#diff-374a0cb29abd55df4ede19167cf0c88bR91) into the `conn.SayHello()` invocation

This adds the overhead of having to create many copies of the set of supported algorithms, but reduces the complexity associated with shared resources across threads, and, importantly, it fixes the current deadlock/timeout issue. As a bonus, it reverts [prior modifications to `crypto/tls`](https://github.com/cloudflare/cfssl/commit/63c0ffb91f83eceebf9a935aa4dd50a3cac40e56#diff-950754c67e10d380039290f86d8ee8edR99) which were seen as necessary, but not ideal, at the time they were committed.

This also fixes a more minor issue where `ParseCIDR()` attempts to [parse "\n"](https://github.com/cloudflare/cfssl/blob/master/scan/connectivity.go#L82) as an IP address.

#### Before
```
$ go run cmd/cfssl/cfssl.go --loglevel 0 scan httpbin.org

2016/04/08 11:46:58 [DEBUG] loading configuration file from 
Scanning httpbin.org...
2016/04/08 11:46:58 [DEBUG] scan: tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey
2016/04/08 11:46:58 [DEBUG] scan: Couldn't parse CIDR range: invalid CIDR address: 
2016/04/08 11:46:59 [DEBUG] scan: tls: DialWithDialer timed out
2016/04/08 11:46:59 [DEBUG] scan: tls: DialWithDialer timed out
2016/04/08 11:46:59 [DEBUG] scan: tls: DialWithDialer timed out
2016/04/08 11:46:59 [DEBUG] scan: tls: DialWithDialer timed out
2016/04/08 11:51:59 [WARNING] Scan timed out after 5m0s
=== httpbin.org ===
{
  "Broad": {
    "IntermediateCAs": {
      "grade": "Skipped"
    }
  },
  "Connectivity": {
    "CloudFlareStatus": {
      "grade": "Skipped",
      "error": "Couldn't parse CIDR range: invalid CIDR address: "
    },
    "DNSLookup": {
      "grade": "Good",
      "output": [
        "54.175.219.8"
      ]
    },
    "TCPDial": {
      "grade": "Good"
    },
    "TLSDial": {
      "grade": "Bad",
      "error": "tls: DialWithDialer timed out"
    }
  },
  "PKI": {
    "ChainExpiration": {
      "grade": "Bad",
      "error": "tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey"
    },
    "ChainValidation": {
      "grade": "Bad",
      "error": "tls: DialWithDialer timed out"
    },
    "MultipleCerts": {
      "grade": "Bad",
      "error": "tls: DialWithDialer timed out"
    }
  },
  "TLSSession": {
    "SessionResume": {
      "grade": "Bad",
      "error": "tls: DialWithDialer timed out"
    }
  }
}


```

#### After
```
$ go run cmd/cfssl/cfssl.go --loglevel 0 scan httpbin.org

2016/04/08 11:44:41 [DEBUG] loading configuration file from 
Scanning httpbin.org...
2016/04/08 11:44:41 [DEBUG] scan: tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey
2016/04/08 11:44:41 [DEBUG] scan: tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey
2016/04/08 11:44:41 [DEBUG] scan: tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey
2016/04/08 11:44:41 [DEBUG] scan: tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey
2016/04/08 11:44:41 [DEBUG] scan: tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey
=== httpbin.org ===
{
  "Broad": {
    "IntermediateCAs": {
      "grade": "Skipped"
    }
  },
  "Connectivity": {
    "CloudFlareStatus": {
      "grade": "Bad",
      "output": {
        "54.175.219.8": false
      }
    },
    "DNSLookup": {
      "grade": "Good",
      "output": [
        "54.175.219.8"
      ]
    },
    "TCPDial": {
      "grade": "Good"
    },
    "TLSDial": {
      "grade": "Bad",
      "error": "tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey"
    }
  },
  "PKI": {
    "ChainExpiration": {
      "grade": "Bad",
      "error": "tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey"
    },
    "ChainValidation": {
      "grade": "Bad",
      "error": "tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey"
    },
    "MultipleCerts": {
      "grade": "Bad",
      "error": "tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey"
    }
  },
  "TLSHandshake": {
    "CertsByCiphers": {
      "grade": "Good",
      "output": {
        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA": "SHA256WithRSA",
        "TLS_DHE_RSA_WITH_SEED_CBC_SHA": "SHA256WithRSA",
        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA": "SHA256WithRSA",
        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256": "SHA256WithRSA",
        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": "SHA256WithRSA",
        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA": "SHA256WithRSA",
        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384": "SHA256WithRSA",
        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384": "SHA256WithRSA"
      }
    },
    "CertsBySigAlgs": {
      "grade": "Good",
      "output": {
        "{ECDSA,SHA1}": "SHA256WithRSA",
        "{ECDSA,SHA256}": "SHA256WithRSA",
        "{ECDSA,SHA384}": "SHA256WithRSA",
        "{RSA,SHA1}": "SHA256WithRSA",
        "{RSA,SHA256}": "SHA256WithRSA",
        "{RSA,SHA384}": "SHA256WithRSA"
      }
    },
    "CipherSuite": {
      "grade": "Good",
      "output": [
        {
          "ECDHE-RSA-AES256-GCM-SHA384": [
            {
              "TLS 1.2": [
                "secp256r1"
              ]
            }
          ]
        },
        {
          "ECDHE-RSA-AES128-GCM-SHA256": [
            {
              "TLS 1.2": [
                "secp256r1"
              ]
            }
          ]
        },
        {
          "ECDHE-RSA-AES256-SHA384": [
            {
              "TLS 1.2": [
                "secp256r1"
              ]
            }
          ]
        },
        {
          "ECDHE-RSA-AES128-SHA256": [
            {
              "TLS 1.2": [
                "secp256r1"
              ]
            }
          ]
        },
        {
          "ECDHE-RSA-AES256-SHA": [
            {
              "TLS 1.2": [
                "secp256r1"
              ]
            },
            {
              "TLS 1.1": [
                "secp256r1"
              ]
            },
            {
              "TLS 1.0": [
                "secp256r1"
              ]
            }
          ]
        },
        {
          "ECDHE-RSA-AES128-SHA": [
            {
              "TLS 1.2": [
                "secp256r1"
              ]
            },
            {
              "TLS 1.1": [
                "secp256r1"
              ]
            },
            {
              "TLS 1.0": [
                "secp256r1"
              ]
            }
          ]
        },
        {
          "DHE-RSA-AES256-GCM-SHA384": [
            "TLS 1.2"
          ]
        },
        {
          "DHE-RSA-AES256-SHA256": [
            "TLS 1.2"
          ]
        },
        {
          "DHE-RSA-AES256-SHA": [
            "TLS 1.2",
            "TLS 1.1",
            "TLS 1.0"
          ]
        },
        {
          "DHE-RSA-CAMELLIA256-SHA": [
            "TLS 1.2",
            "TLS 1.1",
            "TLS 1.0"
          ]
        },
        {
          "DHE-RSA-AES128-GCM-SHA256": [
            "TLS 1.2"
          ]
        },
        {
          "DHE-RSA-AES128-SHA256": [
            "TLS 1.2"
          ]
        },
        {
          "DHE-RSA-AES128-SHA": [
            "TLS 1.2",
            "TLS 1.1",
            "TLS 1.0"
          ]
        },
        {
          "DHE-RSA-SEED-SHA": [
            "TLS 1.2",
            "TLS 1.1",
            "TLS 1.0"
          ]
        },
        {
          "DHE-RSA-CAMELLIA128-SHA": [
            "TLS 1.2",
            "TLS 1.1",
            "TLS 1.0"
          ]
        }
      ]
    },
    "ECCurves": {
      "grade": "Good",
      "output": [
        "secp256r1"
      ]
    },
    "SigAlgs": {
      "grade": "Good",
      "output": [
        {
          "signature": "RSA",
          "hash": "SHA256"
        },
        {
          "signature": "ECDSA",
          "hash": "SHA256"
        },
        {
          "signature": "RSA",
          "hash": "SHA384"
        },
        {
          "signature": "ECDSA",
          "hash": "SHA384"
        },
        {
          "signature": "RSA",
          "hash": "SHA1"
        },
        {
          "signature": "ECDSA",
          "hash": "SHA1"
        }
      ]
    }
  },
  "TLSSession": {
    "SessionResume": {
      "grade": "Bad",
      "error": "tls: server's certificate contains an unsupported type of public key: *rsa.PublicKey"
    }
  }
}
```

Resolves https://github.com/cloudflare/cfssl/issues/569
