### PR TITLE
Push minimum requirement to Go 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-  - 1.5
   - 1.6
+  - 1.7
 # Install g++-4.8 to support std=c++11 for github.com/google/certificate-transparency/go/merkletree
 addons:
   apt:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,10 +26,12 @@ build programs without PKCS #11.
 
 The requirements to build without Docker are:
 
-1. Go version 1.5 is the minimum required version of Go.
+1. Go version 1.5 is the minimum required version of Go. However, only Go 1.6+
+   is supported due to the test system not supporting Go 1.5.
 2. A properly configured go environment
 3. A properly configured GOPATH
-4. With Go 1.5, you are required to set the environment variable `GO15VENDOREXPERIMENT=1`
+4. With Go 1.5, you are required to set the environment variable
+   `GO15VENDOREXPERIMENT=1`.
 
 Run:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 CFSSL is CloudFlare's PKI/TLS swiss army knife. It is both a command line
 tool and an HTTP API server for signing, verifying, and bundling TLS
-certificates. It requires Go 1.5+ to build.
+certificates. It requires Go 1.6+ to build.
 
 Note that certain linux distributions have certain algorithms removed
 (RHEL-based distributions in particular), so the golang from the
@@ -34,7 +34,7 @@ See [BUILDING](BUILDING.md)
 ### Installation
 
 Installation requires a
-[working Go 1.5+ installation](http://golang.org/doc/install) and a
+[working Go 1.6+ installation](http://golang.org/doc/install) and a
 properly set `GOPATH`.
 
 ```
@@ -52,7 +52,7 @@ $ go get -u github.com/cloudflare/cfssl/cmd/...
 This will download, build, and install `cfssl`, `cfssljson`, and
 `mkbundle` into `$GOPATH/bin/`.
 
-Note that CFSSL makes use of vendored packages; in Go 1.5, the
+Note that CFSSL makes use of vendored packages; in Go 1.6, the
 `GO15VENDOREXPERIMENT` environment variable will need to be set, e.g.
 
 ```
@@ -61,8 +61,16 @@ export GO15VENDOREXPERIMENT=1
 
 In Go 1.6, this works out of the box.
 
-#### Installing pre-Go 1.5
-With a Go 1.4 or earlier installation, you won't be able to install the latest version of CFSSL. However, you can checkout the `1.1.0` release and build that.
+#### Installing pre-Go 1.6
+
+With a Go 1.5 installation, CFSSL will still probably build. However,
+the test system uses [`golint`](https://github.com/golang/lint), which
+no longer works on Go 1.5. As our test suite can't cover Go 1.5 anymore,
+we no longer support it.
+
+With a Go 1.4 or earlier installation, you won't be able to install the
+latest version of CFSSL. However, you can checkout the `1.1.0` release
+and build that.
 
 ```
 git clone -b 1.1.0 https://github.com/cloudflare/cfssl.git $GOPATH/src/github.com/cloudflare/cfssl


### PR DESCRIPTION
golint requires a minimum of Go 1.6; this means we can't successfully
test changes on Go 1.5 without additional work and therefore can't
reliably support Go 1.5.