### PR TITLE
README.md: Keep pre-1.6 Go information in same section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,19 @@ $ go get -u github.com/cloudflare/cfssl/cmd/...
 This will download, build, and install `cfssl`, `cfssljson`, and
 `mkbundle` into `$GOPATH/bin/`.
 
-Note that CFSSL makes use of vendored packages; in Go 1.6, the
-`GO15VENDOREXPERIMENT` environment variable will need to be set, e.g.
-
-```
-export GO15VENDOREXPERIMENT=1
-```
-
-In Go 1.6, this works out of the box.
-
 #### Installing pre-Go 1.6
 
 With a Go 1.5 installation, CFSSL will still probably build. However,
 the test system uses [`golint`](https://github.com/golang/lint), which
 no longer works on Go 1.5. As our test suite can't cover Go 1.5 anymore,
 we no longer support it.
+
+Note that CFSSL makes use of vendored packages; in Go 1.5, the
+`GO15VENDOREXPERIMENT` environment variable will need to be set, e.g.
+
+```
+export GO15VENDOREXPERIMENT=1
+```
 
 With a Go 1.4 or earlier installation, you won't be able to install the
 latest version of CFSSL. However, you can checkout the `1.1.0` release


### PR DESCRIPTION
Also fixes #686.