### PR TITLE
Optionally generate OCSP response in cert revocation API endpoint

### DIFF
--- a/api/revoke/revoke.go
+++ b/api/revoke/revoke.go
@@ -21,7 +21,7 @@ import (
 // and revokes
 type Handler struct {
 	dbAccessor certdb.Accessor
-	signer     *ocsp.Signer
+	Signer     ocsp.Signer
 }
 
 // NewHandler returns a new http.Handler that handles a revoke request.
@@ -40,7 +40,7 @@ func NewOCSPHandler(dbAccessor certdb.Accessor, signer ocsp.Signer) http.Handler
 	return &api.HTTPHandler{
 		Handler: &Handler{
 			dbAccessor: dbAccessor,
-			signer:     &signer,
+			Signer:     signer,
 		},
 		Methods: []string{"POST"},
 	}
@@ -86,7 +86,7 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 
 	// If we were given a signer, try and generate an OCSP
 	// response indicating revocation
-	if h.signer != nil {
+	if h.Signer != nil {
 		// TODO: should these errors be errors?
 		// Grab the certificate from the database
 		cr, err := h.dbAccessor.GetCertificate(req.Serial, req.AKI)
@@ -114,7 +114,7 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 			RevokedAt:   time.Now().UTC(),
 		}
 
-		ocspResponse, err := (*h.signer).Sign(sr)
+		ocspResponse, err := h.Signer.Sign(sr)
 		if err != nil {
 			return err
 		}

--- a/api/revoke/revoke.go
+++ b/api/revoke/revoke.go
@@ -2,9 +2,7 @@
 package revoke
 
 import (
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -12,6 +10,7 @@ import (
 	"github.com/cloudflare/cfssl/api"
 	"github.com/cloudflare/cfssl/certdb"
 	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/ocsp"
 
 	stdocsp "golang.org/x/crypto/ocsp"
@@ -97,12 +96,7 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 			return errors.NewBadRequestString("No unique certificate found")
 		}
 
-		block, _ := pem.Decode([]byte(cr[0].PEM))
-		if block == nil {
-			return errors.NewBadRequestString("Unable to parse PEM encoded certificates")
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
+		cert, err := helpers.ParseCertificatePEM([]byte(cr[0].PEM))
 		if err != nil {
 			return errors.NewBadRequestString("Unable to parse certificates from PEM data")
 		}

--- a/api/revoke/revoke.go
+++ b/api/revoke/revoke.go
@@ -120,12 +120,14 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 
-		if err = h.dbAccessor.InsertOCSP(certdb.OCSPRecord{
+		ocspRecord := certdb.OCSPRecord{
 			Serial: req.Serial,
 			AKI:    req.AKI,
 			Body:   string(ocspResponse),
 			Expiry: ocspParsed.NextUpdate,
-		}); err != nil {
+		}
+
+		if err = h.dbAccessor.InsertOCSP(ocspRecord); err != nil {
 			return err
 		}
 	}

--- a/api/revoke/revoke_test.go
+++ b/api/revoke/revoke_test.go
@@ -2,8 +2,15 @@ package revoke
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +20,9 @@ import (
 	"github.com/cloudflare/cfssl/certdb"
 	"github.com/cloudflare/cfssl/certdb/sql"
 	"github.com/cloudflare/cfssl/certdb/testdb"
+	"github.com/cloudflare/cfssl/ocsp"
+
+	stdocsp "golang.org/x/crypto/ocsp"
 )
 
 const (
@@ -109,5 +119,177 @@ func TestRevocation(t *testing.T) {
 
 	if cert.Status != "revoked" || cert.Reason != 5 {
 		t.Fatal("cert was not correctly revoked")
+	}
+}
+
+// TestOCSPGeneration tests that revoking a certificate (when the
+// request handler has an OCSP response signer) generates an
+// appropriate OCSP response in the certdb.
+func TestOCSPGeneration(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialNumberRange := new(big.Int).Lsh(big.NewInt(1), 128)
+
+	// 1. Generate a CA certificate to serve as the signing certificate.
+	issuerSerial, err := rand.Int(rand.Reader, serialNumberRange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issuerTemplate := x509.Certificate{
+		SerialNumber: issuerSerial,
+		Subject: pkix.Name{
+			Organization: []string{"cfssl unit test"},
+		},
+		AuthorityKeyId: []byte{42, 42, 42, 42},
+		KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:           true,
+		BasicConstraintsValid: true,
+	}
+	issuerBytes, err := x509.CreateCertificate(rand.Reader, &issuerTemplate, &issuerTemplate, &privKey.PublicKey, privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issuer, err := x509.ParseCertificate(issuerBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Generate a certificate signed by the CA certificate to revoke.
+	revokedSerial, err := rand.Int(rand.Reader, serialNumberRange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revokedTemplate := x509.Certificate{
+		SerialNumber: revokedSerial,
+		Subject: pkix.Name{
+			Organization: []string{"Cornell CS 5152"},
+		},
+		AuthorityKeyId: []byte{42, 42, 42, 42},
+	}
+	revokedBytes, err := x509.CreateCertificate(rand.Reader, &revokedTemplate, issuer, &privKey.PublicKey, privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	revoked := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: revokedBytes,
+	})
+
+	revokedAKI := hex.EncodeToString(revokedTemplate.AuthorityKeyId)
+	revokedSerialStr := revokedSerial.Text(16)
+
+	// 3. Generate a certificate to use as the responder certificate.
+	responderSerial, err := rand.Int(rand.Reader, serialNumberRange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responderTemplate := x509.Certificate{
+		SerialNumber: responderSerial,
+		Subject: pkix.Name{
+			Organization: []string{"Cornell CS 5152 Responder"},
+		},
+		AuthorityKeyId: []byte{42, 42, 42, 43},
+	}
+	responderBytes, err := x509.CreateCertificate(rand.Reader, &responderTemplate, &responderTemplate, &privKey.PublicKey, privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responder, err := x509.ParseCertificate(responderBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Create the OCSP signer
+	signer, err := ocsp.NewSigner(issuer, responder, privKey, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 5. Spin up the test server
+	// 5a. Prepare the DB
+	dbAccessor, err := prepDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expirationTime := time.Now().AddDate(1, 0, 0)
+	cr := certdb.CertificateRecord{
+		Serial: revokedSerialStr,
+		AKI:    revokedAKI,
+		Expiry: expirationTime,
+		PEM:    string(revoked),
+	}
+	if err := dbAccessor.InsertCertificate(cr); err != nil {
+		t.Fatal(err)
+	}
+
+	// 5b. Start the test server
+	ts := httptest.NewServer(NewOCSPHandler(dbAccessor, signer))
+	defer ts.Close()
+
+	// 6. Prepare the revocation request
+	obj := map[string]interface{}{}
+
+	obj["serial"] = revokedSerialStr
+	obj["authority_key_id"] = revokedAKI
+	obj["reason"] = "unspecified"
+
+	blob, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the original number of OCSP responses
+	ocspsBefore, _ := dbAccessor.GetOCSP(revokedSerialStr, revokedAKI)
+	ocspCountBefore := len(ocspsBefore)
+
+	// 7. Send the revocation request
+	resp, err := http.Post(ts.URL, "application/json", bytes.NewReader(blob))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("unexpected HTTP status code; expected OK", string(body))
+	}
+	message := new(api.Response)
+	err = json.Unmarshal(body, message)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	// 8. Make sure the certificate record was updated
+	certs, err := dbAccessor.GetCertificate(revokedSerialStr, revokedAKI)
+	if err != nil {
+		t.Fatal("failed to get certificate ", err)
+	}
+	if len(certs) != 1 {
+		t.Fatal("failed to get one certificate")
+	}
+
+	cert := certs[0]
+
+	if cert.Status != "revoked" || cert.Reason != stdocsp.Unspecified {
+		t.Fatal("cert was not correctly revoked")
+	}
+
+	// 9. Make sure there is an OCSP record
+	ocsps, err := dbAccessor.GetOCSP(revokedSerialStr, revokedAKI)
+	if err != nil {
+		t.Fatal("failed to get OCSP responses ", err)
+	}
+
+	if len(ocsps) == 0 {
+		t.Fatal("No OCSP response generated")
+	}
+
+	if len(ocsps) <= ocspCountBefore {
+		t.Fatal("No new OCSP response found")
 	}
 }


### PR DESCRIPTION
The certificate revocation handler in `api/revoke` now, when given a signer, will generate an OCSP response and insert it into the certdb; otherwise it is unchanged from before.