### PR TITLE
CN override on the command line, originally suggested as part of #435

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Usage             string
 	PGPPrivate        string
 	Serial            string
+	CNOverride        string
 	AKI               string
 	DBConfigFile      string
 }
@@ -110,6 +111,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.Usage, "usage", "", "usage of private key")
 	f.StringVar(&c.PGPPrivate, "pgp-private", "", "file to load a PGP Private key decryption")
 	f.StringVar(&c.Serial, "serial", "", "certificate serial number")
+	f.StringVar(&c.CNOverride, "cn", "", "certificate certificate common name (CN)")
 	f.StringVar(&c.AKI, "aki", "", "certificate issuer (authority) key identifier")
 	f.StringVar(&c.DBConfigFile, "db-config", "", "certificate db configuration file")
 }

--- a/cli/gencert/gencert.go
+++ b/cli/gencert/gencert.go
@@ -66,6 +66,9 @@ func gencertMain(args []string, c cli.Config) error {
 	if err != nil {
 		return err
 	}
+	if c.CNOverride != "" {
+		req.CN = c.CNOverride
+	}
 	switch {
 	case c.IsCA:
 		var key, csrPEM, cert []byte


### PR DESCRIPTION
here is a patch that allows overriding the CN on the command line, much like the other changes in #435 (was requested in that PR for this to be separate)

This is useful for things like generating Client Certificates where the CN is important and doesn't use the dns name.