### PR TITLE
Minor Adjustment to MySQL CertDB SQL Migrations File

### DIFF
--- a/certdb/mysql/migrations/001_CreateCertificates.sql
+++ b/certdb/mysql/migrations/001_CreateCertificates.sql
@@ -14,7 +14,7 @@ CREATE TABLE certificates (
 );
 
 CREATE TABLE ocsp_responses (
-  serial_number            varbinary(20) NOT NULL,
+  serial_number            varbinary(128) NOT NULL,
   authority_key_identifier varbinary(128) NOT NULL,
   body                     varbinary(4096) NOT NULL,
   expiry                   timestamp DEFAULT '0000-00-00 00:00:00',


### PR DESCRIPTION
Following the certificate serial number increase in the "certificates" table, we have to similarly increase certificate serial number to 128 from the "ocsp_responses" table.