### PR TITLE
Fix error where whitelist does not match

### DIFF
--- a/doc/errorcode.txt
+++ b/doc/errorcode.txt
@@ -29,6 +29,7 @@
     5200: InvalidPolicy
     5300: InvalidRequest
     5400: UnknownProfile
+    5500: UnmatchedWhitelist
 6XXX: DialError
 7XXX: APIClientError
     7100: AuthenticationFailure

--- a/errors/error.go
+++ b/errors/error.go
@@ -149,6 +149,8 @@ const (
 
 	// UnknownProfile indicates that the profile does not exist.
 	UnknownProfile // 54XX
+
+	UnmatchedWhitelist // 55xx
 )
 
 // The following are API client related errors, and should be
@@ -313,6 +315,8 @@ func New(category Category, reason Reason) *Error {
 			msg = "Policy violation request"
 		case UnknownProfile:
 			msg = "Unknown policy profile"
+		case UnmatchedWhitelist:
+			msg = "Request does not match policy whitelist"
 		default:
 			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category PolicyError.",
 				reason))

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -272,17 +272,17 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 	if profile.NameWhitelist != nil {
 		if safeTemplate.Subject.CommonName != "" {
 			if profile.NameWhitelist.Find([]byte(safeTemplate.Subject.CommonName)) == nil {
-				return nil, cferr.New(cferr.PolicyError, cferr.InvalidPolicy)
+				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
 			}
 		}
 		for _, name := range safeTemplate.DNSNames {
 			if profile.NameWhitelist.Find([]byte(name)) == nil {
-				return nil, cferr.New(cferr.PolicyError, cferr.InvalidPolicy)
+				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
 			}
 		}
 		for _, name := range safeTemplate.EmailAddresses {
 			if profile.NameWhitelist.Find([]byte(name)) == nil {
-				return nil, cferr.New(cferr.PolicyError, cferr.InvalidPolicy)
+				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
 			}
 		}
 	}


### PR DESCRIPTION
I was working on a config with a name_whitelist and got a bunch of invalid policy errors. It was only when I ended up removing the whitelist that I realized what the error was. I found where the error was originally thrown and added a new error code and message specifically for whitelist errors.. 