### PR TITLE
Fix documentation typos

### DIFF
--- a/doc/api/endpoint_bundle.txt
+++ b/doc/api/endpoint_bundle.txt
@@ -41,7 +41,7 @@ Result:
 
 	The bundle endpoint returns a JSON object with the following
 	keys:
-	
+
         * bundle contains the concatenated list of PEM certificates
         forming the certificate chain; this forms the actual
         bundle. The remaining parameters are additional metadata
@@ -83,7 +83,7 @@ Result:
           algorithms, it will be rejected by Windows XP SP2), ECDSA
           compatibility warning (if the bundle contains ECDSA certificates,
           it will be rejected by Windows XP, Android 2.2 and Android 2.3
-          etc) and root trust warnning (if the bundle cannot be trusted
+          etc) and root trust warning (if the bundle cannot be trusted
           by some major OSes or browsers).
           * rebundled indicates whether the server had to rebundle the
           certificate. The server will rebundle the uploaded
@@ -93,7 +93,7 @@ Result:
           mark rebundled as true.
           * untrusted_root_stores contains the names of any major
           OSes and browsers that doesn't trust the bundle. The names
-          are used to contruct the root trust warnings in the messages
+          are used to construct the root trust warnings in the messages
           list
         * subject contains the X.509 subject identifier from the
         certificate.

--- a/doc/api/endpoint_init_ca.txt
+++ b/doc/api/endpoint_init_ca.txt
@@ -4,10 +4,10 @@ Endpoint: /api/v1/cfssl/init_ca
 Method:   POST
 
 Required parameters:
-    
+
     * hosts: the list of SANs (subject alternative names) for the
     requested CA certificate
-    * names: the certifcate subject for the requested CA certificate
+    * names: the certificate subject for the requested CA certificate
 
 Optional parameters:
 

--- a/doc/api/endpoint_newcert.txt
+++ b/doc/api/endpoint_newcert.txt
@@ -1,13 +1,13 @@
-THE CERTIFICATAE GENERATING ENDPOINT
+THE CERTIFICATE GENERATING ENDPOINT
 
 Endpoint: /api/v1/cfssl/newcert
 Method:   POST
 
 Required parameters:
-    
+
     * request: a json object specifying the certificate request,
     exactly the one which can be sent to /api/v1/cfssl/newkey
-    to generate a certificate sigining request
+    to generate a certificate signing request
     (referring to endpoint_newkey for how to write such object)
 
 Optional parameters:
@@ -56,4 +56,3 @@ Example:
     },
     "success": true
 }
-

--- a/doc/api/endpoint_newkey.txt
+++ b/doc/api/endpoint_newkey.txt
@@ -4,10 +4,10 @@ Endpoint: /api/v1/cfssl/newkey
 Method:   POST
 
 Required parameters:
-    
+
     * hosts: the list of SANs (subject alternative names) for the
     requested CSR (certificate signing request)
-    * names: the certifcate subject for the requested CSR
+    * names: the certificate subject for the requested CSR
 
 Optional parameters:
 

--- a/doc/api/endpoint_scan.txt
+++ b/doc/api/endpoint_scan.txt
@@ -5,19 +5,19 @@ Method:   GET
 
 Required parameters:
 
-    * host: the hostname (optionall including port) to scan
+    * host: the hostname (optionally including port) to scan
 
 Optional parameters:
 
     * ip: IP Address to override DNS lookup of host
-    * timeout: The ammount of time allotted for the scan to complete (default: 1 minute)
+    * timeout: The amount of time allotted for the scan to complete (default: 1 minute)
 
-    The following parameters are used by the scanner to select which 
+    The following parameters are used by the scanner to select which
     scans to run.
 
     * family:  regular expression specifying scan famil(ies) to run
     * scanner: regular expression specifying scanner(s) to run
-    
+
 
 Result:
 
@@ -33,7 +33,7 @@ Result:
         * "Skipped": indicates that the scan was not performed for some reason
     * error: any error encountered during the scan process
     * output: arbitrary JSON data retrieved during the scan
-    
+
 
 Example:
 

--- a/doc/api/endpoint_sign.txt
+++ b/doc/api/endpoint_sign.txt
@@ -9,7 +9,7 @@ Required parameters:
 
 Optional parameters:
 
-    * hosts: an array of SAN (subject alternatvie names)
+    * hosts: an array of SAN (subject alternative names)
     which overrides the ones in the CSR
     * subject: the certificate subject which overrides
     the ones in the CSR


### PR DESCRIPTION
I've been referring to the CFSSL documentation a lot recently, and collected a few typo fixes along the way.