### PR TITLE
Update golang, enable non-x86 docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 
 ENV USER root
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 
 ENV USER root
 

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,34 +1,24 @@
-FROM alpine:3.5
+FROM golang:1.9.2-alpine3.6
 
-ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 ENV USER root
 
 COPY . /go/src/github.com/cloudflare/cfssl
 
-RUN buildDeps=' \
-		go \
-		git \
-		gcc \
-		libc-dev \
-		libtool \
-		libgcc \
-	' \
-	set -x && \
-	apk update && \
-	apk add $buildDeps && \
+RUN set -x && \
+	apk --no-cache add git gcc libc-dev && \
 	cd /go/src/github.com/cloudflare/cfssl && \
 	go get github.com/GeertJohan/go.rice/rice && rice embed-go -i=./cli/serve && \
-	cp -R /go/src/github.com/cloudflare/cfssl/vendor/github.com/cloudflare/cfssl_trust /etc/cfssl && \
-	go build -o /usr/bin/cfssl ./cmd/cfssl && \
-	go build -o /usr/bin/cfssljson ./cmd/cfssljson && \
-	go build -o /usr/bin/mkbundle ./cmd/mkbundle && \
-	go build -o /usr/bin/multirootca ./cmd/multirootca && \
-	apk del $buildDeps && \
-	rm -rf /var/cache/apk/* && \
-	rm -rf /go && \
+	mkdir bin && cd bin && \
+	go build ../cmd/cfssl && \
+	go build ../cmd/cfssljson && \
+	go build ../cmd/mkbundle && \
+	go build ../cmd/multirootca && \
 	echo "Build complete."
 
+FROM alpine:3.6
+COPY --from=0 /go/src/github.com/cloudflare/cfssl/vendor/github.com/cloudflare/cfssl_trust /etc/cfssl
+COPY --from=0 /go/src/github.com/cloudflare/cfssl/bin/ /usr/bin
 
 VOLUME [ "/etc/cfssl" ]
 WORKDIR /etc/cfssl


### PR DESCRIPTION
This ultimately allows cfssl dockerhub images to be built for non-x86 platforms (such as arm64, ppc64le etc). It was not possible before because versions of base images used (golang and alpine) were not multiarch, and the new ones are.

Also, this introduces multi-stage build for alpine (i.e. Dockerfile.minimal), resulting in simpler Dockerfile and almost twice smaller resulting image (50MB)).

Please consider.