### PR TITLE
Register sqlite backend

### DIFF
--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -43,7 +43,8 @@ import (
 	"github.com/cloudflare/cfssl/cli/sign"
 	"github.com/cloudflare/cfssl/cli/version"
 
-	_ "github.com/lib/pq" // import to support Postgres
+	_ "github.com/lib/pq"           // import to support Postgres
+	_ "github.com/mattn/go-sqlite3" // import to support SQLite3
 )
 
 // main defines the cfssl usage and registers all defined commands and flags.


### PR DESCRIPTION
This fixes "unknown driver `sqlite`" error while trying to use sqlite backend.