### PR TITLE
Fix documented command for installing goose

### DIFF
--- a/certdb/README.md
+++ b/certdb/README.md
@@ -21,7 +21,7 @@ Currently supported:
 
 ### Get goose
 
-    go get https://bitbucket.org/liamstask/goose/
+    go get bitbucket.org/liamstask/goose/cmd/goose
 
 ### Use goose to start and terminate a SQLite DB
 To start a SQLite DB using goose:


### PR DESCRIPTION
The command specified in the documentation to install goose fails due to the protocol prefix (go 1.6):

    % go get https://bitbucket.org/liamstask/goose/
    package https:/bitbucket.org/liamstask/goose: "https://" not allowed in import path

The [upstream goose repository](https://bitbucket.org/liamstask/goose/) specifies a different command, which works:

    % go get bitbucket.org/liamstask/goose/cmd/goose
    % goose

    goose is a database migration management system for Go projects.
    ...