### PR TITLE
Fix L/ST swap in print-defaults csr.

### DIFF
--- a/cli/printdefault/defaults.go
+++ b/cli/printdefault/defaults.go
@@ -40,8 +40,8 @@ var defaults = map[string]string{
     "names": [
         {
             "C": "US",
-            "L": "CA",
-            "ST": "San Francisco"
+            "ST": "CA",
+            "L": "San Francisco"
         }
     ]
 }


### PR DESCRIPTION
"cfssl print-defaults csr" swaps the "ST" and "L" fields inside "names". While the proper field naming is obvious to an American, it might not be obvious to someone from a country that does not have sub-entities called "states", particularly if they are not native English speakers. This trivial change avoids any confusion.