### PR TITLE
Add backdate param for initializing CA

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -133,6 +133,7 @@ type CAConfig struct {
 	PathLength  int    `json:"pathlen" yaml:"pathlen"`
 	PathLenZero bool   `json:"pathlenzero" yaml:"pathlenzero"`
 	Expiry      string `json:"expiry" yaml:"expiry"`
+	Backdate    string `json:"backdate" yaml:"backdate"`
 }
 
 // A CertificateRequest encapsulates the API interface to the

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -54,6 +54,13 @@ func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
 			}
 		}
 
+		if req.CA.Backdate != "" {
+			policy.Default.Backdate, err = time.ParseDuration(req.CA.Backdate)
+			if err != nil {
+				return
+			}
+		}
+
 		policy.Default.CAConstraint.MaxPathLen = req.CA.PathLength
 		if req.CA.PathLength != 0 && req.CA.PathLenZero {
 			log.Infof("ignore invalid 'pathlenzero' value")


### PR DESCRIPTION
This commit adds a backdate param for CAConfig along the same lines as
SigningProfile.