### PR TITLE
update Dockerfile.minimal to use alpine 3.4 (and go 1.6)

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.4
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go


### PR DESCRIPTION
The alpine-based minimal docker image has been broken since 0d7ae8e.
That commit removed Godep-based dependency management favor of go
1.5/1.6 vendoring. This commit moves the base alpine image forward to
3.4 which includes go 1.6.3. The resulting image of 0d7ae8e^ grows from
66 MB to 73 MB.