### PR TITLE
Added "parseTime=true" to query string in example MySQL db-config fil…

### DIFF
--- a/certdb/README.md
+++ b/certdb/README.md
@@ -72,4 +72,4 @@ or
  
 or
 
-    {"driver":"mysql","data_source":"user:password@tcp(hostname:3306)/db"}
+    {"driver":"mysql","data_source":"user:password@tcp(hostname:3306)/db?parseTime=true"}


### PR DESCRIPTION
Adds "parseTime=true" query string parameter to example MySQL db-config file, for reasons described here: https://github.com/go-sql-driver/mysql#timetime-support (and as already done in the mysql/dbconf.yml and testdb.go) #636