### PR TITLE
Format SKI properly in certinfo

### DIFF
--- a/certinfo/certinfo.go
+++ b/certinfo/certinfo.go
@@ -76,7 +76,7 @@ func formatKeyID(id []byte) string {
 		if i > 0 {
 			s += ":"
 		}
-		s += fmt.Sprintf("%X", c)
+		s += fmt.Sprintf("%02X", c)
 	}
 
 	return s


### PR DESCRIPTION
This fixes a bug in which bytes with values less than 0x10 will be formatted in a single hex character instead of two hex characters (e.g., `8` instead of `08`).