### PR TITLE
Fix 'too many open files' bug 

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -119,11 +119,11 @@ func (srv *server) post(url string, jsonData []byte) (*api.Response, error) {
 		err = fmt.Errorf("failed POST to %s: %v", url, err)
 		return nil, errors.Wrap(errors.APIClientError, errors.ClientHTTPError, err)
 	}
+	defer req.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(errors.APIClientError, errors.IOError, err)
 	}
-	resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Errorf("http error with %s", url)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -109,6 +109,7 @@ func (srv *server) post(url string, jsonData []byte) (*api.Response, error) {
 		err = fmt.Errorf("failed POST to %s: %v", url, err)
 		return nil, errors.Wrap(errors.APIClientError, errors.ClientHTTPError, err)
 	}
+	req.Close = true
 	req.Header.Set("content-type", "application/json")
 	if srv.reqModifier != nil {
 		srv.reqModifier(req, jsonData)

--- a/cmd/multirootca/api.go
+++ b/cmd/multirootca/api.go
@@ -102,12 +102,12 @@ func dispatchRequest(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		fail(w, req, http.StatusInternalServerError, 1, err.Error(), "while reading request body")
 		return
 	}
-	defer req.Body.Close()
 
 	var authReq auth.AuthenticatedRequest
 	err = json.Unmarshal(body, &authReq)


### PR DESCRIPTION
This fixes an issue with the `multirootca` that we were seeing in production.
Namely, when requesting a new cert roughly every 3 minutes after ~28 hours we would see failure of the CA with the following log output:
```
2017/01/06 22:39:34 http: Accept error: accept tcp [::]:443: accept4: too many open files; retrying in 1s
2017/01/06 22:39:35 http: Accept error: accept tcp [::]:443: accept4: too many open files; retrying in 1s
2017/01/06 22:39:36 http: Accept error: accept tcp [::]:443: accept4: too many open files; retrying in 1s
2017/01/06 22:39:37 http: Accept error: accept tcp [::]:443: accept4: too many open files; retrying in 1s
...
```

I wrote a test to verify this behavior, which can be seen here: https://gist.github.com/mrobinsn/c1b83bc17b879185b2ca1e7844c98da9
You can run the test by placing the file in `$GOPATH/src/github.com/cloudflare/cfssl/cmd/multirootca/` and then running `go test -v github.com/cloudflare/cfssl/cmd/multirootca`
I don't think this test necessarily belongs in the code base since it depends on your file descriptor limit. 

Here is the output of the test on my machine before the fix with `ulimit -n 10000`:
```
=== RUN   TestMultiRootCA
COMMAND     PID    USER   FD   TYPE   DEVICE SIZE/OFF     NODE NAME
multiroot 19521 michael    3u  IPv4 11175754      0t0      TCP localhost:40676 (LISTEN)
multiroot 19521 michael    5u  IPv4 11175755      0t0      TCP localhost:35535->localhost:40676 (ESTABLISHED)
multiroot 19521 michael    6u  IPv4 11175756      0t0      TCP localhost:40676->localhost:35535 (ESTABLISHED)
multiroot 19521 michael    7u  IPv4 11177812      0t0      TCP localhost:35536->localhost:40676 (ESTABLISHED)
multiroot 19521 michael    8u  IPv4 11172847      0t0      TCP localhost:40676->localhost:35536 (ESTABLISHED)
multiroot 19521 michael    9u  IPv4 11175758      0t0      TCP localhost:35537->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   10u  IPv4 11177813      0t0      TCP localhost:40676->localhost:35537 (ESTABLISHED)
multiroot 19521 michael   11u  IPv4 11179082      0t0      TCP localhost:35538->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   12u  IPv4 11179083      0t0      TCP localhost:40676->localhost:35538 (ESTABLISHED)
multiroot 19521 michael   13u  IPv4 11182081      0t0      TCP localhost:35539->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   14u  IPv4 11179085      0t0      TCP localhost:40676->localhost:35539 (ESTABLISHED)
multiroot 19521 michael   15u  IPv4 11172849      0t0      TCP localhost:35540->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   16u  IPv4 11172850      0t0      TCP localhost:40676->localhost:35540 (ESTABLISHED)
multiroot 19521 michael   17u  IPv4 11172852      0t0      TCP localhost:35541->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   18u  IPv4 11172853      0t0      TCP localhost:40676->localhost:35541 (ESTABLISHED)
multiroot 19521 michael   19u  IPv4 11182082      0t0      TCP localhost:35542->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   20u  IPv4 11178026      0t0      TCP localhost:40676->localhost:35542 (ESTABLISHED)
multiroot 19521 michael   21u  IPv4 11172855      0t0      TCP localhost:35543->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   22u  IPv4 11172856      0t0      TCP localhost:40676->localhost:35543 (ESTABLISHED)
multiroot 19521 michael   23u  IPv4 11172858      0t0      TCP localhost:35544->localhost:40676 (ESTABLISHED)
multiroot 19521 michael   24u  IPv4 11172859      0t0      TCP localhost:40676->localhost:35544 (ESTABLISHED)

Signed 1199 certificates so far
Signed 2429 certificates so far
Signed 3654 certificates so far
Signed 4940 certificates so far
2017/01/06 22:51:14 http: Accept error: accept tcp 127.0.0.1:40676: accept4: too many open files; retrying in 5ms
2017/01/06 22:51:14 http: Accept error: accept tcp 127.0.0.1:40676: accept4: too many open files; retrying in 10ms
```

After applying the fix:
```
=== RUN   TestMultiRootCA
COMMAND     PID    USER   FD   TYPE   DEVICE SIZE/OFF     NODE NAME
multiroot 19755 michael    3u  IPv4 11198115      0t0      TCP localhost:57276 (LISTEN)

Signed 1307 certificates so far
Signed 2637 certificates so far
Signed 3959 certificates so far
Signed 5296 certificates so far
...
Signed 98691 certificates so far
Signed 100000 total certificates in 1m15.985804362s
--- PASS: TestMultiRootCA (75.99s)
PASS
ok  	github.com/tehjojo/cfssl/cmd/multirootca	76.005s
```