### PR TITLE
ocsp: Reduce user-triggerable logs to debug.

### DIFF
--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -226,7 +226,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	case "GET":
 		base64Request, err := url.QueryUnescape(request.URL.Path)
 		if err != nil {
-			log.Infof("Error decoding URL: %s", request.URL.Path)
+			log.Debugf("Error decoding URL: %s", request.URL.Path)
 			response.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -249,7 +249,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 		}
 		requestBody, err = base64.StdEncoding.DecodeString(string(base64RequestBytes))
 		if err != nil {
-			log.Infof("Error decoding base64 from URL: %s", string(base64RequestBytes))
+			log.Debugf("Error decoding base64 from URL: %s", string(base64RequestBytes))
 			response.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -278,7 +278,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	//      should return unauthorizedRequest instead of malformed.
 	ocspRequest, err := ocsp.ParseRequest(requestBody)
 	if err != nil {
-		log.Infof("Error decoding request body: %s", b64Body)
+		log.Debugf("Error decoding request body: %s", b64Body)
 		response.WriteHeader(http.StatusBadRequest)
 		response.Write(malformedRequestErrorResponse)
 		return


### PR DESCRIPTION
There are some log lines that can be triggered by users submitting malformed
input. Since malformed input is unfortunately common on the internet, reduce
these log lines to debug level to decrease log spam.