### PR TITLE
Making extensibility changes for endpoints and request modification

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,8 +34,8 @@ func (f HandlerFunc) Handle(w http.ResponseWriter, r *http.Request) error {
 	return f(w, r)
 }
 
-// handleError is the centralised error handling and reporting.
-func handleError(w http.ResponseWriter, err error) (code int) {
+// HandleError is the centralised error handling and reporting.
+func HandleError(w http.ResponseWriter, err error) (code int) {
 	if err == nil {
 		return http.StatusOK
 	}
@@ -82,7 +82,7 @@ func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		err = errors.NewMethodNotAllowed(r.Method)
 	}
-	status := handleError(w, err)
+	status := HandleError(w, err)
 	log.Infof("%s - \"%s %s\" %d", r.RemoteAddr, r.Method, r.URL, status)
 }
 

--- a/api/client/group.go
+++ b/api/client/group.go
@@ -3,6 +3,7 @@ package client
 import (
 	"crypto/tls"
 	"errors"
+	"net/http"
 	"strings"
 
 	"github.com/cloudflare/cfssl/auth"
@@ -109,4 +110,9 @@ func (g *orderedListGroup) Info(jsonData []byte) (resp *info.Resp, err error) {
 	}
 
 	return nil, err
+}
+
+// SetReqModifier does nothing because there is no request modifier for group
+func (g *orderedListGroup) SetReqModifier(mod func(*http.Request, []byte)) {
+	// noop
 }

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -207,15 +207,18 @@ var endpoints = map[string]func() (http.Handler, error){
 // registerHandlers instantiates various handlers and associate them to corresponding endpoints.
 func registerHandlers() {
 	for path, getHandler := range endpoints {
-		path = v1APIPath(path)
-		log.Infof("Setting up '%s' endpoint", path)
+		log.Debugf("getHandler for %s", path)
 		if handler, err := getHandler(); err != nil {
 			log.Warningf("endpoint '%s' is disabled: %v", path, err)
 		} else {
-			http.Handle(path, handler)
+			if path, handler, err = wrapHandler(path, handler, err); err != nil {
+				log.Warningf("endpoint '%s' is disabled by wrapper: %v", path, err)
+			} else {
+				log.Infof("endpoint '%s' is enabled", path)
+				http.Handle(path, handler)
+			}
 		}
 	}
-
 	log.Info("Handler set up complete.")
 }
 
@@ -302,3 +305,22 @@ func serverMain(args []string, c cli.Config) error {
 
 // Command assembles the definition of Command 'serve'
 var Command = &cli.Command{UsageText: serverUsageText, Flags: serverFlags, Main: serverMain}
+
+var wrapHandler = defaultWrapHandler
+
+// The default wrapper simply returns the normal handler and prefixes the path appropriately
+func defaultWrapHandler(path string, handler http.Handler, err error) (string, http.Handler, error) {
+	return v1APIPath(path), handler, err
+}
+
+// SetWrapHandler sets the wrap handler which is called for all endpoints
+// A custom wrap handler may be provided in order to add arbitrary server-side pre or post processing
+// of server-side HTTP handling of requests.
+func SetWrapHandler(wh func(path string, handler http.Handler, err error) (string, http.Handler, error)) {
+	wrapHandler = wh
+}
+
+// SetEndpoint can be used to add additional routes/endpoints to the HTTP server, or to override an existing route/endpoint
+func SetEndpoint(path string, getHandler func() (http.Handler, error)) {
+	endpoints[path] = getHandler
+}

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"net/http"
 	"net/mail"
 	"os"
 
@@ -28,8 +29,6 @@ import (
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
-	"github.com/google/certificate-transparency/go/jsonclient"
-	"golang.org/x/net/context"
 )
 
 // Signer contains a signer that uses the standard library to
@@ -354,12 +353,9 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 
 		for _, server := range profile.CTLogServers {
 			log.Infof("submitting poisoned precertificate to %s", server)
-			ctclient, err := client.New(server, nil, jsonclient.Options{})
-			if err != nil {
-				return nil, cferr.Wrap(cferr.CTError, cferr.CTClientConstructionFailed, err)
-			}
+			var ctclient = client.New(server, nil)
 			var resp *ct.SignedCertificateTimestamp
-			resp, err = ctclient.AddPreChain(context.TODO(), prechain)
+			resp, err = ctclient.AddPreChain(prechain)
 			if err != nil {
 				return nil, cferr.Wrap(cferr.CTError, cferr.PrecertSubmissionFailed, err)
 			}
@@ -466,6 +462,11 @@ func (s *Signer) SetPolicy(policy *config.Signing) {
 // SetDBAccessor sets the signers' cert db accessor
 func (s *Signer) SetDBAccessor(dba certdb.Accessor) {
 	s.dbAccessor = dba
+}
+
+// SetReqModifier does nothing for local
+func (s *Signer) SetReqModifier(func(*http.Request, []byte)) {
+	// noop
 }
 
 // Policy returns the signer's policy.

--- a/signer/remote/remote.go
+++ b/signer/remote/remote.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"net/http"
 
 	"github.com/cloudflare/cfssl/api/client"
 	"github.com/cloudflare/cfssl/certdb"
@@ -17,7 +18,8 @@ import (
 // A Signer represents a CFSSL instance running as signing server.
 // fulfills the signer.Signer interface
 type Signer struct {
-	policy *config.Signing
+	policy      *config.Signing
+	reqModifier func(*http.Request, []byte)
 }
 
 // NewSigner creates a new remote Signer directly from a
@@ -81,6 +83,8 @@ func (s *Signer) remoteOp(req interface{}, profile, target string) (resp interfa
 			errors.New("failed to connect to remote"))
 	}
 
+	server.SetReqModifier(s.reqModifier)
+
 	// There's no auth provider for the "info" method
 	if target == "info" {
 		resp, err = server.Info(jsonData)
@@ -111,6 +115,11 @@ func (s *Signer) SetPolicy(policy *config.Signing) {
 // SetDBAccessor sets the signers' cert db accessor
 func (s *Signer) SetDBAccessor(dba certdb.Accessor) {
 	// noop
+}
+
+// SetReqModifier sets the function to call to modify the HTTP request prior to sending it
+func (s *Signer) SetReqModifier(mod func(*http.Request, []byte)) {
+	s.reqModifier = mod
 }
 
 // Policy returns the signer's policy.

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -12,6 +12,7 @@ import (
 	"encoding/asn1"
 	"errors"
 	"math/big"
+	"net/http"
 	"strings"
 	"time"
 
@@ -99,6 +100,7 @@ type Signer interface {
 	SetPolicy(*config.Signing)
 	SigAlgo() x509.SignatureAlgorithm
 	Sign(req SignRequest) (cert []byte, err error)
+	SetReqModifier(func(*http.Request, []byte))
 }
 
 // Profile gets the specific profile from the signer

--- a/signer/universal/universal.go
+++ b/signer/universal/universal.go
@@ -3,6 +3,7 @@ package universal
 
 import (
 	"crypto/x509"
+	"net/http"
 
 	"github.com/cloudflare/cfssl/certdb"
 	"github.com/cloudflare/cfssl/config"
@@ -185,6 +186,12 @@ func (s *Signer) Info(req info.Req) (resp *info.Resp, err error) {
 func (s *Signer) SetDBAccessor(dba certdb.Accessor) {
 	s.local.SetDBAccessor(dba)
 	s.remote.SetDBAccessor(dba)
+}
+
+// SetReqModifier sets the function to call to modify the HTTP request prior to sending it
+func (s *Signer) SetReqModifier(mod func(*http.Request, []byte)) {
+	s.local.SetReqModifier(mod)
+	s.remote.SetReqModifier(mod)
 }
 
 // SigAlgo returns the RSA signer's signature algorithm.


### PR DESCRIPTION
These modifications allow CFSSL to be extended with respect to:
1) adding new endpoints to the CFSSL server;
2) wrappering endpoint handling to give both pre and post
   processing control;
3) performing request modification for such things as additional
   headers to outgoing requests.

See issue #692