### PR TITLE
Fix time argument parsing for gencrl

### DIFF
--- a/cli/gencrl/gencrl.go
+++ b/cli/gencrl/gencrl.go
@@ -16,7 +16,7 @@ Arguments:
         INPUTFILE:               Text file with one serial number per line, use '-' for reading text from stdin
         CERT:                    The certificate that is signing this CRL, use '-' for reading text from stdin
         KEY:                     The private key of the certificate that is signing the CRL, use '-' for reading text from stdin
-        TIME (OPTIONAL):         The desired expiration from now, in seconds, use '-' for reading text from stdin
+        TIME (OPTIONAL):         The desired expiration from now, in seconds
 
 Flags:
 `
@@ -62,12 +62,7 @@ func gencrlMain(args []string, c cli.Config) (err error) {
 			return err
 		}
 
-		timeBytes, err := cli.ReadStdin(timeArg)
-		if err != nil {
-			return err
-		}
-
-		timeString = string(timeBytes)
+		timeString = string(timeArg)
 
 		// This is used to get rid of newlines
 		timeString = strings.TrimSpace(timeString)

--- a/cli/gencrl/gencrl_test.go
+++ b/cli/gencrl/gencrl_test.go
@@ -16,3 +16,10 @@ func TestGencrl(t *testing.T) {
 	}
 
 }
+
+func TestGencrlTime(t *testing.T) {
+	err := gencrlMain([]string{"testdata/serialList", "testdata/caTwo.pem", "testdata/ca-keyTwo.pem", "123"}, cli.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
> Usage of gencrl:
>         cfssl gencrl INPUTFILE CERT KEY TIME
> 
> Arguments:
>         ...
>         TIME (OPTIONAL):         The desired expiration from now, in seconds

This PR uses the time argument as a string (as expected from the usage). The current code takes the time arg and uses it as a file name to read from.

Eg:
PR: `./cfssl gencrl serials.txt cert.pem key.pem 86400`
Current: `./cfssl gencrl serials.txt cert.pem key.pem time.txt` where time.txt has contents '86400'.
