### PR TITLE
Add API and CLI methods for generating CRL from local DB

### DIFF
--- a/api/crl/crl.go
+++ b/api/crl/crl.go
@@ -1,0 +1,94 @@
+// Package crl implements the HTTP handler for the crl command.
+package crl
+
+import (
+	"crypto"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/certdb"
+	"github.com/cloudflare/cfssl/crl"
+	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
+)
+
+// A Handler accepts requests with a serial number parameter
+// and revokes
+type Handler struct {
+	dbAccessor certdb.Accessor
+	ca         *x509.Certificate
+	key        crypto.Signer
+}
+
+// NewHandler returns a new http.Handler that handles a revoke request.
+func NewHandler(dbAccessor certdb.Accessor, caPath string, caKeyPath string) (http.Handler, error) {
+	ca, err := ioutil.ReadFile(caPath)
+	if err != nil {
+		return nil, err
+	}
+
+	caKey, err := ioutil.ReadFile(caKeyPath)
+	if err != nil {
+		return nil, errors.Wrap(errors.PrivateKeyError, errors.ReadFailed, err)
+	}
+
+	// Parse the PEM encoded certificate
+	issuerCert, err := helpers.ParseCertificatePEM(ca)
+	if err != nil {
+		return nil, err
+	}
+
+	strPassword := os.Getenv("CFSSL_CA_PK_PASSWORD")
+	password := []byte(strPassword)
+	if strPassword == "" {
+		password = nil
+	}
+
+	// Parse the key given
+	key, err := helpers.ParsePrivateKeyPEMWithPassword(caKey, password)
+	if err != nil {
+		log.Debug("malformed private key %v", err)
+		return nil, err
+	}
+
+	return &api.HTTPHandler{
+		Handler: &Handler{
+			dbAccessor: dbAccessor,
+			ca:         issuerCert,
+			key:        key,
+		},
+		Methods: []string{"GET"},
+	}, nil
+}
+
+// Handle responds to revocation requests. It attempts to revoke
+// a certificate with a given serial number
+func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
+	var newExpiryTime = 7 * helpers.OneDay
+
+	certs, err := h.dbAccessor.GetRevokedAndUnexpiredCertificates()
+	if err != nil {
+		return err
+	}
+
+	queryExpiryTime := r.URL.Query().Get("expiry")
+	if queryExpiryTime != "" {
+		log.Infof("requested expiry time of %s", queryExpiryTime)
+		newExpiryTime, err = time.ParseDuration(queryExpiryTime)
+		if err != nil {
+			return err
+		}
+	}
+
+	result, err := crl.NewCRLFromDB(certs, h.ca, h.key, newExpiryTime)
+	if err != nil {
+		return err
+	}
+
+	return api.SendResponse(w, result)
+}

--- a/api/crl/crl_test.go
+++ b/api/crl/crl_test.go
@@ -1,0 +1,149 @@
+package crl
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/certdb"
+	"github.com/cloudflare/cfssl/certdb/sql"
+	"github.com/cloudflare/cfssl/certdb/testdb"
+	"github.com/cloudflare/cfssl/helpers"
+)
+
+const (
+	fakeAKI       = "fake aki"
+	testCaFile    = "../testdata/ca.pem"
+	testCaKeyFile = "../testdata/ca_key.pem"
+)
+
+func prepDB() (certdb.Accessor, error) {
+	db := testdb.SQLiteDB("../../certdb/testdb/certstore_development.db")
+	expirationTime := time.Now().AddDate(1, 0, 0)
+	var cert = certdb.CertificateRecord{
+		Serial:    "1",
+		AKI:       fakeAKI,
+		Expiry:    expirationTime,
+		PEM:       "revoked cert",
+		Status:    "revoked",
+		RevokedAt: time.Now(),
+		Reason:    4,
+	}
+
+	dbAccessor := sql.NewAccessor(db)
+	err := dbAccessor.InsertCertificate(cert)
+	if err != nil {
+		return nil, err
+	}
+
+	return dbAccessor, nil
+}
+
+func testGetCRL(t *testing.T, dbAccessor certdb.Accessor, expiry string) (resp *http.Response, body []byte) {
+	handler, err := NewHandler(dbAccessor, testCaFile, testCaKeyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	if expiry != "" {
+		resp, err = http.Get(ts.URL + "?expiry=" + expiry)
+	} else {
+		resp, err = http.Get(ts.URL)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+func TestCRLGeneration(t *testing.T) {
+	dbAccessor, err := prepDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, body := testGetCRL(t, dbAccessor, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("unexpected HTTP status code; expected OK", string(body))
+	}
+	message := new(api.Response)
+	err = json.Unmarshal(body, message)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	crlBytes := message.Result.(string)
+	crlBytesDER, err := base64.StdEncoding.DecodeString(crlBytes)
+	if err != nil {
+		t.Fatal("failed to decode certificate ", err)
+	}
+	parsedCrl, err := x509.ParseCRL(crlBytesDER)
+	if err != nil {
+		t.Fatal("failed to get certificate ", err)
+	}
+	if parsedCrl.HasExpired(time.Now().Add(5 * helpers.OneDay)) {
+		t.Fatal("the request will expire after 5 days, this shouldn't happen")
+	}
+	certs := parsedCrl.TBSCertList.RevokedCertificates
+	if len(certs) != 1 {
+		t.Fatal("failed to get one certificate")
+	}
+
+	cert := certs[0]
+
+	if cert.SerialNumber.String() != "1" {
+		t.Fatal("cert was not correctly inserted in CRL, serial was ", cert.SerialNumber)
+	}
+}
+
+func TestCRLGenerationWithExpiry(t *testing.T) {
+	dbAccessor, err := prepDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, body := testGetCRL(t, dbAccessor, "119h")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("unexpected HTTP status code; expected OK", string(body))
+	}
+	message := new(api.Response)
+	err = json.Unmarshal(body, message)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	crlBytes := message.Result.(string)
+	crlBytesDER, err := base64.StdEncoding.DecodeString(crlBytes)
+	if err != nil {
+		t.Fatal("failed to decode certificate ", err)
+	}
+	parsedCrl, err := x509.ParseCRL(crlBytesDER)
+	if err != nil {
+		t.Fatal("failed to get certificate ", err)
+	}
+	if !parsedCrl.HasExpired(time.Now().Add(5 * helpers.OneDay)) {
+		t.Fatal("the request should have expired")
+	}
+	certs := parsedCrl.TBSCertList.RevokedCertificates
+	if len(certs) != 1 {
+		t.Fatal("failed to get one certificate")
+	}
+
+	cert := certs[0]
+
+	if cert.SerialNumber.String() != "1" {
+		t.Fatal("cert was not correctly inserted in CRL, serial was ", cert.SerialNumber)
+	}
+}

--- a/api/gencrl/gencrl.go
+++ b/api/gencrl/gencrl.go
@@ -1,5 +1,5 @@
-// Package crl implements the HTTP handler for the crl commands.
-package crl
+// Package gencrl implements the HTTP handler for the gencrl commands.
+package gencrl
 
 import (
 	"crypto/rand"
@@ -27,8 +27,7 @@ type jsonCRLRequest struct {
 
 // Handle responds to requests for crl generation. It creates this crl
 // based off of the given certificate, serial numbers, and private key
-func crlHandler(w http.ResponseWriter, r *http.Request) error {
-
+func gencrlHandler(w http.ResponseWriter, r *http.Request) error {
 	var revokedCerts []pkix.RevokedCertificate
 	var oneWeek = time.Duration(604800) * time.Second
 	var newExpiryTime = time.Now()
@@ -40,7 +39,6 @@ func crlHandler(w http.ResponseWriter, r *http.Request) error {
 	r.Body.Close()
 
 	req := &jsonCRLRequest{}
-
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		log.Error(err)
@@ -66,8 +64,8 @@ func crlHandler(w http.ResponseWriter, r *http.Request) error {
 
 	cert, err := helpers.ParseCertificatePEM([]byte(req.Certificate))
 	if err != nil {
-		log.Error("Error from ParseCertificatePEM", err)
-		return errors.NewBadRequestString("Malformed certificate")
+		log.Error("error from ParseCertificatePEM", err)
+		return errors.NewBadRequestString("malformed certificate")
 	}
 
 	for _, value := range req.SerialNumber {
@@ -82,13 +80,13 @@ func crlHandler(w http.ResponseWriter, r *http.Request) error {
 
 	key, err := helpers.ParsePrivateKeyPEM([]byte(req.PrivateKey))
 	if err != nil {
-		log.Debug("Malformed private key %v", err)
-		return errors.NewBadRequestString("Malformed Private Key")
+		log.Debug("malformed private key %v", err)
+		return errors.NewBadRequestString("malformed Private Key")
 	}
 
 	result, err := cert.CreateCRL(rand.Reader, key, revokedCerts, time.Now(), newExpiryTime)
 	if err != nil {
-		log.Debug("Unable to create CRL: %v", err)
+		log.Debug("unable to create CRL: %v", err)
 		return err
 	}
 
@@ -98,7 +96,7 @@ func crlHandler(w http.ResponseWriter, r *http.Request) error {
 // NewHandler returns a new http.Handler that handles a crl generation request.
 func NewHandler() http.Handler {
 	return api.HTTPHandler{
-		Handler: api.HandlerFunc(crlHandler),
+		Handler: api.HandlerFunc(gencrlHandler),
 		Methods: []string{"POST"},
 	}
 }

--- a/api/gencrl/gencrl_test.go
+++ b/api/gencrl/gencrl_test.go
@@ -1,4 +1,4 @@
-package crl
+package gencrl
 
 import (
 	"bytes"
@@ -49,7 +49,6 @@ func newCRLServer(t *testing.T) *httptest.Server {
 }
 
 func testCRLCreation(t *testing.T, issuingKey, certFile string, expiry string, serialList []string) (resp *http.Response, body []byte) {
-
 	ts := newCRLServer(t)
 	defer ts.Close()
 

--- a/certdb/certdb.go
+++ b/certdb/certdb.go
@@ -31,6 +31,7 @@ type Accessor interface {
 	InsertCertificate(cr CertificateRecord) error
 	GetCertificate(serial, aki string) ([]CertificateRecord, error)
 	GetUnexpiredCertificates() ([]CertificateRecord, error)
+	GetRevokedAndUnexpiredCertificates() ([]CertificateRecord, error)
 	RevokeCertificate(serial, aki string, reasonCode int) error
 	InsertOCSP(rr OCSPRecord) error
 	GetOCSP(serial, aki string) ([]OCSPRecord, error)

--- a/cli/config.go
+++ b/cli/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	CNOverride        string
 	AKI               string
 	DBConfigFile      string
+	CRLExpiration     time.Duration
 }
 
 // registerFlags defines all cfssl command flags and associates their values with variables.
@@ -125,6 +126,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.CNOverride, "cn", "", "certificate common name (CN)")
 	f.StringVar(&c.AKI, "aki", "", "certificate issuer (authority) key identifier")
 	f.StringVar(&c.DBConfigFile, "db-config", "", "certificate db configuration file")
+	f.DurationVar(&c.CRLExpiration, "expiry", 7*helpers.OneDay, "time from now after which the CRL will expire (default: one week)")
 	f.IntVar(&log.Level, "loglevel", log.LevelInfo, "Log level (0 = DEBUG, 5 = FATAL)")
 }
 

--- a/cli/crl/crl.go
+++ b/cli/crl/crl.go
@@ -1,0 +1,97 @@
+//Package crl implements the crl command
+package crl
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/cloudflare/cfssl/certdb/dbconf"
+	certsql "github.com/cloudflare/cfssl/certdb/sql"
+	"github.com/cloudflare/cfssl/cli"
+	"github.com/cloudflare/cfssl/crl"
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var crlUsageText = `cfssl crl -- generate a new Certificate Revocation List from Database
+
+Usage of crl:
+        cfssl crl
+
+Flags:
+`
+var crlFlags = []string{"db-config", "ca", "ca-key", "expiry"}
+
+func crlMain(args []string, c cli.Config) (err error) {
+	if c.CAFile == "" {
+		log.Error("need CA certificate (provide one with -ca)")
+		return
+	}
+
+	if c.CAKeyFile == "" {
+		log.Error("need CA key (provide one with -ca-key)")
+		return
+	}
+
+	var db *sqlx.DB
+	if c.DBConfigFile != "" {
+		db, err = dbconf.DBFromConfig(c.DBConfigFile)
+		if err != nil {
+			return
+		}
+	} else {
+		log.Error("no Database specified!")
+		return
+	}
+
+	dbAccessor := certsql.NewAccessor(db)
+
+	log.Debug("loading CA: ", c.CAFile)
+	ca, err := ioutil.ReadFile(c.CAFile)
+	if err != nil {
+		return err
+	}
+	log.Debug("loading CA key: ", c.CAKeyFile)
+	cakey, err := ioutil.ReadFile(c.CAKeyFile)
+	if err != nil {
+		return cferr.Wrap(cferr.CertificateError, cferr.ReadFailed, err)
+	}
+
+	// Parse the PEM encoded certificate
+	issuerCert, err := helpers.ParseCertificatePEM(ca)
+	if err != nil {
+		return nil, err
+	}
+
+	strPassword := os.Getenv("CFSSL_CA_PK_PASSWORD")
+	password := []byte(strPassword)
+	if strPassword == "" {
+		password = nil
+	}
+
+	// Parse the key given
+	key, err := helpers.ParsePrivateKeyPEMWithPassword(cakey, password)
+	if err != nil {
+		log.Debug("malformed private key %v", err)
+		return nil, err
+	}
+
+	certs, err := dbAccessor.GetRevokedAndUnexpiredCertificates()
+	if err != nil {
+		return err
+	}
+
+	req, err := crl.NewCRLFromDB(certs, issuerCert, key, c.CRLExpiration)
+	if err != nil {
+		return
+	}
+
+	cli.PrintCRL(req)
+	return nil
+}
+
+// Command assembles the definition of Command 'crl'
+var Command = &cli.Command{UsageText: crlUsageText, Flags: crlFlags, Main: crlMain}

--- a/cli/crl/crl_test.go
+++ b/cli/crl/crl_test.go
@@ -1,0 +1,91 @@
+package crl
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/cfssl/certdb"
+	"github.com/cloudflare/cfssl/certdb/sql"
+	"github.com/cloudflare/cfssl/certdb/testdb"
+	"github.com/cloudflare/cfssl/cli"
+	"github.com/cloudflare/cfssl/helpers"
+)
+
+var dbAccessor certdb.Accessor
+
+const (
+	fakeAKI       = "fake aki"
+	testCaFile    = "../testdata/ca.pem"
+	testCaKeyFile = "../testdata/ca-key.pem"
+)
+
+func prepDB() (err error) {
+	db := testdb.SQLiteDB("../../certdb/testdb/certstore_development.db")
+	expirationTime := time.Now().AddDate(1, 0, 0)
+	var cert = certdb.CertificateRecord{
+		Serial:    "1",
+		AKI:       fakeAKI,
+		Expiry:    expirationTime,
+		PEM:       "revoked cert",
+		Status:    "revoked",
+		RevokedAt: time.Now(),
+		Reason:    4,
+	}
+
+	dbAccessor = sql.NewAccessor(db)
+	err = dbAccessor.InsertCertificate(cert)
+	if err != nil {
+		return err
+	}
+
+	return
+}
+
+func verifyCRL(t *testing.T, crlBytesDER []byte, serial string, expireAfter time.Duration) {
+	parsedCrl, err := x509.ParseCRL(crlBytesDER)
+	if err != nil {
+		t.Fatal("failed to get certificate ", err)
+	}
+	if !parsedCrl.HasExpired(time.Now().Add(expireAfter)) {
+		t.Fatal("the CRL should have expired")
+	}
+	certs := parsedCrl.TBSCertList.RevokedCertificates
+	if len(certs) != 1 {
+		t.Fatal("failed to get one certificate")
+	}
+
+	cert := certs[0]
+
+	if cert.SerialNumber.String() != serial {
+		t.Fatal("cert was not correctly inserted in CRL, serial was " + cert.SerialNumber.String())
+	}
+}
+
+func TestRevokeMain(t *testing.T) {
+	err := prepDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	crlBytes, err := generateCRL(cli.Config{CAFile: testCaFile, CAKeyFile: testCaKeyFile, DBConfigFile: "../testdata/db-config.json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifyCRL(t, crlBytes, "1", 7*helpers.OneDay+time.Second)
+}
+
+func TestRevokeExpiry(t *testing.T) {
+	err := prepDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	crlBytes, err := generateCRL(cli.Config{CAFile: testCaFile, CAKeyFile: testCaKeyFile, DBConfigFile: "../testdata/db-config.json", CRLExpiration: 23 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifyCRL(t, crlBytes, "1", 23*time.Hour+time.Second)
+}

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cloudflare/cfssl/api"
 	"github.com/cloudflare/cfssl/api/bundle"
 	"github.com/cloudflare/cfssl/api/certinfo"
-	"github.com/cloudflare/cfssl/api/crl"
+	"github.com/cloudflare/cfssl/api/gencrl"
 	"github.com/cloudflare/cfssl/api/generator"
 	"github.com/cloudflare/cfssl/api/info"
 	"github.com/cloudflare/cfssl/api/initca"
@@ -140,7 +140,7 @@ var endpoints = map[string]func() (http.Handler, error){
 		if s == nil {
 			return nil, errBadSigner
 		}
-		return crl.NewHandler(), nil
+		return gencrl.NewHandler(), nil
 	},
 
 	"newcert": func() (http.Handler, error) {

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cloudflare/cfssl/api"
 	"github.com/cloudflare/cfssl/api/bundle"
 	"github.com/cloudflare/cfssl/api/certinfo"
+	"github.com/cloudflare/cfssl/api/crl"
 	"github.com/cloudflare/cfssl/api/gencrl"
 	"github.com/cloudflare/cfssl/api/generator"
 	"github.com/cloudflare/cfssl/api/info"
@@ -134,6 +135,18 @@ var endpoints = map[string]func() (http.Handler, error){
 			return nil, errBadSigner
 		}
 		return info.NewHandler(s)
+	},
+
+	"crl": func() (http.Handler, error) {
+		if s == nil {
+			return nil, errBadSigner
+		}
+
+		if db == nil {
+			return nil, errNoCertDBConfigured
+		}
+
+		return crl.NewHandler(certsql.NewAccessor(db), conf.CAFile, conf.CAKeyFile)
 	},
 
 	"gencrl": func() (http.Handler, error) {

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -38,6 +38,7 @@ func TestServe(t *testing.T) {
 	expected[v1APIPath("newcert")] = http.StatusNotFound
 	expected[v1APIPath("info")] = http.StatusNotFound
 	expected[v1APIPath("ocspsign")] = http.StatusNotFound
+	expected[v1APIPath("crl")] = http.StatusNotFound
 	expected[v1APIPath("gencrl")] = http.StatusNotFound
 	expected[v1APIPath("revoke")] = http.StatusNotFound
 

--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/cli/bundle"
 	"github.com/cloudflare/cfssl/cli/certinfo"
+	"github.com/cloudflare/cfssl/cli/crl"
 	"github.com/cloudflare/cfssl/cli/gencert"
 	"github.com/cloudflare/cfssl/cli/gencrl"
 	"github.com/cloudflare/cfssl/cli/genkey"
@@ -56,6 +57,7 @@ func main() {
 	cmds := map[string]*cli.Command{
 		"bundle":         bundle.Command,
 		"certinfo":       certinfo.Command,
+		"crl":            crl.Command,
 		"sign":           sign.Command,
 		"serve":          serve.Command,
 		"version":        version.Command,

--- a/doc/api/endpoint_crl.txt
+++ b/doc/api/endpoint_crl.txt
@@ -1,0 +1,18 @@
+THE CRL ENDPOINT
+
+Endpoint: /api/v1/cfssl/crl
+Method:   GET
+
+Optional URL Query parameters:
+
+    * expiry: a value, in seconds, after which the CRL should expire
+      from the moment of the request.
+
+Result:
+
+    The returned result is an empty JSON object
+
+Example:
+
+    $ curl ${CFSSL_HOST}/api/v1/cfssl/crl
+    $ curl ${CFSSL_HOST}/api/v1/cfssl/crl?expiry=7200h

--- a/doc/api/intro.txt
+++ b/doc/api/intro.txt
@@ -12,6 +12,7 @@ under the name `endpoint_<endpoint>`. These nine endpoints are:
 
       - authsign: authenticated signing endpoint
       - bundle: build certificate bundles
+      - crl: generates a CRL out of the certificate DB
       - info: obtain information about the CA, including the CA
         certificate
       - init_ca: initialise a new certificate authority


### PR DESCRIPTION
CFSSL is capable of generating CRLs, but mainly in a swiss army knife fashion. This PR enables CFSSL to generate a CRL out of its configured DB/CA, both in CLI and API Server mode.

TODO:

- [x] Unit Tests
- [x] Endpoint Documentation