### PR TITLE
OCSP checks should not depend on CDP

### DIFF
--- a/revoke/revoke.go
+++ b/revoke/revoke.go
@@ -79,17 +79,17 @@ func revCheck(cert *x509.Certificate) (revoked, ok bool) {
 			log.Info("certificate is revoked via CRL")
 			return true, true
 		}
+	}
 
-		if revoked, ok := certIsRevokedOCSP(cert, HardFail); !ok {
-			log.Warning("error checking revocation via OCSP")
-			if HardFail {
-				return true, false
-			}
-			return false, false
-		} else if revoked {
-			log.Info("certificate is revoked via OCSP")
-			return true, true
+	if revoked, ok := certIsRevokedOCSP(cert, HardFail); !ok {
+		log.Warning("error checking revocation via OCSP")
+		if HardFail {
+			return true, false
 		}
+		return false, false
+	} else if revoked {
+		log.Info("certificate is revoked via OCSP")
+		return true, true
 	}
 
 	return false, true


### PR DESCRIPTION
When a certificates doesn't contain a CDP (CRL) the package did not perform any OCSP checks and would return good for revoked certificates.