### PR TITLE
MySQL: Certificate Serial Number should be 128 in length.

### DIFF
--- a/certdb/mysql/migrations/001_CreateCertificates.sql
+++ b/certdb/mysql/migrations/001_CreateCertificates.sql
@@ -2,7 +2,7 @@
 -- SQL in section 'Up' is executed when this migration is applied
 
 CREATE TABLE certificates (
-  serial_number            varbinary(20)  NOT NULL,
+  serial_number            varbinary(128) NOT NULL,
   authority_key_identifier varbinary(128) NOT NULL,
   ca_label                 varbinary(128),
   status                   varbinary(128) NOT NULL,


### PR DESCRIPTION
Modified previous migration as per @lziest suggestion.

Fixes #703