### PR TITLE
test: allow to run tests on the machine without proper go env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/*
 cli/serve/static.rice-box.go
 .coverprofile
 certdb/testdb/certstore_development.db
+gopath

--- a/test.sh
+++ b/test.sh
@@ -20,17 +20,23 @@ fi
 
 ls "${GOPATH}/src/${REPO_PATH}"
 
-PACKAGES=$(go list ./... | grep -v /vendor/ | grep ^_)
-
-# Escape current cirectory
-CDIR_ESC=$(printf "%q" "$CDIR/")
-# Remove current directory from the package path
-PACKAGES=${PACKAGES//$CDIR_ESC/}
-# Remove underscores
-PACKAGES=${PACKAGES//_/}
-# split PACKAGES into an array and prepend REPO_PATH to each local package
-split=(${PACKAGES// / })
-PACKAGES=${split[@]/#/${REPO_PATH}/}
+PACKAGES=""
+if [ "$#" != 0 ]; then
+    for pkg in "$@"; do
+        PACKAGES="$PACKAGES $REPO_PATH/$pkg"
+    done
+else
+    PACKAGES=$(go list ./... | grep -v /vendor/ | grep ^_)
+    # Escape current cirectory
+    CDIR_ESC=$(printf "%q" "$CDIR/")
+    # Remove current directory from the package path
+    PACKAGES=${PACKAGES//$CDIR_ESC/}
+    # Remove underscores
+    PACKAGES=${PACKAGES//_/}
+    # split PACKAGES into an array and prepend REPO_PATH to each local package
+    split=(${PACKAGES// / })
+    PACKAGES=${split[@]/#/${REPO_PATH}/}
+fi
 
 go vet $PACKAGES
 if ! which fgt > /dev/null ; then


### PR DESCRIPTION
Now all you need are only go and gofmt binaries.

Before `test.sh` failed with the following msg:

```
$ ./test.sh 
ls: cannot access /src/github.com/cloudflare/cfssl: No such file or directory
```

And even with the GOPATH:

```
$ ./test.sh 
api          cli     Dockerfile          initca     scan       ubiquity
auth         cmd     Dockerfile.build    LICENSE    script     vendor
BUILDING.md  config  Dockerfile.minimal  log        selfsign   whitelist
bundler      crl     errors              multiroot  signer
certdb       crypto  gopath              ocsp       testdata
certinfo     csr     helpers             README.md  test.sh
CHANGELOG    doc     info                revoke     transport
can't load package: package _/home/user/git/cfssl/api: cannot find package "_/home/user/git/cfssl/api" in any of:
        /home/user/go/src/_/home/user/git/cfssl/api (from $GOROOT)
        /home/user/git/cfssl/gopath/src/_/home/user/git/cfssl/api (from $GOPATH)
can't load package: package _/home/user/git/cfssl/api/bundle: cannot find package "_/home/user/git/cfssl/api/bundle" in any of:
        /home/user/go/src/_/home/user/git/cfssl/api/bundle (from $GOROOT)
        /home/user/git/cfssl/gopath/src/_/home/user/git/cfssl/api/bundle (from $GOPATH)
```