### PR TITLE
Added database connection capabilities to OCSP responder

### DIFF
--- a/cli/ocsprefresh/ocsprefresh.go
+++ b/cli/ocsprefresh/ocsprefresh.go
@@ -64,6 +64,10 @@ func ocsprefreshMain(args []string, c cli.Config) error {
 
 	// Set an expiry timestamp for all certificates refreshed in this batch
 	ocspExpiry := time.Now().Add(c.Interval)
+	start := time.Now()
+
+	log.Info("OCSP responses are being updated")
+
 	for _, certRecord := range certs {
 		cert, err := helpers.ParseCertificatePEM([]byte(certRecord.PEM))
 		if err != nil {
@@ -93,6 +97,8 @@ func ocsprefreshMain(args []string, c cli.Config) error {
 			return err
 		}
 	}
+
+	log.Infof("OCSP responses update finished: %s", time.Since(start))
 
 	return nil
 }

--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -8,26 +8,28 @@
 package ocsp
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"regexp"
-	"time"
+    "crypto/sha256"
+    "encoding/base64"
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "net/url"
+    "regexp"
+    "time"
 
-	"github.com/cloudflare/cfssl/log"
-	"github.com/jmhodges/clock"
-	"golang.org/x/crypto/ocsp"
+    "github.com/cloudflare/cfssl/certdb/dbconf"
+    "github.com/cloudflare/cfssl/certdb/sql"
+    "github.com/cloudflare/cfssl/log"
+    "github.com/jmhodges/clock"
+    "golang.org/x/crypto/ocsp"
 )
 
 var (
-	malformedRequestErrorResponse = []byte{0x30, 0x03, 0x0A, 0x01, 0x01}
-	internalErrorErrorResponse    = []byte{0x30, 0x03, 0x0A, 0x01, 0x02}
-	tryLaterErrorResponse         = []byte{0x30, 0x03, 0x0A, 0x01, 0x03}
-	sigRequredErrorResponse       = []byte{0x30, 0x03, 0x0A, 0x01, 0x05}
-	unauthorizedErrorResponse     = []byte{0x30, 0x03, 0x0A, 0x01, 0x06}
+    malformedRequestErrorResponse = []byte{0x30, 0x03, 0x0A, 0x01, 0x01}
+    internalErrorErrorResponse    = []byte{0x30, 0x03, 0x0A, 0x01, 0x02}
+    tryLaterErrorResponse         = []byte{0x30, 0x03, 0x0A, 0x01, 0x03}
+    sigRequredErrorResponse       = []byte{0x30, 0x03, 0x0A, 0x01, 0x05}
+    unauthorizedErrorResponse     = []byte{0x30, 0x03, 0x0A, 0x01, 0x06}
 )
 
 // Source represents the logical source of OCSP responses, i.e.,
@@ -35,7 +37,7 @@ var (
 // order to create an actual responder, wrap one of these in a Responder
 // object and pass it to http.Handle.
 type Source interface {
-	Response(*ocsp.Request) ([]byte, bool)
+    Response(*ocsp.Request) ([]byte, bool)
 }
 
 // An InMemorySource is a map from serialNumber -> der(response)
@@ -45,8 +47,8 @@ type InMemorySource map[string][]byte
 // InMemorySource looks up a response purely based on serial number,
 // without regard to what issuer the request is asking for.
 func (src InMemorySource) Response(request *ocsp.Request) (response []byte, present bool) {
-	response, present = src[request.SerialNumber.String()]
-	return
+    response, present = src[request.SerialNumber.String()]
+    return
 }
 
 // NewSourceFromFile reads the named file into an InMemorySource.
@@ -55,50 +57,125 @@ func (src InMemorySource) Response(request *ocsp.Request) (response []byte, pres
 // PEM without headers or whitespace).  Invalid responses are ignored.
 // This function pulls the entire file into an InMemorySource.
 func NewSourceFromFile(responseFile string) (Source, error) {
-	fileContents, err := ioutil.ReadFile(responseFile)
-	if err != nil {
-		return nil, err
-	}
+    fileContents, err := ioutil.ReadFile(responseFile)
+    if err != nil {
+        return nil, err
+    }
 
-	responsesB64 := regexp.MustCompile("\\s").Split(string(fileContents), -1)
-	src := InMemorySource{}
-	for _, b64 := range responsesB64 {
-		// if the line/space is empty just skip
-		if b64 == "" {
-			continue
-		}
-		der, tmpErr := base64.StdEncoding.DecodeString(b64)
-		if tmpErr != nil {
-			log.Errorf("Base64 decode error %s on: %s", tmpErr, b64)
-			continue
-		}
+    responsesB64 := regexp.MustCompile("\\s").Split(string(fileContents), -1)
+    src := InMemorySource{}
+    for _, b64 := range responsesB64 {
+        // if the line/space is empty just skip
+        if b64 == "" {
+            continue
+        }
+        der, tmpErr := base64.StdEncoding.DecodeString(b64)
+        if tmpErr != nil {
+            log.Errorf("Base64 decode error %s on: %s", tmpErr, b64)
+            continue
+        }
 
-		response, tmpErr := ocsp.ParseResponse(der, nil)
-		if tmpErr != nil {
-			log.Errorf("OCSP decode error %s on: %s", tmpErr, b64)
-			continue
-		}
+        response, tmpErr := ocsp.ParseResponse(der, nil)
+        if tmpErr != nil {
+            log.Errorf("OCSP decode error %s on: %s", tmpErr, b64)
+            continue
+        }
 
-		src[response.SerialNumber.String()] = der
-	}
+        src[response.SerialNumber.String()] = der
+    }
 
-	log.Infof("Read %d OCSP responses", len(src))
-	return src, nil
+    log.Infof("Read %d OCSP responses", len(src))
+    return src, nil
+}
+
+// nexUpdate and Interval dictated when the structure
+// should update the in memory reponses,
+// DBaccesor is used to query for new OCSP reponses with the given connection,
+// Responses is a map made from serialNumber -> der(response)
+type DBsource struct {
+    nextUpdate time.Time
+    Interval   time.Duration
+    DBaccessor *sql.Accessor
+    Responses  map[string][]byte
+}
+
+// Response looks up an OCSP response to provide for a given request.
+// BDsource looks up a response purely based on serial number,
+// without regard to what issuer the request is asking for.
+// Responses are updated based on the given time interval in BDsource.
+func (src *DBsource) Response(request *ocsp.Request) (response []byte, present bool) {
+    now := time.Now()
+
+    // Update responses.
+    // This allows responses to be updated only when the service receives requests
+    // and not when is inactive.
+    if src.nextUpdate.Before(now) {
+        updateSource(src)
+        src.nextUpdate = now.Add(src.Interval)
+    }
+
+    response, present = src.Responses[request.SerialNumber.String()]
+    return
+}
+
+// Helper function to update a given DBsource.
+// This function takes the data accessor inside the DBsource structure to query
+// all new OCSP responses and a dumps the data into a in memory structure.
+func updateSource(src *DBsource) {
+    start := time.Now()
+
+    log.Infof("OCSP responses are being updated")
+
+    // Get unexprired records
+    records, err := src.DBaccessor.GetUnexpiredOCSPs()
+    if err != nil {
+        log.Errorf("Couldn't access OCSP responses table: %s", err)
+    }
+
+    for _, certRecord := range records {
+        src.Responses[certRecord.Serial] = []byte(certRecord.Body)
+    }
+
+    log.Infof("OCSP responses update finished: %s", time.Since(start))
+}
+
+// NewSourceFromDB reads the given database configuration file,
+// creates a new data accessor,
+// and dumps data accessor and time interval into a new DB Source structure.
+// The given configuration file must have all the needed information to connect
+// to the intended database, wich in turn has all relations required by CFSSL.
+func NewSourceFromDB(DBConfigFile string, interval time.Duration) (Source, error) {
+    // Load DB from cofiguration file
+    db, err := dbconf.DBFromConfig(DBConfigFile)
+    if err != nil {
+        return nil, err
+    }
+
+    // Create accesor
+    dbAccessor := sql.NewAccessor(db)
+
+    // Initialize source
+    src := DBsource{
+        Interval: interval,
+        DBaccessor: dbAccessor,
+    }
+
+    return &src, nil
 }
 
 // A Responder object provides the HTTP logic to expose a
 // Source of OCSP responses.
 type Responder struct {
-	Source Source
-	clk    clock.Clock
+    Source Source
+    clk    clock.Clock
 }
 
 // NewResponder instantiates a Responder with the give Source.
 func NewResponder(source Source) *Responder {
-	return &Responder{
-		Source: source,
-		clk:    clock.Default(),
-	}
+    return &Responder{
+        Source: source,
+        clk:    clock.Default(),
+    }
 }
 
 // A Responder can process both GET and POST requests.  The mapping
@@ -112,115 +189,115 @@ func NewResponder(source Source) *Responder {
 // strings of repeated '/' into a single '/', which will break the base64
 // encoding.
 func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	// By default we set a 'max-age=0, no-cache' Cache-Control header, this
-	// is only returned to the client if a valid authorized OCSP response
-	// is not found or an error is returned. If a response if found the header
-	// will be altered to contain the proper max-age and modifiers.
-	response.Header().Add("Cache-Control", "max-age=0, no-cache")
-	// Read response from request
-	var requestBody []byte
-	var err error
-	switch request.Method {
-	case "GET":
-		base64Request, err := url.QueryUnescape(request.URL.Path)
-		if err != nil {
-			log.Infof("Error decoding URL: %s", request.URL.Path)
-			response.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		// url.QueryUnescape not only unescapes %2B escaping, but it additionally
-		// turns the resulting '+' into a space, which makes base64 decoding fail.
-		// So we go back afterwards and turn ' ' back into '+'. This means we
-		// accept some malformed input that includes ' ' or %20, but that's fine.
-		base64RequestBytes := []byte(base64Request)
-		for i := range base64RequestBytes {
-			if base64RequestBytes[i] == ' ' {
-				base64RequestBytes[i] = '+'
-			}
-		}
-		requestBody, err = base64.StdEncoding.DecodeString(string(base64RequestBytes))
-		if err != nil {
-			log.Infof("Error decoding base64 from URL: %s", base64Request)
-			response.WriteHeader(http.StatusBadRequest)
-			return
-		}
-	case "POST":
-		requestBody, err = ioutil.ReadAll(request.Body)
-		if err != nil {
-			log.Errorf("Problem reading body of POST: %s", err)
-			response.WriteHeader(http.StatusBadRequest)
-			return
-		}
-	default:
-		response.WriteHeader(http.StatusMethodNotAllowed)
-		return
-	}
-	b64Body := base64.StdEncoding.EncodeToString(requestBody)
-	log.Debugf("Received OCSP request: %s", b64Body)
+    // By default we set a 'max-age=0, no-cache' Cache-Control header, this
+    // is only returned to the client if a valid authorized OCSP response
+    // is not found or an error is returned. If a response if found the header
+    // will be altered to contain the proper max-age and modifiers.
+    response.Header().Add("Cache-Control", "max-age=0, no-cache")
+    // Read response from request
+    var requestBody []byte
+    var err error
+    switch request.Method {
+    case "GET":
+        base64Request, err := url.QueryUnescape(request.URL.Path)
+        if err != nil {
+            log.Infof("Error decoding URL: %s", request.URL.Path)
+            response.WriteHeader(http.StatusBadRequest)
+            return
+        }
+        // url.QueryUnescape not only unescapes %2B escaping, but it additionally
+        // turns the resulting '+' into a space, which makes base64 decoding fail.
+        // So we go back afterwards and turn ' ' back into '+'. This means we
+        // accept some malformed input that includes ' ' or %20, but that's fine.
+        base64RequestBytes := []byte(base64Request)
+        for i := range base64RequestBytes {
+            if base64RequestBytes[i] == ' ' {
+                base64RequestBytes[i] = '+'
+            }
+        }
+        requestBody, err = base64.StdEncoding.DecodeString(string(base64RequestBytes))
+        if err != nil {
+            log.Infof("Error decoding base64 from URL: %s", base64Request)
+            response.WriteHeader(http.StatusBadRequest)
+            return
+        }
+    case "POST":
+        requestBody, err = ioutil.ReadAll(request.Body)
+        if err != nil {
+            log.Errorf("Problem reading body of POST: %s", err)
+            response.WriteHeader(http.StatusBadRequest)
+            return
+        }
+    default:
+        response.WriteHeader(http.StatusMethodNotAllowed)
+        return
+    }
+    b64Body := base64.StdEncoding.EncodeToString(requestBody)
+    log.Debugf("Received OCSP request: %s", b64Body)
 
-	// All responses after this point will be OCSP.
-	// We could check for the content type of the request, but that
-	// seems unnecessariliy restrictive.
-	response.Header().Add("Content-Type", "application/ocsp-response")
+    // All responses after this point will be OCSP.
+    // We could check for the content type of the request, but that
+    // seems unnecessariliy restrictive.
+    response.Header().Add("Content-Type", "application/ocsp-response")
 
-	// Parse response as an OCSP request
-	// XXX: This fails if the request contains the nonce extension.
-	//      We don't intend to support nonces anyway, but maybe we
-	//      should return unauthorizedRequest instead of malformed.
-	ocspRequest, err := ocsp.ParseRequest(requestBody)
-	if err != nil {
-		log.Infof("Error decoding request body: %s", b64Body)
-		response.WriteHeader(http.StatusBadRequest)
-		response.Write(malformedRequestErrorResponse)
-		return
-	}
+    // Parse response as an OCSP request
+    // XXX: This fails if the request contains the nonce extension.
+    //      We don't intend to support nonces anyway, but maybe we
+    //      should return unauthorizedRequest instead of malformed.
+    ocspRequest, err := ocsp.ParseRequest(requestBody)
+    if err != nil {
+        log.Infof("Error decoding request body: %s", b64Body)
+        response.WriteHeader(http.StatusBadRequest)
+        response.Write(malformedRequestErrorResponse)
+        return
+    }
 
-	// Look up OCSP response from source
-	ocspResponse, found := rs.Source.Response(ocspRequest)
-	if !found {
-		log.Infof("No response found for request: %s", b64Body)
-		response.Write(unauthorizedErrorResponse)
-		return
-	}
+    // Look up OCSP response from source
+    ocspResponse, found := rs.Source.Response(ocspRequest)
+    if !found {
+        log.Infof("No response found for request: %s", b64Body)
+        response.Write(unauthorizedErrorResponse)
+        return
+    }
 
-	parsedResponse, err := ocsp.ParseResponse(ocspResponse, nil)
-	if err != nil {
-		log.Errorf("Error parsing response: %s", err)
-		response.Write(unauthorizedErrorResponse)
-		return
-	}
+    parsedResponse, err := ocsp.ParseResponse(ocspResponse, nil)
+    if err != nil {
+        log.Errorf("Error parsing response: %s", err)
+        response.Write(unauthorizedErrorResponse)
+        return
+    }
 
-	// Write OCSP response to response
-	response.Header().Add("Last-Modified", parsedResponse.ThisUpdate.Format(time.RFC1123))
-	response.Header().Add("Expires", parsedResponse.NextUpdate.Format(time.RFC1123))
-	now := rs.clk.Now()
-	maxAge := 0
-	if now.Before(parsedResponse.NextUpdate) {
-		maxAge = int(parsedResponse.NextUpdate.Sub(now) / time.Second)
-	} else {
-		// TODO(#530): we want max-age=0 but this is technically an authorized OCSP response
-		//             (despite being stale) and 5019 forbids attaching no-cache
-		maxAge = 0
-	}
-	response.Header().Set(
-		"Cache-Control",
-		fmt.Sprintf(
-			"max-age=%d, public, no-transform, must-revalidate",
-			maxAge,
-		),
-	)
-	responseHash := sha256.Sum256(ocspResponse)
-	response.Header().Add("ETag", fmt.Sprintf("\"%X\"", responseHash))
+    // Write OCSP response to response
+    response.Header().Add("Last-Modified", parsedResponse.ThisUpdate.Format(time.RFC1123))
+    response.Header().Add("Expires", parsedResponse.NextUpdate.Format(time.RFC1123))
+    now := rs.clk.Now()
+    maxAge := 0
+    if now.Before(parsedResponse.NextUpdate) {
+        maxAge = int(parsedResponse.NextUpdate.Sub(now) / time.Second)
+    } else {
+        // TODO(#530): we want max-age=0 but this is technically an authorized OCSP response
+        //             (despite being stale) and 5019 forbids attaching no-cache
+        maxAge = 0
+    }
+    response.Header().Set(
+        "Cache-Control",
+        fmt.Sprintf(
+            "max-age=%d, public, no-transform, must-revalidate",
+            maxAge,
+        ),
+    )
+    responseHash := sha256.Sum256(ocspResponse)
+    response.Header().Add("ETag", fmt.Sprintf("\"%X\"", responseHash))
 
-	// RFC 7232 says that a 304 response must contain the above
-	// headers if they would also be sent for a 200 for the same
-	// request, so we have to wait until here to do this
-	if etag := request.Header.Get("If-None-Match"); etag != "" {
-		if etag == fmt.Sprintf("\"%X\"", responseHash) {
-			response.WriteHeader(http.StatusNotModified)
-			return
-		}
-	}
-	response.WriteHeader(http.StatusOK)
-	response.Write(ocspResponse)
+    // RFC 7232 says that a 304 response must contain the above
+    // headers if they would also be sent for a 200 for the same
+    // request, so we have to wait until here to do this
+    if etag := request.Header.Get("If-None-Match"); etag != "" {
+        if etag == fmt.Sprintf("\"%X\"", responseHash) {
+            response.WriteHeader(http.StatusNotModified)
+            return
+        }
+    }
+    response.WriteHeader(http.StatusOK)
+    response.Write(ocspResponse)
 }

--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -8,28 +8,28 @@
 package ocsp
 
 import (
-    "crypto/sha256"
-    "encoding/base64"
-    "fmt"
-    "io/ioutil"
-    "net/http"
-    "net/url"
-    "regexp"
-    "time"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
 
-    "github.com/cloudflare/cfssl/certdb/dbconf"
-    "github.com/cloudflare/cfssl/certdb/sql"
-    "github.com/cloudflare/cfssl/log"
-    "github.com/jmhodges/clock"
-    "golang.org/x/crypto/ocsp"
+	"github.com/cloudflare/cfssl/certdb/dbconf"
+	"github.com/cloudflare/cfssl/certdb/sql"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/jmhodges/clock"
+	"golang.org/x/crypto/ocsp"
 )
 
 var (
-    malformedRequestErrorResponse = []byte{0x30, 0x03, 0x0A, 0x01, 0x01}
-    internalErrorErrorResponse    = []byte{0x30, 0x03, 0x0A, 0x01, 0x02}
-    tryLaterErrorResponse         = []byte{0x30, 0x03, 0x0A, 0x01, 0x03}
-    sigRequredErrorResponse       = []byte{0x30, 0x03, 0x0A, 0x01, 0x05}
-    unauthorizedErrorResponse     = []byte{0x30, 0x03, 0x0A, 0x01, 0x06}
+	malformedRequestErrorResponse = []byte{0x30, 0x03, 0x0A, 0x01, 0x01}
+	internalErrorErrorResponse    = []byte{0x30, 0x03, 0x0A, 0x01, 0x02}
+	tryLaterErrorResponse         = []byte{0x30, 0x03, 0x0A, 0x01, 0x03}
+	sigRequredErrorResponse       = []byte{0x30, 0x03, 0x0A, 0x01, 0x05}
+	unauthorizedErrorResponse     = []byte{0x30, 0x03, 0x0A, 0x01, 0x06}
 )
 
 // Source represents the logical source of OCSP responses, i.e.,
@@ -37,7 +37,7 @@ var (
 // order to create an actual responder, wrap one of these in a Responder
 // object and pass it to http.Handle.
 type Source interface {
-    Response(*ocsp.Request) ([]byte, bool)
+	Response(*ocsp.Request) ([]byte, bool)
 }
 
 // An InMemorySource is a map from serialNumber -> der(response)
@@ -47,8 +47,8 @@ type InMemorySource map[string][]byte
 // InMemorySource looks up a response purely based on serial number,
 // without regard to what issuer the request is asking for.
 func (src InMemorySource) Response(request *ocsp.Request) (response []byte, present bool) {
-    response, present = src[request.SerialNumber.String()]
-    return
+	response, present = src[request.SerialNumber.String()]
+	return
 }
 
 // NewSourceFromFile reads the named file into an InMemorySource.
@@ -57,35 +57,35 @@ func (src InMemorySource) Response(request *ocsp.Request) (response []byte, pres
 // PEM without headers or whitespace).  Invalid responses are ignored.
 // This function pulls the entire file into an InMemorySource.
 func NewSourceFromFile(responseFile string) (Source, error) {
-    fileContents, err := ioutil.ReadFile(responseFile)
-    if err != nil {
-        return nil, err
-    }
+	fileContents, err := ioutil.ReadFile(responseFile)
+	if err != nil {
+		return nil, err
+	}
 
-    responsesB64 := regexp.MustCompile("\\s").Split(string(fileContents), -1)
-    src := InMemorySource{}
-    for _, b64 := range responsesB64 {
-        // if the line/space is empty just skip
-        if b64 == "" {
-            continue
-        }
-        der, tmpErr := base64.StdEncoding.DecodeString(b64)
-        if tmpErr != nil {
-            log.Errorf("Base64 decode error %s on: %s", tmpErr, b64)
-            continue
-        }
+	responsesB64 := regexp.MustCompile("\\s").Split(string(fileContents), -1)
+	src := InMemorySource{}
+	for _, b64 := range responsesB64 {
+		// if the line/space is empty just skip
+		if b64 == "" {
+			continue
+		}
+		der, tmpErr := base64.StdEncoding.DecodeString(b64)
+		if tmpErr != nil {
+			log.Errorf("Base64 decode error %s on: %s", tmpErr, b64)
+			continue
+		}
 
-        response, tmpErr := ocsp.ParseResponse(der, nil)
-        if tmpErr != nil {
-            log.Errorf("OCSP decode error %s on: %s", tmpErr, b64)
-            continue
-        }
+		response, tmpErr := ocsp.ParseResponse(der, nil)
+		if tmpErr != nil {
+			log.Errorf("OCSP decode error %s on: %s", tmpErr, b64)
+			continue
+		}
 
-        src[response.SerialNumber.String()] = der
-    }
+		src[response.SerialNumber.String()] = der
+	}
 
-    log.Infof("Read %d OCSP responses", len(src))
-    return src, nil
+	log.Infof("Read %d OCSP responses", len(src))
+	return src, nil
 }
 
 // nexUpdate and Interval dictated when the structure
@@ -93,10 +93,10 @@ func NewSourceFromFile(responseFile string) (Source, error) {
 // DBaccesor is used to query for new OCSP reponses with the given connection,
 // Responses is a map made from serialNumber -> der(response)
 type DBsource struct {
-    nextUpdate time.Time
-    Interval   time.Duration
-    DBaccessor *sql.Accessor
-    Responses  map[string][]byte
+	nextUpdate time.Time
+	Interval   time.Duration
+	DBaccessor *sql.Accessor
+	Responses  map[string][]byte
 }
 
 // Response looks up an OCSP response to provide for a given request.
@@ -104,39 +104,39 @@ type DBsource struct {
 // without regard to what issuer the request is asking for.
 // Responses are updated based on the given time interval in BDsource.
 func (src *DBsource) Response(request *ocsp.Request) (response []byte, present bool) {
-    now := time.Now()
+	now := time.Now()
 
-    // Update responses.
-    // This allows responses to be updated only when the service receives requests
-    // and not when is inactive.
-    if src.nextUpdate.Before(now) {
-        updateSource(src)
-        src.nextUpdate = now.Add(src.Interval)
-    }
+	// Update responses.
+	// This allows responses to be updated only when the service receives requests
+	// and not when is inactive.
+	if src.nextUpdate.Before(now) {
+		updateSource(src)
+		src.nextUpdate = now.Add(src.Interval)
+	}
 
-    response, present = src.Responses[request.SerialNumber.String()]
-    return
+	response, present = src.Responses[request.SerialNumber.String()]
+	return
 }
 
 // Helper function to update a given DBsource.
 // This function takes the data accessor inside the DBsource structure to query
 // all new OCSP responses and a dumps the data into a in memory structure.
 func updateSource(src *DBsource) {
-    start := time.Now()
+	start := time.Now()
 
-    log.Info("OCSP responses are being updated")
+	log.Info("OCSP responses are being updated")
 
-    // Get unexprired records
-    records, err := src.DBaccessor.GetUnexpiredOCSPs()
-    if err != nil {
-        log.Errorf("Couldn't access OCSP responses table: %s", err)
-    }
+	// Get unexprired records
+	records, err := src.DBaccessor.GetUnexpiredOCSPs()
+	if err != nil {
+		log.Errorf("Couldn't access OCSP responses table: %s", err)
+	}
 
-    for _, certRecord := range records {
-        src.Responses[certRecord.Serial] = []byte(certRecord.Body)
-    }
+	for _, certRecord := range records {
+		src.Responses[certRecord.Serial] = []byte(certRecord.Body)
+	}
 
-    log.Infof("OCSP responses update finished: %s", time.Since(start))
+	log.Infof("OCSP responses update finished: %s", time.Since(start))
 }
 
 // NewSourceFromDB reads the given database configuration file,
@@ -145,37 +145,37 @@ func updateSource(src *DBsource) {
 // The given configuration file must have all the needed information to connect
 // to the intended database, wich in turn has all relations required by CFSSL.
 func NewSourceFromDB(DBConfigFile string, interval time.Duration) (Source, error) {
-    // Load DB from cofiguration file
-    db, err := dbconf.DBFromConfig(DBConfigFile)
-    if err != nil {
-        return nil, err
-    }
+	// Load DB from cofiguration file
+	db, err := dbconf.DBFromConfig(DBConfigFile)
+	if err != nil {
+		return nil, err
+	}
 
-    // Create accesor
-    dbAccessor := sql.NewAccessor(db)
+	// Create accesor
+	dbAccessor := sql.NewAccessor(db)
 
-    // Initialize source
-    src := DBsource{
-        Interval: interval,
-        DBaccessor: dbAccessor,
-    }
+	// Initialize source
+	src := DBsource{
+		Interval:   interval,
+		DBaccessor: dbAccessor,
+	}
 
-    return &src, nil
+	return &src, nil
 }
 
 // A Responder object provides the HTTP logic to expose a
 // Source of OCSP responses.
 type Responder struct {
-    Source Source
-    clk    clock.Clock
+	Source Source
+	clk    clock.Clock
 }
 
 // NewResponder instantiates a Responder with the give Source.
 func NewResponder(source Source) *Responder {
-    return &Responder{
-        Source: source,
-        clk:    clock.Default(),
-    }
+	return &Responder{
+		Source: source,
+		clk:    clock.Default(),
+	}
 }
 
 // A Responder can process both GET and POST requests.  The mapping
@@ -189,115 +189,122 @@ func NewResponder(source Source) *Responder {
 // strings of repeated '/' into a single '/', which will break the base64
 // encoding.
 func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-    // By default we set a 'max-age=0, no-cache' Cache-Control header, this
-    // is only returned to the client if a valid authorized OCSP response
-    // is not found or an error is returned. If a response if found the header
-    // will be altered to contain the proper max-age and modifiers.
-    response.Header().Add("Cache-Control", "max-age=0, no-cache")
-    // Read response from request
-    var requestBody []byte
-    var err error
-    switch request.Method {
-    case "GET":
-        base64Request, err := url.QueryUnescape(request.URL.Path)
-        if err != nil {
-            log.Infof("Error decoding URL: %s", request.URL.Path)
-            response.WriteHeader(http.StatusBadRequest)
-            return
-        }
-        // url.QueryUnescape not only unescapes %2B escaping, but it additionally
-        // turns the resulting '+' into a space, which makes base64 decoding fail.
-        // So we go back afterwards and turn ' ' back into '+'. This means we
-        // accept some malformed input that includes ' ' or %20, but that's fine.
-        base64RequestBytes := []byte(base64Request)
-        for i := range base64RequestBytes {
-            if base64RequestBytes[i] == ' ' {
-                base64RequestBytes[i] = '+'
-            }
-        }
-        requestBody, err = base64.StdEncoding.DecodeString(string(base64RequestBytes))
-        if err != nil {
-            log.Infof("Error decoding base64 from URL: %s", base64Request)
-            response.WriteHeader(http.StatusBadRequest)
-            return
-        }
-    case "POST":
-        requestBody, err = ioutil.ReadAll(request.Body)
-        if err != nil {
-            log.Errorf("Problem reading body of POST: %s", err)
-            response.WriteHeader(http.StatusBadRequest)
-            return
-        }
-    default:
-        response.WriteHeader(http.StatusMethodNotAllowed)
-        return
-    }
-    b64Body := base64.StdEncoding.EncodeToString(requestBody)
-    log.Debugf("Received OCSP request: %s", b64Body)
+	// By default we set a 'max-age=0, no-cache' Cache-Control header, this
+	// is only returned to the client if a valid authorized OCSP response
+	// is not found or an error is returned. If a response if found the header
+	// will be altered to contain the proper max-age and modifiers.
+	response.Header().Add("Cache-Control", "max-age=0, no-cache")
+	// Read response from request
+	var requestBody []byte
+	var err error
+	switch request.Method {
+	case "GET":
+		base64Request, err := url.QueryUnescape(request.URL.Path)
+		if err != nil {
+			log.Infof("Error decoding URL: %s", request.URL.Path)
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
 
-    // All responses after this point will be OCSP.
-    // We could check for the content type of the request, but that
-    // seems unnecessariliy restrictive.
-    response.Header().Add("Content-Type", "application/ocsp-response")
+		// URL.Path returns a /[PATH] string when using responder for OCSP stapling.
+		// In order to process the request correctly, the "/" must be removed
+		if base64Request[0] == '/' {
+			base64Request = base64Request[1:]
+		}
 
-    // Parse response as an OCSP request
-    // XXX: This fails if the request contains the nonce extension.
-    //      We don't intend to support nonces anyway, but maybe we
-    //      should return unauthorizedRequest instead of malformed.
-    ocspRequest, err := ocsp.ParseRequest(requestBody)
-    if err != nil {
-        log.Infof("Error decoding request body: %s", b64Body)
-        response.WriteHeader(http.StatusBadRequest)
-        response.Write(malformedRequestErrorResponse)
-        return
-    }
+		// url.QueryUnescape not only unescapes %2B escaping, but it additionally
+		// turns the resulting '+' into a space, which makes base64 decoding fail.
+		// So we go back afterwards and turn ' ' back into '+'. This means we
+		// accept some malformed input that includes ' ' or %20, but that's fine.
+		base64RequestBytes := []byte(base64Request)
+		for i := range base64RequestBytes {
+			if base64RequestBytes[i] == ' ' {
+				base64RequestBytes[i] = '+'
+			}
+		}
+		requestBody, err = base64.StdEncoding.DecodeString(string(base64RequestBytes))
+		if err != nil {
+			log.Infof("Error decoding base64 from URL: %s", base64Request)
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	case "POST":
+		requestBody, err = ioutil.ReadAll(request.Body)
+		if err != nil {
+			log.Errorf("Problem reading body of POST: %s", err)
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	default:
+		response.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	b64Body := base64.StdEncoding.EncodeToString(requestBody)
+	log.Debugf("Received OCSP request: %s", b64Body)
 
-    // Look up OCSP response from source
-    ocspResponse, found := rs.Source.Response(ocspRequest)
-    if !found {
-        log.Infof("No response found for request: %s", b64Body)
-        response.Write(unauthorizedErrorResponse)
-        return
-    }
+	// All responses after this point will be OCSP.
+	// We could check for the content type of the request, but that
+	// seems unnecessariliy restrictive.
+	response.Header().Add("Content-Type", "application/ocsp-response")
 
-    parsedResponse, err := ocsp.ParseResponse(ocspResponse, nil)
-    if err != nil {
-        log.Errorf("Error parsing response: %s", err)
-        response.Write(unauthorizedErrorResponse)
-        return
-    }
+	// Parse response as an OCSP request
+	// XXX: This fails if the request contains the nonce extension.
+	//      We don't intend to support nonces anyway, but maybe we
+	//      should return unauthorizedRequest instead of malformed.
+	ocspRequest, err := ocsp.ParseRequest(requestBody)
+	if err != nil {
+		log.Infof("Error decoding request body: %s", b64Body)
+		response.WriteHeader(http.StatusBadRequest)
+		response.Write(malformedRequestErrorResponse)
+		return
+	}
 
-    // Write OCSP response to response
-    response.Header().Add("Last-Modified", parsedResponse.ThisUpdate.Format(time.RFC1123))
-    response.Header().Add("Expires", parsedResponse.NextUpdate.Format(time.RFC1123))
-    now := rs.clk.Now()
-    maxAge := 0
-    if now.Before(parsedResponse.NextUpdate) {
-        maxAge = int(parsedResponse.NextUpdate.Sub(now) / time.Second)
-    } else {
-        // TODO(#530): we want max-age=0 but this is technically an authorized OCSP response
-        //             (despite being stale) and 5019 forbids attaching no-cache
-        maxAge = 0
-    }
-    response.Header().Set(
-        "Cache-Control",
-        fmt.Sprintf(
-            "max-age=%d, public, no-transform, must-revalidate",
-            maxAge,
-        ),
-    )
-    responseHash := sha256.Sum256(ocspResponse)
-    response.Header().Add("ETag", fmt.Sprintf("\"%X\"", responseHash))
+	// Look up OCSP response from source
+	ocspResponse, found := rs.Source.Response(ocspRequest)
+	if !found {
+		log.Infof("No response found for request: %s", b64Body)
+		response.Write(unauthorizedErrorResponse)
+		return
+	}
 
-    // RFC 7232 says that a 304 response must contain the above
-    // headers if they would also be sent for a 200 for the same
-    // request, so we have to wait until here to do this
-    if etag := request.Header.Get("If-None-Match"); etag != "" {
-        if etag == fmt.Sprintf("\"%X\"", responseHash) {
-            response.WriteHeader(http.StatusNotModified)
-            return
-        }
-    }
-    response.WriteHeader(http.StatusOK)
-    response.Write(ocspResponse)
+	parsedResponse, err := ocsp.ParseResponse(ocspResponse, nil)
+	if err != nil {
+		log.Errorf("Error parsing response: %s", err)
+		response.Write(unauthorizedErrorResponse)
+		return
+	}
+
+	// Write OCSP response to response
+	response.Header().Add("Last-Modified", parsedResponse.ThisUpdate.Format(time.RFC1123))
+	response.Header().Add("Expires", parsedResponse.NextUpdate.Format(time.RFC1123))
+	now := rs.clk.Now()
+	maxAge := 0
+	if now.Before(parsedResponse.NextUpdate) {
+		maxAge = int(parsedResponse.NextUpdate.Sub(now) / time.Second)
+	} else {
+		// TODO(#530): we want max-age=0 but this is technically an authorized OCSP response
+		//             (despite being stale) and 5019 forbids attaching no-cache
+		maxAge = 0
+	}
+	response.Header().Set(
+		"Cache-Control",
+		fmt.Sprintf(
+			"max-age=%d, public, no-transform, must-revalidate",
+			maxAge,
+		),
+	)
+	responseHash := sha256.Sum256(ocspResponse)
+	response.Header().Add("ETag", fmt.Sprintf("\"%X\"", responseHash))
+
+	// RFC 7232 says that a 304 response must contain the above
+	// headers if they would also be sent for a 200 for the same
+	// request, so we have to wait until here to do this
+	if etag := request.Header.Get("If-None-Match"); etag != "" {
+		if etag == fmt.Sprintf("\"%X\"", responseHash) {
+			response.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+	response.WriteHeader(http.StatusOK)
+	response.Write(ocspResponse)
 }

--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -124,7 +124,7 @@ func (src *DBsource) Response(request *ocsp.Request) (response []byte, present b
 func updateSource(src *DBsource) {
     start := time.Now()
 
-    log.Infof("OCSP responses are being updated")
+    log.Info("OCSP responses are being updated")
 
     // Get unexprired records
     records, err := src.DBaccessor.GetUnexpiredOCSPs()


### PR DESCRIPTION
### This pull request follows the discussion in the issue #596  

## OCSP responder is now backed by a CertDB instance
Now the `ocspserve` command accepts `-db-config` and `-interval` flags in order to establish a connection to a `CertDB` instance and query new responses every given interval of time.

Along with this, some issues were solved regarding to the OCSP responder, and some logs were added  to the `ocsprefresh` command.

## Further development
I noticed that the OCSP has no way to know when a CA revokes a certificate. By knowing if a certificate was revoked, the OCSP could update its responses to match the current state of the certificate.

For instance, if a new certificate is issued and its response validity is set to `2h0m0s`. In case said certificate was revoked before its validity time expired, the entity owner of the certificate will be entitled to access service or resources that it shouldn't have access to _(since its OCSP response would still be valid)_.

**Shouldn’t be added some kind of inline updates for certificate revocation to CFSSL? So this way the OCSP responder can update revoked certificates so their responses wouldn't be valid any more**