### PR TITLE
Update checkout path for staticcheck.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
   - go get -u github.com/golang/lint/golint
   - go get github.com/modocache/gover
   - go get -v github.com/GeertJohan/fgt
-  - go get honnef.co/go/staticcheck/cmd/staticcheck
+  - go get -u honnef.co/go/tools/cmd/staticcheck
   # Setup DBs + run migrations
   - go get bitbucket.org/liamstask/goose/cmd/goose
   - if [[ $(uname -s) == 'Linux' ]]; then

--- a/test.sh
+++ b/test.sh
@@ -53,7 +53,7 @@ do
 done
 
 if ! command -v staticcheck  > /dev/null ; then
-    go get honnef.co/go/tools/cmd/staticcheck
+    go get -u honnef.co/go/tools/cmd/staticcheck
 fi
 
 for package in $PACKAGES


### PR DESCRIPTION
This fixes the build errors from #736; this is due to staticcheck moving repos.