### PR TITLE
Update github.com/google/certificate-transparency/go

### DIFF
--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -352,7 +352,7 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 
 		for _, server := range profile.CTLogServers {
 			log.Infof("submitting poisoned precertificate to %s", server)
-			var ctclient = client.New(server)
+			var ctclient = client.New(server, nil)
 			var resp *ct.SignedCertificateTimestamp
 			resp, err = ctclient.AddPreChain(prechain)
 			if err != nil {

--- a/vendor/github.com/google/certificate-transparency/go/client/logclient.go
+++ b/vendor/github.com/google/certificate-transparency/go/client/logclient.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/google/certificate-transparency/go"
-	"github.com/mreiferson/go-httpclient"
 	"golang.org/x/net/context"
 )
 
@@ -109,18 +108,12 @@ type getEntryAndProofResponse struct {
 // New constructs a new LogClient instance.
 // |uri| is the base URI of the CT log instance to interact with, e.g.
 // http://ct.googleapis.com/pilot
-func New(uri string) *LogClient {
-	var c LogClient
-	c.uri = uri
-	transport := &httpclient.Transport{
-		ConnectTimeout:        10 * time.Second,
-		RequestTimeout:        30 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
-		MaxIdleConnsPerHost:   10,
-		DisableKeepAlives:     false,
+// |hc| is the underlying client to be used for HTTP requests to the CT log.
+func New(uri string, hc *http.Client) *LogClient {
+	if hc == nil {
+		hc = new(http.Client)
 	}
-	c.httpClient = &http.Client{Transport: transport}
-	return &c
+	return &LogClient{uri: uri, httpClient: hc}
 }
 
 // Makes a HTTP call to |uri|, and attempts to parse the response as a JSON

--- a/vendor/github.com/google/certificate-transparency/go/client/logclient_test.go
+++ b/vendor/github.com/google/certificate-transparency/go/client/logclient_test.go
@@ -57,7 +57,7 @@ func TestGetEntriesWorks(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := New(ts.URL)
+	client := New(ts.URL, &http.Client{})
 	leaves, err := client.GetEntries(0, 1)
 	if err != nil {
 		t.Fatal(err)
@@ -78,7 +78,7 @@ func TestGetSTHWorks(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := New(ts.URL)
+	client := New(ts.URL, &http.Client{})
 	sth, err := client.GetSTH()
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func TestAddChainWithContext(t *testing.T) {
 	}
 	chain := []ct.ASN1Cert{certBytes}
 
-	c := New(hs.URL)
+	c := New(hs.URL, &http.Client{})
 	leeway := time.Millisecond * 100
 	instant := time.Millisecond
 	fiveSeconds := time.Second * 5
@@ -193,7 +193,7 @@ func TestAddJSON(t *testing.T) {
 	}))
 	defer hs.Close()
 
-	c := New(hs.URL)
+	c := New(hs.URL, &http.Client{})
 
 	tests := []struct {
 		success bool

--- a/vendor/github.com/google/certificate-transparency/go/merkletree/merkle_verifier.go
+++ b/vendor/github.com/google/certificate-transparency/go/merkletree/merkle_verifier.go
@@ -1,0 +1,188 @@
+package merkletree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+type RootMismatchError struct {
+	ExpectedRoot   []byte
+	CalculatedRoot []byte
+}
+
+func (e RootMismatchError) Error() string {
+	return fmt.Sprintf("calculated root:\n%v\n does not match expected root:\n%v", e.CalculatedRoot, e.ExpectedRoot)
+}
+
+// MerkleVerifier is a class which knows how to verify merkle inclusion and consistency proofs.
+type MerkleVerifier struct {
+	treeHasher *TreeHasher
+}
+
+// NewMerkleVerifier returns a new MerkleVerifier for a tree based on the passed in hasher.
+func NewMerkleVerifier(h HasherFunc) MerkleVerifier {
+	return MerkleVerifier{
+		treeHasher: NewTreeHasher(h),
+	}
+}
+
+// VerifyInclusionProof verifies the correctness of the proof given the passed in information about the tree and leaf.
+func (m MerkleVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof [][]byte, root []byte, leaf []byte) error {
+	calcRoot, err := m.RootFromInclusionProof(leafIndex, treeSize, proof, leaf)
+	if err != nil {
+		return err
+	}
+	if len(calcRoot) == 0 {
+		return errors.New("calculated empty root")
+	}
+	if !bytes.Equal(calcRoot, root) {
+		return RootMismatchError{
+			CalculatedRoot: calcRoot,
+			ExpectedRoot:   root,
+		}
+	}
+	return nil
+}
+
+// RootFromInclusionProof calculates the expected tree root given the proof and leaf.
+func (m MerkleVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][]byte, leaf []byte) ([]byte, error) {
+	if leafIndex > treeSize {
+		return nil, fmt.Errorf("leafIndex %d > treeSize %d", leafIndex, treeSize)
+	}
+	if leafIndex == 0 {
+		return nil, errors.New("leafIndex is zero")
+	}
+
+	node := leafIndex - 1
+	lastNode := treeSize - 1
+	nodeHash := m.treeHasher.HashLeaf(leaf)
+	proofIndex := 0
+
+	for lastNode > 0 {
+		if proofIndex == len(proof) {
+			return nil, fmt.Errorf("insuficient number of proof components (%d) for treeSize %d", len(proof), treeSize)
+		}
+		if isRightChild(node) {
+			nodeHash = m.treeHasher.HashChildren(proof[proofIndex], nodeHash)
+			proofIndex++
+		} else if node < lastNode {
+			nodeHash = m.treeHasher.HashChildren(nodeHash, proof[proofIndex])
+			proofIndex++
+		} else {
+			// the sibling does not exist and the parent is a dummy copy; do nothing.
+		}
+		node = parent(node)
+		lastNode = parent(lastNode)
+	}
+	if proofIndex != len(proof) {
+		return nil, fmt.Errorf("invalid proof, expected %d components, but have %d", proofIndex, len(proof))
+	}
+	return nodeHash, nil
+}
+
+// VerifyConsistencyProof checks that the passed in consistency proof is valid between the passed in tree snapshots.
+func (m MerkleVerifier) VerifyConsistencyProof(snapshot1, snapshot2 int64, root1, root2 []byte, proof [][]byte) error {
+	if snapshot1 > snapshot2 {
+		return fmt.Errorf("snapshot1 (%d) > snapshot2 (%d)", snapshot1, snapshot2)
+	}
+	if snapshot1 == snapshot2 {
+		if !bytes.Equal(root1, root2) {
+			return fmt.Errorf("root1:\n%v\ndoes not match root2:\n%v", root1, root2)
+		}
+		if len(proof) > 0 {
+			return fmt.Errorf("root1 and root2 match, but proof is non-empty")
+		}
+		// proof ok
+		return nil
+	}
+
+	if snapshot1 == 0 {
+		// Any snapshot greater than 0 is consistent with snapshot 0.
+		if len(proof) > 0 {
+			return fmt.Errorf("expected empty proof, but provided proof has %d components", len(proof))
+		}
+		return nil
+	}
+
+	if len(proof) == 0 {
+		return errors.New("empty proof")
+	}
+
+	node := snapshot1 - 1
+	lastNode := snapshot2 - 1
+	proofIndex := 0
+
+	for isRightChild(node) {
+		node = parent(node)
+		lastNode = parent(lastNode)
+	}
+
+	var node1Hash []byte
+	var node2Hash []byte
+
+	if node > 0 {
+		node1Hash = proof[proofIndex]
+		node2Hash = proof[proofIndex]
+		proofIndex++
+	} else {
+		// The tree at snapshot1 was balanced, nothing to verify for root1.
+		node1Hash = root1
+		node2Hash = root1
+	}
+
+	for node > 0 {
+		if proofIndex == len(proof) {
+			return errors.New("insufficient number of proof components")
+		}
+
+		if isRightChild(node) {
+			node1Hash = m.treeHasher.HashChildren(proof[proofIndex], node1Hash)
+			node2Hash = m.treeHasher.HashChildren(proof[proofIndex], node2Hash)
+			proofIndex++
+		} else if node < lastNode {
+			// The sibling only exists in the later tree. The parent in the snapshot1 tree is a dummy copy.
+			node2Hash = m.treeHasher.HashChildren(node2Hash, proof[proofIndex])
+			proofIndex++
+		} else {
+			// Else the sibling does not exist in either tree. Do nothing.
+		}
+
+		node = parent(node)
+		lastNode = parent(lastNode)
+	}
+
+	// Verify the first root.
+	if !bytes.Equal(node1Hash, root1) {
+		return fmt.Errorf("failed to verify root1:\n%v\ncalculated root of:\n%v\nfrom proof", root1, node1Hash)
+	}
+
+	for lastNode > 0 {
+		if proofIndex == len(proof) {
+			return errors.New("can't verify newer root; insufficient number of proof components")
+		}
+
+		node2Hash = m.treeHasher.HashChildren(node2Hash, proof[proofIndex])
+		proofIndex++
+		lastNode = parent(lastNode)
+	}
+
+	// Verify the second root.
+	if !bytes.Equal(node2Hash, root2) {
+		return fmt.Errorf("failed to verify root2:\n%v\ncalculated root of:\n%v\nfrom proof", root2, node2Hash)
+	}
+	if proofIndex != len(proof) {
+		return errors.New("proof has too many components")
+	}
+
+	// proof ok
+	return nil
+}
+
+func parent(leafIndex int64) int64 {
+	return leafIndex >> 1
+}
+
+func isRightChild(leafIndex int64) bool {
+	return leafIndex&1 == 1
+}

--- a/vendor/github.com/google/certificate-transparency/go/merkletree/merkle_verifier_test.go
+++ b/vendor/github.com/google/certificate-transparency/go/merkletree/merkle_verifier_test.go
@@ -1,0 +1,427 @@
+package merkletree
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+const (
+	sha256EmptyTreeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+func verifierCheck(v *MerkleVerifier, leafIndex, treeSize int64, proof [][]byte, root []byte, leaf []byte) error {
+	// Verify original inclusion proof
+	got, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leaf)
+	if err != nil {
+		return err
+	}
+	if want := root; !bytes.Equal(got, want) {
+		return fmt.Errorf("got root:\n%v\nexpected:\n%v", got, want)
+	}
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err != nil {
+		return err
+	}
+
+	// Wrong leaf index
+	if err := v.VerifyInclusionProof(leafIndex-1, treeSize, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against leafIndex - 1")
+	}
+	if err := v.VerifyInclusionProof(leafIndex+1, treeSize, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against leafIndex + 1")
+	}
+	if err := v.VerifyInclusionProof(leafIndex^2, treeSize, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against leafIndex ^ 2")
+	}
+
+	// Wrong tree height
+	if err := v.VerifyInclusionProof(leafIndex, treeSize*2, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against treeSize * 2")
+	}
+	if err := v.VerifyInclusionProof(leafIndex, treeSize/2, proof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against treeSize / 2")
+	}
+
+	// Wrong leaf
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, []byte("WrongLeaf")); err == nil {
+		return errors.New("incorrectly verified against WrongLeaf")
+	}
+
+	// Wrong root
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, dh(sha256EmptyTreeHash), leaf); err == nil {
+		return errors.New("incorrectly verified against empty root hash")
+	}
+
+	// Wrong inclusion proofs
+
+	// Modify single element of the proof
+	for i := 0; i < len(proof); i++ {
+		tmp := proof[i]
+		proof[i] = dh(sha256EmptyTreeHash)
+		if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err == nil {
+			return errors.New("incorrectly verified against incorrect inclusion proof")
+		}
+		proof[i] = tmp
+	}
+
+	// Add garbage at the end
+	wrongProof := append(proof, []byte(""))
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with trailing garbage")
+	}
+
+	wrongProof = append(proof, root)
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with trailing root")
+	}
+
+	if len(proof) > 0 {
+		// Remove a node from the end
+		wrongProof = proof[:len(proof)-1]
+		if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+			return errors.New("incorrectly verified against truncated proof")
+		}
+	}
+
+	// Add garbage at the front
+	wrongProof = append([][]byte{{}}, proof...)
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	wrongProof = append([][]byte{root}, proof...)
+	if err := v.VerifyInclusionProof(leafIndex, treeSize, wrongProof, root, leaf); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	return nil
+}
+
+func verifierConsistencyCheck(v *MerkleVerifier, snapshot1, snapshot2 int64, root1, root2 []byte, proof [][]byte) error {
+	// Verify original consistency proof
+	err := v.VerifyConsistencyProof(snapshot1, snapshot2, root1, root2, proof)
+	if err != nil {
+		return err
+	}
+
+	if len(proof) == 0 {
+		// For simplicity test only non-trivial proofs that have root1 != root2
+		// snapshot1 != 0 and snapshot1 != snapshot2.
+		return nil
+	}
+
+	// Wrong snapshot index
+	if err := v.VerifyConsistencyProof(snapshot1-1, snapshot2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot1-1")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1+1, snapshot2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot1+1")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1^2, snapshot2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot1^2")
+	}
+
+	// Wrong tree height
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2*2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot2*2")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2/2, root1, root2, proof); err == nil {
+		return errors.New("incorrectly verified against snapshot2/2")
+	}
+
+	// Wrong root
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, []byte("WrongRoot"), root2, proof); err == nil {
+		return errors.New("incorrectly verified against wrong root1")
+	}
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root1, []byte("WrongRoot"), proof); err == nil {
+		return errors.New("incorrectly verified against wrong root2")
+	}
+	// Swap roots
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2*2, root2, root1, proof); err == nil {
+		return errors.New("incorrectly verified against swapped roots")
+	}
+
+	// Wrong consistency proofs
+	// Empty proof
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, [][]byte{}); err == nil {
+		return errors.New("incorrectly verified against empty proof")
+	}
+
+	// Modify single element of the proof
+	for i := 0; i < len(proof); i++ {
+		tmp := proof[i]
+		proof[i] = dh(sha256EmptyTreeHash)
+		if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, proof); err == nil {
+			return errors.New("incorrectly verified against incorrect consistency proof")
+		}
+		proof[i] = tmp
+	}
+
+	// Add garbage at the end
+	wrongProof := append(proof, []byte(""))
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with trailing garbage")
+	}
+
+	wrongProof = append(proof, root1)
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with trailing root")
+	}
+
+	// Remove a node from the end
+	wrongProof = proof[:len(proof)-1]
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against truncated proof")
+	}
+
+	// Add garbage at the front
+	wrongProof = append([][]byte{{}}, proof...)
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	wrongProof = append([][]byte{proof[0]}, proof...)
+	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root2, root1, wrongProof); err == nil {
+		return errors.New("incorrectly verified against proof with preceding garbage")
+	}
+
+	return nil
+}
+
+func getVerifier() MerkleVerifier {
+	return NewMerkleVerifier(func(b []byte) []byte {
+		h := sha256.Sum256(b)
+		return h[:]
+	})
+}
+
+type proofTestVector struct {
+	h []byte
+	l int
+}
+
+type inclusionProofTestVector struct {
+	leaf, snapshot, proofLength int64
+	proof                       []proofTestVector
+}
+
+func getInputs() []proofTestVector {
+	return []proofTestVector{
+		{dh(""), 0},
+		{dh("00"), 1},
+		{dh("10"), 1},
+		{dh("2021"), 2},
+		{dh("3031"), 2},
+		{dh("40414243"), 4},
+		{dh("5051525354555657"), 8},
+		{dh("606162636465666768696a6b6c6d6e6f"), 16},
+	}
+}
+
+func getInclusionTestVector() []inclusionProofTestVector {
+	return []inclusionProofTestVector{
+		{0, 0, 0, []proofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1, 1, 0, []proofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1,
+			8,
+			3,
+			[]proofTestVector{
+				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
+		{6,
+			8,
+			3,
+			[]proofTestVector{
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
+				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
+				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
+		{3,
+			3,
+			1,
+			[]proofTestVector{
+				{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
+				{dh(""), 0},
+				{dh(""), 0}}},
+		{2,
+			5,
+			3,
+			[]proofTestVector{
+				{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32}},
+		}}
+}
+
+func getRoots() []proofTestVector {
+	return []proofTestVector{
+		{dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"), 32},
+		{dh("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"), 32},
+		{dh("aeb6bcfe274b70a14fb067a5e5578264db0fa9b51af5e0ba159158f329e06e77"), 32},
+		{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32},
+		{dh("4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"), 32},
+		{dh("76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef"), 32},
+		{dh("ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"), 32},
+		{dh("5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328"), 32}}
+}
+
+type consistencyTestVector struct {
+	snapshot1, snapshot2, proofLen int64
+	proof                          [3]proofTestVector
+}
+
+func getConsistencyProofs() []consistencyTestVector {
+	return []consistencyTestVector{
+		{1, 1, 0, [3]proofTestVector{{dh(""), 0}, {dh(""), 0}, {dh(""), 0}}},
+		{1,
+			8,
+			3,
+			[3]proofTestVector{
+				{dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"), 32},
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"), 32}}},
+		{6,
+			8,
+			3,
+			[3]proofTestVector{
+				{dh("0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a"), 32},
+				{dh("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"), 32},
+				{dh("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"), 32}}},
+		{2,
+			5,
+			2,
+			[3]proofTestVector{
+				{dh("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"), 32},
+				{dh("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"), 32},
+				{dh(""), 0}}},
+	}
+}
+
+func TestVerifyInclusionProof(t *testing.T) {
+	v := getVerifier()
+
+	path := [][]byte{}
+	// Various invalid paths
+	if err := v.VerifyInclusionProof(0, 0, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 1")
+	}
+	if err := v.VerifyInclusionProof(0, 1, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 2")
+	}
+	if err := v.VerifyInclusionProof(1, 0, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 3")
+	}
+	if err := v.VerifyInclusionProof(2, 1, path, []byte{}, []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid path 4")
+	}
+
+	if err := v.VerifyInclusionProof(0, 0, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 1")
+	}
+	if err := v.VerifyInclusionProof(0, 1, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 2")
+	}
+	if err := v.VerifyInclusionProof(1, 0, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 3")
+	}
+	if err := v.VerifyInclusionProof(2, 1, path, dh(sha256EmptyTreeHash), []byte{}); err == nil {
+		t.Fatal("Incorrectly verified invalid root 4")
+	}
+
+	// Known good paths.
+
+	inclusionProofs := getInclusionTestVector()
+	inputs := getInputs()
+	roots := getRoots()
+	// i = 0 is an invalid path.
+	for i := 1; i < 6; i++ {
+		// Construct the path.
+		proof := [][]byte{}
+		for j := int64(0); j < inclusionProofs[i].proofLength; j++ {
+			proof = append(proof, inclusionProofs[i].proof[j].h)
+		}
+		err := verifierCheck(&v, inclusionProofs[i].leaf, inclusionProofs[i].snapshot, proof,
+			roots[inclusionProofs[i].snapshot-1].h,
+			inputs[inclusionProofs[i].leaf-1].h)
+		if err != nil {
+			t.Fatalf("i=%d: %s", i, err)
+		}
+	}
+
+}
+
+func TestVerifyConsistencyProof(t *testing.T) {
+	v := getVerifier()
+
+	proof := [][]byte{}
+	root1 := []byte("don't care")
+	root2 := []byte("don't care")
+
+	// Snapshots that are always consistent
+	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err != nil {
+		t.Fatalf("Failed to verify proof: %s", err)
+	}
+	if err := verifierConsistencyCheck(&v, 0, 1, root1, root2, proof); err != nil {
+		t.Fatalf("Failed to verify proof: %s", err)
+	}
+	if err := verifierConsistencyCheck(&v, 1, 1, root1, root2, proof); err != nil {
+		t.Fatalf("Failed to verify proof: %s", err)
+	}
+
+	// Invalid consistency proofs.
+	// Time travel to the past.
+	if err := verifierConsistencyCheck(&v, 1, 0, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified timetravelling proof")
+	}
+	if err := verifierConsistencyCheck(&v, 2, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified timetravelling proof")
+	}
+
+	// Empty proof
+	if err := verifierConsistencyCheck(&v, 1, 2, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified timetravelling proof")
+	}
+
+	root1 = dh(sha256EmptyTreeHash)
+	// Roots don't match.
+	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified mismatched root")
+	}
+	if err := verifierConsistencyCheck(&v, 1, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified mismatched root")
+	}
+
+	// Roots match but the proof is not empty.
+	root2 = dh(sha256EmptyTreeHash)
+	proof = [][]byte{dh(sha256EmptyTreeHash)}
+
+	if err := verifierConsistencyCheck(&v, 0, 0, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified non-empty proof")
+	}
+	if err := verifierConsistencyCheck(&v, 0, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified non-empty proof")
+	}
+	if err := verifierConsistencyCheck(&v, 1, 1, root1, root2, proof); err == nil {
+		t.Fatal("Incorrectly verified non-empty proof")
+	}
+
+	// Known good proofs.
+	roots := getRoots()
+	proofs := getConsistencyProofs()
+	for i := 0; i < 4; i++ {
+		proof := [][]byte{}
+		for j := int64(0); j < proofs[i].proofLen; j++ {
+			proof = append(proof, proofs[i].proof[j].h)
+		}
+		snapshot1 := proofs[i].snapshot1
+		snapshot2 := proofs[i].snapshot2
+		err := verifierConsistencyCheck(&v, snapshot1, snapshot2,
+			roots[snapshot1-1].h,
+			roots[snapshot2-1].h, proof)
+		if err != nil {
+			t.Fatalf("Failed to verify known good proof for i=%d: %s", i, err)
+		}
+	}
+}

--- a/vendor/github.com/google/certificate-transparency/go/merkletree/tree_hasher.go
+++ b/vendor/github.com/google/certificate-transparency/go/merkletree/tree_hasher.go
@@ -1,0 +1,40 @@
+package merkletree
+
+const (
+	// LeafPrefix is the domain separation prefix for leaf hashes.
+	LeafPrefix = 0
+
+	// NodePrefix is the domain separation prefix for internal tree nodes.
+	NodePrefix = 1
+)
+
+// HasherFunc takes a slice of bytes and returns a cryptographic hash of those bytes.
+type HasherFunc func([]byte) []byte
+
+// TreeHasher performs the various hashing operations required when manipulating MerkleTrees.
+type TreeHasher struct {
+	hasher HasherFunc
+}
+
+// NewTreeHasher returns a new TreeHasher based on the passed in hash.
+func NewTreeHasher(h HasherFunc) *TreeHasher {
+	return &TreeHasher{
+		hasher: h,
+	}
+}
+
+// HashEmpty returns the hash of the empty string.
+func (h TreeHasher) HashEmpty() []byte {
+	return h.hasher([]byte{})
+}
+
+// HashLeaf returns the hash of the passed in leaf, after applying domain separation.
+func (h TreeHasher) HashLeaf(leaf []byte) []byte {
+	return h.hasher(append([]byte{LeafPrefix}, leaf...))
+
+}
+
+// HashChildren returns the merkle hash of the two passed in children.
+func (h TreeHasher) HashChildren(left, right []byte) []byte {
+	return h.hasher(append(append([]byte{NodePrefix}, left...), right...))
+}

--- a/vendor/github.com/google/certificate-transparency/go/merkletree/tree_hasher_test.go
+++ b/vendor/github.com/google/certificate-transparency/go/merkletree/tree_hasher_test.go
@@ -1,0 +1,134 @@
+package merkletree
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+type leafTestVector struct {
+	inputLength int64
+	input       []byte
+	output      []byte
+}
+
+// Inputs and outputs are of fixed digest size.
+type nodeTestVector struct {
+	left   []byte
+	right  []byte
+	output []byte
+}
+
+type testVector struct {
+	emptyHash []byte
+	leaves    []leafTestVector
+	nodes     []nodeTestVector
+}
+
+const (
+	sha256EmptyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+func dh(h string) []byte {
+	r, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func getTestVector() testVector {
+	return testVector{
+		emptyHash: dh(sha256EmptyHash),
+		leaves: []leafTestVector{
+			{0, dh(""), dh("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d")},
+			{1, dh("00"), dh("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7")},
+			{16, dh("101112131415161718191a1b1c1d1e1f"), dh("3bfb960453ebaebf33727da7a1f4db38acc051d381b6da20d6d4e88f0eabfd7a")},
+		},
+		nodes: []nodeTestVector{
+			{dh("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"),
+				dh("202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"),
+				dh("1a378704c17da31e2d05b6d121c2bb2c7d76f6ee6fa8f983e596c2d034963c57")},
+		},
+	}
+}
+
+func getTreeHasher() *TreeHasher {
+	return NewTreeHasher(func(b []byte) []byte {
+		h := sha256.Sum256(b)
+		return h[:]
+	})
+}
+
+const (
+	digestSize = sha256.Size
+)
+
+func TestCollisionEmptyHashZeroLengthLeaf(t *testing.T) {
+	th := getTreeHasher()
+
+	// Check that the empty hash is not the same as the hash of an empty leaf.
+	leaf1Digest := th.HashEmpty()
+	if got, want := len(leaf1Digest), digestSize; got != want {
+		t.Fatalf("Empty digest has length %d, but expected %d", got, want)
+	}
+
+	leaf2Digest := th.HashLeaf([]byte{})
+	if got, want := len(leaf2Digest), digestSize; got != want {
+		t.Fatalf("Empty leaf digest has length %d, but expected %d", got, want)
+	}
+
+	if bytes.Equal(leaf1Digest, leaf2Digest) {
+		t.Fatalf("Digests of empty string (%v) and zero-length leaf (%v) should differ", leaf1Digest, leaf2Digest)
+	}
+}
+
+func TestCollisionDifferentLeaves(t *testing.T) {
+	th := getTreeHasher()
+
+	// Check that different leaves hash to different digests.
+	const leaf1 = "Hello"
+	const leaf2 = "World"
+
+	leaf1Digest := th.HashLeaf([]byte(leaf1))
+	if got, want := len(leaf1Digest), digestSize; got != want {
+		t.Fatalf("Got unexpected leaf1 digest size %d, expected %d", got, want)
+	}
+
+	leaf2Digest := th.HashLeaf([]byte(leaf2))
+	if got, want := len(leaf2Digest), digestSize; got != want {
+		t.Fatalf("Got unexpected leaf2 digest size %d, expected %d", got, want)
+	}
+
+	if bytes.Equal(leaf1Digest, leaf2Digest) {
+		t.Fatalf("Digests of leaf1 (%v) and leaf2 (%v) should differ", leaf1Digest, leaf2Digest)
+	}
+
+	// Compute an intermediate node digest.
+	node1Digest := th.HashChildren(leaf1Digest, leaf2Digest)
+	if got, want := len(node1Digest), digestSize; got != want {
+		t.Fatalf("Got unexpected intermediate digest size %d, expected %d", got, want)
+	}
+
+	// Check that this is not the same as a leaf hash of their concatenation.
+	image := append(leaf1Digest, leaf2Digest...)
+	node2Digest := th.HashLeaf(image)
+	if got, want := len(node2Digest), digestSize; got != want {
+		t.Fatalf("Got unexpected node2Digest size %d, expected %d", got, want)
+	}
+
+	if bytes.Equal(node1Digest, node2Digest) {
+		t.Fatalf("node1Digest (%v) and node2Digest (%v) should differ", node1Digest, node2Digest)
+	}
+
+	// Swap the order of nodes and check that the hash is different.
+	node3Digest := th.HashChildren(leaf2Digest, leaf1Digest)
+	if got, want := len(node3Digest), digestSize; got != want {
+		t.Fatalf("Got unexpected node3 digest size %d, expected %d", got, want)
+	}
+
+	if bytes.Equal(node1Digest, node3Digest) {
+		t.Fatalf("node1Digest (%v) and node3Digest (%v) should differ", node1Digest, node3Digest)
+	}
+}

--- a/vendor/github.com/google/certificate-transparency/go/scanner/main/scanner.go
+++ b/vendor/github.com/google/certificate-transparency/go/scanner/main/scanner.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net/http"
 	"regexp"
+	"time"
 
 	"encoding/base64"
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
 	"github.com/google/certificate-transparency/go/scanner"
+	"github.com/mreiferson/go-httpclient"
 )
 
 const (
@@ -96,7 +99,15 @@ func createMatcherFromFlags() (scanner.Matcher, error) {
 
 func main() {
 	flag.Parse()
-	logClient := client.New(*logUri)
+	logClient := client.New(*logUri, &http.Client{
+		Transport: &httpclient.Transport{
+			ConnectTimeout:        10 * time.Second,
+			RequestTimeout:        30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			MaxIdleConnsPerHost:   10,
+			DisableKeepAlives:     false,
+			},
+		})
 	matcher, err := createMatcherFromFlags()
 	if err != nil {
 		log.Fatal(err)

--- a/vendor/github.com/google/certificate-transparency/go/scanner/scanner_test.go
+++ b/vendor/github.com/google/certificate-transparency/go/scanner/scanner_test.go
@@ -171,7 +171,7 @@ func TestScannerEndToEnd(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logClient := client.New(ts.URL)
+	logClient := client.New(ts.URL, &http.Client{})
 	opts := ScannerOptions{
 		Matcher:       &MatchSubjectRegex{regexp.MustCompile(".*\\.google\\.com"), nil},
 		BatchSize:     10,

--- a/vendor/github.com/google/certificate-transparency/go/serialization.go
+++ b/vendor/github.com/google/certificate-transparency/go/serialization.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"container/list"
 	"crypto"
+	"encoding/asn1"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -23,6 +24,8 @@ const (
 const (
 	MaxCertificateLength = (1 << 24) - 1
 	MaxExtensionsLength  = (1 << 16) - 1
+	MaxSCTInListLength   = (1 << 16) - 1
+	MaxSCTListLength     = (1 << 16) - 1
 )
 
 func writeUint(w io.Writer, value uint64, numBytes int) error {
@@ -80,7 +83,7 @@ func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
 		return nil, err
 	}
 	data := make([]byte, l)
-	if n, err := io.ReadFull(r, data);  err != nil {
+	if n, err := io.ReadFull(r, data); err != nil {
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
 		}
@@ -508,4 +511,53 @@ func SerializeSTHSignatureInput(sth SignedTreeHead) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unsupported STH version %d", sth.Version)
 	}
+}
+
+// SCTListSerializedLength determines the length of the required buffer should a SCT List need to be serialized
+func SCTListSerializedLength(scts []SignedCertificateTimestamp) (int, error) {
+	if len(scts) == 0 {
+		return 0, fmt.Errorf("SCT List empty")
+	}
+
+	sctListLen := 0
+	for i, sct := range scts {
+		n, err := sct.SerializedLength()
+		if err != nil {
+			return 0, fmt.Errorf("unable to determine length of SCT in position %d: %v", i, err)
+		}
+		if n > MaxSCTInListLength {
+			return 0, fmt.Errorf("SCT in position %d too large: %d", i, n)
+		}
+		sctListLen += 2 + n
+	}
+
+	return sctListLen, nil
+}
+
+// SerializeSCTList serializes the passed-in slice of SignedCertificateTimestamp into a
+// byte slice as a SignedCertificateTimestampList (see RFC6962 Section 3.3)
+func SerializeSCTList(scts []SignedCertificateTimestamp) ([]byte, error) {
+	size, err := SCTListSerializedLength(scts)
+	if err != nil {
+		return nil, err
+	}
+	fullSize := 2 + size // 2 bytes for length + size of SCT list
+	if fullSize > MaxSCTListLength {
+		return nil, fmt.Errorf("SCT List too large to serialize: %d", fullSize)
+	}
+	buf := new(bytes.Buffer)
+	buf.Grow(fullSize)
+	if err = writeUint(buf, uint64(size), 2); err != nil {
+		return nil, err
+	}
+	for _, sct := range scts {
+		serialized, err := SerializeSCT(sct)
+		if err != nil {
+			return nil, err
+		}
+		if err = writeVarBytes(buf, serialized, 2); err != nil {
+			return nil, err
+		}
+	}
+	return asn1.Marshal(buf.Bytes()) // transform to Octet String
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -160,7 +160,7 @@
 			"importpath": "github.com/google/certificate-transparency/go",
 			"repository": "https://github.com/google/certificate-transparency",
 			"vcs": "git",
-			"revision": "ceb124408274d5270de73c6cfcce6d4d03539c8e",
+			"revision": "0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341",
 			"branch": "master",
 			"path": "/go"
 		},


### PR DESCRIPTION
Updates `github.com/google/certificate-transparency/go` to current master. This fixes some strange vendoring issues `github.com/letsencrypt/boulder` was having downstream (also now includes SCT list serialization).