### PR TITLE
throw policy errors when signer unable to sign CA csr due to CA

### DIFF
--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -248,17 +248,20 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 
 	if safeTemplate.IsCA {
 		if !profile.CAConstraint.IsCA {
-			return nil, cferr.New(cferr.CertificateError, cferr.InvalidRequest)
+			log.Error("local signer policy disallows issuing CA certificate")
+			return nil, cferr.New(cferr.PolicyError, cferr.InvalidRequest)
 		}
 
 		if s.ca != nil && s.ca.MaxPathLen > 0 {
 			if safeTemplate.MaxPathLen >= s.ca.MaxPathLen {
+				log.Error("local signer certificate disallows CA MaxPathLen extending")
 				// do not sign a cert with pathlen > current
-				return nil, cferr.New(cferr.CertificateError, cferr.InvalidRequest)
+				return nil, cferr.New(cferr.PolicyError, cferr.InvalidRequest)
 			}
 		} else if s.ca != nil && s.ca.MaxPathLen == 0 && s.ca.MaxPathLenZero {
+			log.Error("local signer certificate disallows issuing CA certificate")
 			// signer has pathlen of 0, do not sign more intermediate CAs
-			return nil, cferr.New(cferr.CertificateError, cferr.InvalidRequest)
+			return nil, cferr.New(cferr.PolicyError, cferr.InvalidRequest)
 		}
 	}
 

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -751,7 +751,7 @@ func TestCASignPathlen(t *testing.T) {
 			caKeyFile:  testECDSACaKeyFile,
 			caProfile:  true,
 			csrFile:    "testdata/inter_pathlen_1.csr",
-			err:        cferr.New(cferr.CertificateError, cferr.InvalidRequest),
+			err:        cferr.New(cferr.PolicyError, cferr.InvalidRequest),
 		},
 		{
 			name:       "pathlen 0 signing pathlen 0",
@@ -759,7 +759,7 @@ func TestCASignPathlen(t *testing.T) {
 			caKeyFile:  testCaKeyFile,
 			caProfile:  true,
 			csrFile:    "testdata/inter_pathlen_0.csr",
-			err:        cferr.New(cferr.CertificateError, cferr.InvalidRequest),
+			err:        cferr.New(cferr.PolicyError, cferr.InvalidRequest),
 		},
 		{
 			name:       "pathlen 0 signing pathlen 1",
@@ -767,7 +767,7 @@ func TestCASignPathlen(t *testing.T) {
 			caKeyFile:  testCaKeyFile,
 			caProfile:  true,
 			csrFile:    "testdata/inter_pathlen_1.csr",
-			err:        cferr.New(cferr.CertificateError, cferr.InvalidRequest),
+			err:        cferr.New(cferr.PolicyError, cferr.InvalidRequest),
 		},
 		{
 			name:       "pathlen 0 signing pathlen unspecified",
@@ -775,7 +775,7 @@ func TestCASignPathlen(t *testing.T) {
 			caKeyFile:  testCaKeyFile,
 			caProfile:  true,
 			csrFile:    "testdata/inter_pathlen_unspecified.csr",
-			err:        cferr.New(cferr.CertificateError, cferr.InvalidRequest),
+			err:        cferr.New(cferr.PolicyError, cferr.InvalidRequest),
 		},
 		{
 			name:       "pathlen 1 signing unspecified pathlen",
@@ -791,28 +791,28 @@ func TestCASignPathlen(t *testing.T) {
 			isCA:    true,
 		},
 		{
-			name:       "non-ca singing profile sighing pathlen 0",
+			name:       "non-ca singing profile signing pathlen 0",
 			caCertFile: testECDSACaFile,
 			caKeyFile:  testECDSACaKeyFile,
 			caProfile:  false,
 			csrFile:    "testdata/inter_pathlen_0.csr",
-			err:        cferr.New(cferr.CertificateError, cferr.InvalidRequest),
+			err:        cferr.New(cferr.PolicyError, cferr.InvalidRequest),
 		},
 		{
-			name:       "non-ca singing profile sighing pathlen 1",
+			name:       "non-ca singing profile signing pathlen 1",
 			caCertFile: testECDSACaFile,
 			caKeyFile:  testECDSACaKeyFile,
 			caProfile:  false,
 			csrFile:    "testdata/inter_pathlen_1.csr",
-			err:        cferr.New(cferr.CertificateError, cferr.InvalidRequest),
+			err:        cferr.New(cferr.PolicyError, cferr.InvalidRequest),
 		},
 		{
-			name:       "non-ca singing profile sighing pathlen 0",
+			name:       "non-ca singing profile signing pathlen 0",
 			caCertFile: testECDSACaFile,
 			caKeyFile:  testECDSACaKeyFile,
 			caProfile:  false,
 			csrFile:    "testdata/inter_pathlen_unspecified.csr",
-			err:        cferr.New(cferr.CertificateError, cferr.InvalidRequest),
+			err:        cferr.New(cferr.PolicyError, cferr.InvalidRequest),
 		},
 	}
 


### PR DESCRIPTION
constraint mismatch

- fix tests as well