### PR TITLE
cfssljson: add --version flag

### DIFF
--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -27,9 +27,14 @@ Usage of version:
 	cfssl version
 `
 
+// FormatVersion returns the formatted version string.
+func FormatVersion() string {
+	return fmt.Sprintf("Version: %s\nRevision: %s\nRuntime: %s\n", versionString(), version.Revision, runtime.Version())
+}
+
 // The main functionality of 'cfssl version' is to print out the version info.
 func versionMain(args []string, c cli.Config) (err error) {
-	fmt.Printf("Version: %s\nRevision: %s\nRuntime: %s\n", versionString(), version.Revision, runtime.Version())
+	fmt.Printf("%s", FormatVersion())
 	return nil
 }
 

--- a/cmd/cfssljson/cfssljson.go
+++ b/cmd/cfssljson/cfssljson.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"github.com/cloudflare/cfssl/cli/version"
 )
 
 func readFile(filespec string) ([]byte, error) {
@@ -51,7 +53,13 @@ func main() {
 	bare := flag.Bool("bare", false, "the response from CFSSL is not wrapped in the API standard response")
 	inFile := flag.String("f", "-", "JSON input")
 	output := flag.Bool("stdout", false, "output the response instead of saving to a file")
+	printVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	if *printVersion {
+		fmt.Printf("%s", version.FormatVersion())
+		return
+	}
 
 	var baseName string
 	if flag.NArg() == 0 {


### PR DESCRIPTION
As noted in https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/02-client-tools.md#verification, cfssljson lacks a way to check its version.