### PR TITLE
Fix nil pointer panic in ParseCSRPEM 

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -450,8 +450,10 @@ func ParseCSR(in []byte) (csr *x509.CertificateRequest, rest []byte, err error) 
 // locally.
 func ParseCSRPEM(csrPEM []byte) (*x509.CertificateRequest, error) {
 	block, _ := pem.Decode([]byte(csrPEM))
-	der := block.Bytes
-	csrObject, err := x509.ParseCertificateRequest(der)
+	if block == nil {
+		return nil, cferr.New(cferr.CSRError, cferr.DecodeFailed)
+	}
+	csrObject, err := x509.ParseCertificateRequest(block.Bytes)
 
 	if err != nil {
 		return nil, err

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -406,6 +406,10 @@ func TestParseCSRPEMMore(t *testing.T) {
 	if _, err := ParseCSRPEM(csrPEM); err == nil {
 		t.Fatal(err)
 	}
+
+	if _, err := ParseCSRPEM([]byte("not even pem")); err == nil {
+		t.Fatal("Expected an invalid CSR.")
+	}
 }
 
 // Imported from signers/local/testdata/


### PR DESCRIPTION
Currently `ParseCSRPEM` will panic if the CSR bytes to be parsed cannot be decoded as a valid PEM block.  This adds a check to ensure that the block is valid before passing the DER bytes to `x509.ParseCertificateRequest`.