### PR TITLE
Make CFSSL extensible with respect to local signers

### DIFF
--- a/signer/universal/universal.go
+++ b/signer/universal/universal.go
@@ -50,6 +50,11 @@ var localSignerList = []localSignerCheck{
 	fileBackedSigner,
 }
 
+// PrependLocalSignerToList prepends signer to the local signer's list
+func PrependLocalSignerToList(signer localSignerCheck) {
+	localSignerList = append([]localSignerCheck{signer}, localSignerList...)
+}
+
 func newLocalSigner(root Root, policy *config.Signing) (s signer.Signer, err error) {
 	// shouldProvide indicates whether the
 	// function *should* have produced a key. If


### PR DESCRIPTION
This change has two parts:
1) Allow a local signer to be prepended to the list in universal.go
2) Split a function into two parts in OCSP processing
   to allow a signer object to be passed in.

See https://github.com/cloudflare/cfssl/issues/711