### PR TITLE
Fix wrong example on scaninfo API document

### DIFF
--- a/doc/api/endpoint_scaninfo.txt
+++ b/doc/api/endpoint_scaninfo.txt
@@ -12,9 +12,7 @@ Result:
 
 Example:
 
-    $ curl -d '{"label": "primary"}' \
-          ${CFSSL_HOST}/api/v1/cfssl/sign  \
-          | python -m json.tool
+    $ curl ${CFSSL_HOST}/api/v1/cfssl/scaninfo | python -m json.tool
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  1412  100  1412    0     0   391k      0 --:--:-- --:--:-- --:--:--  459k


### PR DESCRIPTION
Initial api example is same as `/api/v1/cfssl/info`, but the result of the command is for `/api/v1/cfssl/scaninfo`.

Fixed mismatching.