### PR TITLE
Zi/sign pathlen

### DIFF
--- a/api/generator/generator_test.go
+++ b/api/generator/generator_test.go
@@ -109,7 +109,7 @@ func TestNewCertGeneratorHandlerFromSigner(t *testing.T) {
 				Usage:        []string{"cert sign", "crl sign"},
 				ExpiryString: "43800h",
 				Expiry:       expiry,
-				CA:           true,
+				CAConstraint: config.CAConstraint{IsCA: true},
 
 				ClientProvidesSerialNumbers: true,
 			},

--- a/bundler/bundler_sha1_deprecation_test.go
+++ b/bundler/bundler_sha1_deprecation_test.go
@@ -151,7 +151,7 @@ func makeCASigner(certBytes, keyBytes []byte, sigAlgo x509.SignatureAlgorithm, t
 
 	defaultProfile := &config.SigningProfile{
 		Usage:        []string{"cert sign"},
-		CA:           true,
+		CAConstraint: config.CAConstraint{IsCA: true},
 		Expiry:       time.Hour,
 		ExpiryString: "1h",
 	}

--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -301,9 +301,9 @@ func TestRebundleExpiring(t *testing.T) {
 	policy := &config.Signing{
 		Profiles: map[string]*config.SigningProfile{
 			"expireIn1Hour": {
-				Usage:  []string{"cert sign"},
-				Expiry: expiry,
-				CA:     true,
+				Usage:        []string{"cert sign"},
+				Expiry:       expiry,
+				CAConstraint: config.CAConstraint{IsCA: true},
 			},
 		},
 		Default: config.DefaultConfig(),

--- a/config/config.go
+++ b/config/config.go
@@ -60,26 +60,35 @@ type AuthRemote struct {
 	AuthKeyName string `json:"auth_key"`
 }
 
+// CAConstraint specifies various CA constraints on the signed certificate.
+// CAConstraint would verify against (and override) the CA
+// extensions in the given CSR.
+type CAConstraint struct {
+	IsCA           bool `json:"is_ca"`
+	MaxPathLen     int  `json:"max_path_len"`
+	MaxPathLenZero bool `json:"max_path_len_zero"`
+}
+
 // A SigningProfile stores information that the CA needs to store
 // signature policy.
 type SigningProfile struct {
-	Usage               []string   `json:"usages"`
-	IssuerURL           []string   `json:"issuer_urls"`
-	OCSP                string     `json:"ocsp_url"`
-	CRL                 string     `json:"crl_url"`
-	CA                  bool       `json:"is_ca"`
-	OCSPNoCheck         bool       `json:"ocsp_no_check"`
-	ExpiryString        string     `json:"expiry"`
-	BackdateString      string     `json:"backdate"`
-	AuthKeyName         string     `json:"auth_key"`
-	RemoteName          string     `json:"remote"`
-	NotBefore           time.Time  `json:"not_before"`
-	NotAfter            time.Time  `json:"not_after"`
-	NameWhitelistString string     `json:"name_whitelist"`
-	AuthRemote          AuthRemote `json:"auth_remote"`
-	CTLogServers        []string   `json:"ct_log_servers"`
-	AllowedExtensions   []OID      `json:"allowed_extensions"`
-	CertStore           string     `json:"cert_store"`
+	Usage               []string     `json:"usages"`
+	IssuerURL           []string     `json:"issuer_urls"`
+	OCSP                string       `json:"ocsp_url"`
+	CRL                 string       `json:"crl_url"`
+	CAConstraint        CAConstraint `json:"ca_constraint"`
+	OCSPNoCheck         bool         `json:"ocsp_no_check"`
+	ExpiryString        string       `json:"expiry"`
+	BackdateString      string       `json:"backdate"`
+	AuthKeyName         string       `json:"auth_key"`
+	RemoteName          string       `json:"remote"`
+	NotBefore           time.Time    `json:"not_before"`
+	NotAfter            time.Time    `json:"not_after"`
+	NameWhitelistString string       `json:"name_whitelist"`
+	AuthRemote          AuthRemote   `json:"auth_remote"`
+	CTLogServers        []string     `json:"ct_log_servers"`
+	AllowedExtensions   []OID        `json:"allowed_extensions"`
+	CertStore           string       `json:"cert_store"`
 
 	Policies                    []CertificatePolicy
 	Expiry                      time.Duration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,6 +153,36 @@ var validMinimalLocalConfig = `
 	}
 }`
 
+var validLocalConfigsWithCAConstraint = []string{
+	`{
+		"signing": {
+			"default": {
+				"usages": ["digital signature", "email protection"],
+				"ca_constraint": { "is_ca": true },
+				"expiry": "8000h"
+			}
+		}
+	}`,
+	`{
+		"signing": {
+			"default": {
+				"usages": ["digital signature", "email protection"],
+				"ca_constraint": { "is_ca": true, "max_path_len": 1 },
+				"expiry": "8000h"
+			}
+		}
+	}`,
+	`{
+		"signing": {
+			"default": {
+				"usages": ["digital signature", "email protection"],
+				"ca_constraint": { "is_ca": true, "max_path_len_zero": true },
+				"expiry": "8000h"
+			}
+		}
+	}`,
+}
+
 func TestInvalidProfile(t *testing.T) {
 	if invalidProfileConfig.Signing.Profiles["invalid"].validProfile(false) {
 		t.Fatal("invalid profile accepted as valid")
@@ -406,5 +436,14 @@ func TestBadAuthRemoteConfig(t *testing.T) {
 	_, err := LoadConfig([]byte(invalidRemoteConfig))
 	if err == nil {
 		t.Fatal("load invalid config should failed")
+	}
+}
+
+func TestValidCAConstraint(t *testing.T) {
+	for _, config := range validLocalConfigsWithCAConstraint {
+		_, err := LoadConfig([]byte(config))
+		if err != nil {
+			t.Fatal("can't parse valid ca constraint")
+		}
 	}
 }

--- a/doc/cmd/cfssl.txt
+++ b/doc/cmd/cfssl.txt
@@ -118,8 +118,14 @@ blank.
 
     + crl_url: the URL of the CRL server for this CA.
 
-    + is_ca: this should be true if the returned certificates should
-      be permitted to issue new certificates.
+    + ca_constraint: this object controls the CA bit and CA pathlen
+      constraint of the returned certificates. For example, in order
+      to issue a intermediate CA certificate with pathlen = 1, we put
+      {"is_ca": true, "max_path_len":1}. For another example, to
+      issue a intermediate CA certificate with pathlen = 0, we put
+      {"is_ca": true, "max_path_len":0, "max_path_len_zero": true}.
+      Notice the extra "max_path_len_zero" field: Without it, the
+      intermediate CA certificate will have no pathlen constraint.
 
     + ocsp_no_check: this should be true if the id-pkix-ocsp-nocheck
       extension should be used (RFC 2560 4.2.2.2.1).

--- a/helpers/testsuite/testing_helpers.go
+++ b/helpers/testsuite/testing_helpers.go
@@ -4,20 +4,19 @@ package testsuite
 
 import (
 	"bufio"
-	"testing"
-	// "crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
-	// "github.com/cloudflare/cfssl/helpers/testsuite/stoppable"
 )
 
 // CFSSLServerData is the data with which a server is initialized. These fields
@@ -187,7 +186,7 @@ func CreateSelfSignedCert(request csr.CertificateRequest) (encodedCert, encodedK
 	CLIOutput, err := command.CombinedOutput()
 	if err != nil {
 		os.Remove(tempFile)
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%v - CLI output: %s", err, string(CLIOutput))
 	}
 	err = checkCLIOutput(CLIOutput)
 	if err != nil {
@@ -230,7 +229,7 @@ func SignCertificate(request csr.CertificateRequest, signerCert, signerKey []byt
 	CLIOutput, err := command.CombinedOutput()
 	if err != nil {
 		os.Remove(tempJSONFile)
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%v - CLI output: %s", err, string(CLIOutput))
 	}
 	err = checkCLIOutput(CLIOutput)
 	if err != nil {
@@ -287,7 +286,7 @@ func SignCertificate(request csr.CertificateRequest, signerCert, signerKey []byt
 	CLIOutput, err = command.CombinedOutput()
 	err = checkCLIOutput(CLIOutput)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%v - CLI output: %s", err, string(CLIOutput))
 	}
 	encodedCert, err = cleanCLIOutput(CLIOutput, "cert")
 	if err != nil {

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -217,7 +217,7 @@ var CAPolicy = func() *config.Signing {
 			Usage:        []string{"cert sign", "crl sign"},
 			ExpiryString: "43800h",
 			Expiry:       5 * helpers.OneYear,
-			CA:           true,
+			CAConstraint: config.CAConstraint{IsCA: true},
 		},
 	}
 }

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -50,11 +50,11 @@ func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
 			policy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
 		}
 
-		signer.MaxPathLen = req.CA.PathLength
+		policy.Default.CAConstraint.MaxPathLen = req.CA.PathLength
 		if req.CA.PathLength != 0 && req.CA.PathLenZero == true {
 			log.Infof("ignore invalid 'pathlenzero' value")
 		} else {
-			signer.MaxPathLenZero = req.CA.PathLenZero
+			policy.Default.CAConstraint.MaxPathLenZero = req.CA.PathLenZero
 		}
 	}
 
@@ -72,12 +72,11 @@ func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
 		return
 	}
 
-	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), nil)
+	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), policy)
 	if err != nil {
 		log.Errorf("failed to create signer: %v", err)
 		return
 	}
-	s.SetPolicy(policy)
 
 	signReq := signer.SignRequest{Hosts: req.Hosts, Request: string(csrPEM)}
 	cert, err = s.Sign(signReq)
@@ -143,11 +142,11 @@ func NewFromSigner(req *csr.CertificateRequest, priv crypto.Signer) (cert, csrPE
 			}
 		}
 
-		signer.MaxPathLen = req.CA.PathLength
+		policy.Default.CAConstraint.MaxPathLen = req.CA.PathLength
 		if req.CA.PathLength != 0 && req.CA.PathLenZero == true {
 			log.Infof("ignore invalid 'pathlenzero' value")
 		} else {
-			signer.MaxPathLenZero = req.CA.PathLenZero
+			policy.Default.CAConstraint.MaxPathLenZero = req.CA.PathLenZero
 		}
 	}
 
@@ -156,12 +155,11 @@ func NewFromSigner(req *csr.CertificateRequest, priv crypto.Signer) (cert, csrPE
 		return nil, nil, err
 	}
 
-	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), nil)
+	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), policy)
 	if err != nil {
 		log.Errorf("failed to create signer: %v", err)
 		return
 	}
-	s.SetPolicy(policy)
 
 	signReq := signer.SignRequest{Request: string(csrPEM)}
 	cert, err = s.Sign(signReq)

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -48,6 +48,9 @@ func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
 		if req.CA.Expiry != "" {
 			policy.Default.ExpiryString = req.CA.Expiry
 			policy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
+			if err != nil {
+				return
+			}
 		}
 
 		policy.Default.CAConstraint.MaxPathLen = req.CA.PathLength

--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -126,7 +126,7 @@ func TestInitCA(t *testing.T) {
 						Usage:        []string{"cert sign", "crl sign"},
 						ExpiryString: "300s",
 						Expiry:       300 * time.Second,
-						CA:           true,
+						CAConstraint: config.CAConstraint{IsCA: true},
 					},
 				}
 			}

--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -28,10 +28,16 @@ var validCAConfigs = []csr.CAConfig{
 	{PathLength: 0, PathLenZero: true},
 	{PathLength: 0, PathLenZero: false},
 	{PathLength: 2},
+	{PathLength: 2, Expiry: "1h"},
 	// invalid PathLenZero value will be ignored
 	{PathLength: 2, PathLenZero: true},
 }
 
+var invalidCAConfig = csr.CAConfig{
+	PathLength: 2,
+	// Expiry must be a duration string
+	Expiry: "2116/12/31",
+}
 var csrFiles = []string{
 	"testdata/rsa2048.csr",
 	"testdata/rsa3072.csr",
@@ -167,7 +173,29 @@ func TestInitCA(t *testing.T) {
 		}
 	}
 }
+func TestInvalidCAConfig(t *testing.T) {
+	hostname := "example.com"
+	req := &csr.CertificateRequest{
+		Names: []csr.Name{
+			{
+				C:  "US",
+				ST: "California",
+				L:  "San Francisco",
+				O:  "CloudFlare",
+				OU: "Systems Engineering",
+			},
+		},
+		CN:         hostname,
+		Hosts:      []string{hostname, "www." + hostname},
+		KeyRequest: &validKeyParams[0],
+		CA:         &invalidCAConfig,
+	}
 
+	_, _, _, err := New(req)
+	if err == nil {
+		t.Fatal("InitCA with bad CAConfig should fail:", err)
+	}
+}
 func TestInvalidCryptoParams(t *testing.T) {
 	var req *csr.CertificateRequest
 	hostname := "cloudflare.com"

--- a/selfsign/selfsign.go
+++ b/selfsign/selfsign.go
@@ -119,7 +119,7 @@ func Sign(priv crypto.Signer, csrPEM []byte, profile *config.SigningProfile) ([]
 	template.KeyUsage = ku
 	template.ExtKeyUsage = eku
 	template.BasicConstraintsValid = true
-	template.IsCA = profile.CA
+	template.IsCA = profile.CAConstraint.IsCA
 	template.SubjectKeyId = pubhash.Sum(nil)
 
 	if ocspURL != "" {

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -247,7 +247,7 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 	}
 
 	if safeTemplate.IsCA {
-		if !profile.CA {
+		if !profile.CAConstraint.IsCA {
 			return nil, cferr.New(cferr.CertificateError, cferr.InvalidRequest)
 		}
 

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -115,9 +115,6 @@ func (s *Signer) sign(template *x509.Certificate, profile *config.SigningProfile
 		template.EmailAddresses = nil
 		s.ca = template
 		initRoot = true
-	} else if template.IsCA {
-		template.DNSNames = nil
-		template.EmailAddresses = nil
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, s.ca, template.PublicKey, s.priv)

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -59,7 +59,7 @@ func TestNewSignerFromFilePolicy(t *testing.T) {
 				Usage:        []string{"cert sign", "crl sign"},
 				ExpiryString: "43800h",
 				Expiry:       expiry,
-				CA:           true,
+				CAConstraint: config.CAConstraint{IsCA: true},
 			},
 		},
 	}
@@ -196,13 +196,14 @@ func testSign(t *testing.T) {
 	// nil ca
 	nilca := *signer
 	prof = signer.policy.Default
-	prof.CA = false
+	prof.CAConstraint.IsCA = false
 	nilca.ca = nil
 	_, err = nilca.sign(cert, prof)
 	if err == nil {
 		t.Fatal("nil ca with isca false raised an error")
 	}
-	prof.CA = true
+
+	prof.CAConstraint.IsCA = true
 	_, err = nilca.sign(cert, prof)
 	if err != nil {
 		t.Fatal("nil ca with CA true raised an error")
@@ -446,7 +447,7 @@ func TestCAIssuing(t *testing.T) {
 			Usage:        []string{"cert sign", "crl sign"},
 			ExpiryString: "1h",
 			Expiry:       1 * time.Hour,
-			CA:           true,
+			CAConstraint: config.CAConstraint{IsCA: true, MaxPathLenZero: true},
 		},
 	}
 	var hostname = "cloudflare-inter.com"
@@ -490,6 +491,12 @@ func TestCAIssuing(t *testing.T) {
 				}
 				if cert.SignatureAlgorithm != interSigner.SigAlgo() {
 					t.Fatal("Cert Signature Algorithm does not match the issuer.")
+				}
+				if cert.MaxPathLen != 0 {
+					t.Fatal("CA Cert Max Path is not zero.")
+				}
+				if cert.MaxPathLenZero != true {
+					t.Fatal("CA Cert Max Path is not zero.")
 				}
 			}
 		}
@@ -830,7 +837,10 @@ func TestCASignPathlen(t *testing.T) {
 				Usage:        []string{"cert sign", "crl sign"},
 				ExpiryString: "1h",
 				Expiry:       1 * time.Hour,
-				CA:           testCase.caProfile,
+				CAConstraint: config.CAConstraint{IsCA: testCase.caProfile,
+					MaxPathLen:     testCase.pathlen,
+					MaxPathLenZero: testCase.isZero,
+				},
 			},
 		}
 
@@ -887,7 +897,7 @@ func TestNoWhitelistSign(t *testing.T) {
 			Usage:        []string{"cert sign", "crl sign"},
 			ExpiryString: "1h",
 			Expiry:       1 * time.Hour,
-			CA:           true,
+			CAConstraint: config.CAConstraint{IsCA: true},
 		},
 	}
 
@@ -941,7 +951,7 @@ func TestWhitelistSign(t *testing.T) {
 			Usage:        []string{"cert sign", "crl sign"},
 			ExpiryString: "1h",
 			Expiry:       1 * time.Hour,
-			CA:           true,
+			CAConstraint: config.CAConstraint{IsCA: true},
 			CSRWhitelist: &config.CSRWhitelist{
 				PublicKey:          true,
 				PublicKeyAlgorithm: true,
@@ -1013,7 +1023,7 @@ func TestNameWhitelistSign(t *testing.T) {
 			Usage:         []string{"cert sign", "crl sign"},
 			ExpiryString:  "1h",
 			Expiry:        1 * time.Hour,
-			CA:            true,
+			CAConstraint:  config.CAConstraint{IsCA: true},
 			NameWhitelist: wl,
 		},
 	}
@@ -1090,7 +1100,7 @@ func TestExtensionSign(t *testing.T) {
 			Usage:              []string{"cert sign", "crl sign"},
 			ExpiryString:       "1h",
 			Expiry:             1 * time.Hour,
-			CA:                 true,
+			CAConstraint:       config.CAConstraint{IsCA: true},
 			ExtensionWhitelist: map[string]bool{"1.2.3.4": true},
 		},
 	}
@@ -1162,7 +1172,7 @@ func TestCTFailure(t *testing.T) {
 	var config = &config.Signing{
 		Default: &config.SigningProfile{
 			Expiry:       helpers.OneYear,
-			CA:           true,
+			CAConstraint: config.CAConstraint{IsCA: true},
 			Usage:        []string{"signing", "key encipherment", "server auth", "client auth"},
 			ExpiryString: "8760h",
 			CTLogServers: []string{ts.URL},
@@ -1199,7 +1209,7 @@ func TestCTSuccess(t *testing.T) {
 	var config = &config.Signing{
 		Default: &config.SigningProfile{
 			Expiry:       helpers.OneYear,
-			CA:           true,
+			CAConstraint: config.CAConstraint{IsCA: true},
 			Usage:        []string{"signing", "key encipherment", "server auth", "client auth"},
 			ExpiryString: "8760h",
 			CTLogServers: []string{ts.URL},

--- a/signer/remote/remote_test.go
+++ b/signer/remote/remote_test.go
@@ -333,7 +333,7 @@ func newHandler(t *testing.T, caFile, caKeyFile, op string) (http.Handler, error
 				Usage:        []string{"cert sign", "crl sign"},
 				ExpiryString: "43800h",
 				Expiry:       expiry,
-				CA:           true,
+				CAConstraint: config.CAConstraint{IsCA: true},
 
 				ClientProvidesSerialNumbers: true,
 			},

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -294,7 +294,15 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 	template.KeyUsage = ku
 	template.ExtKeyUsage = eku
 	template.BasicConstraintsValid = true
-	template.IsCA = profile.CA
+	template.IsCA = profile.CAConstraint.IsCA
+	if template.IsCA {
+		template.MaxPathLen = profile.CAConstraint.MaxPathLen
+		if template.MaxPathLen == 0 {
+			template.MaxPathLenZero = profile.CAConstraint.MaxPathLenZero
+		}
+		template.DNSNames = nil
+		template.EmailAddresses = nil
+	}
 	template.SubjectKeyId = ski
 
 	if ocspURL != "" {

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -23,12 +23,6 @@ import (
 	"github.com/cloudflare/cfssl/info"
 )
 
-// MaxPathLen is the default path length for a new CA certificate.
-var MaxPathLen = 2
-
-// MaxPathLenZero indicates whether a new CA certificate has pathlen=0
-var MaxPathLenZero = false
-
 // Subject contains the information that should be used to override the
 // subject information when signing a certificate.
 type Subject struct {


### PR DESCRIPTION
A new CA config entry: CAContraint, which can be used to specify intermediate CA's pathlen constraints.