### PR TITLE
Enabling build for ppc64le binaries

### DIFF
--- a/script/build
+++ b/script/build
@@ -25,7 +25,7 @@ else
 fi
 
 if [ -z "$2" ]; then
-    OS_ARCH_ARG=(-arch="386 amd64 arm")
+    OS_ARCH_ARG=(-arch="386 amd64 arm ppc64le")
 else
     OS_ARCH_ARG=($2)
 fi

--- a/script/build-docker
+++ b/script/build-docker
@@ -18,7 +18,7 @@ else
 fi
 
 if [ -z "$2" ]; then
-    OS_ARCH_ARG=(-arch="386 amd64 arm")
+    OS_ARCH_ARG=(-arch="386 amd64 arm ppc64le")
 else
     OS_ARCH_ARG=($2)
 fi


### PR DESCRIPTION
This PR enables builds for ppc64le binaries for cfssl.