### PR TITLE
Update Dockerfile.minimal

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -7,8 +7,9 @@ COPY . /go/src/github.com/cloudflare/cfssl
 
 RUN set -x && \
 	apk --no-cache add git gcc libc-dev && \
-	cd /go/src/github.com/cloudflare/cfssl && \
-	go get github.com/GeertJohan/go.rice/rice && rice embed-go -i=./cli/serve && \
+	go get github.com/cloudflare/cfssl_trust/... && \
+	go get github.com/GeertJohan/go.rice/rice && \
+	cd /go/src/github.com/cloudflare/cfssl && rice embed-go -i=./cli/serve && \
 	mkdir bin && cd bin && \
 	go build ../cmd/cfssl && \
 	go build ../cmd/cfssljson && \
@@ -17,7 +18,7 @@ RUN set -x && \
 	echo "Build complete."
 
 FROM alpine:3.6
-COPY --from=0 /go/src/github.com/cloudflare/cfssl/vendor/github.com/cloudflare/cfssl_trust /etc/cfssl
+COPY --from=0 /go/src/github.com/cloudflare/cfssl_trust /etc/cfssl
 COPY --from=0 /go/src/github.com/cloudflare/cfssl/bin/ /usr/bin
 
 VOLUME [ "/etc/cfssl" ]


### PR DESCRIPTION
Path to cfssl_trust was nested under cfssl for the final copy block, but nothing in the build sequence satisfied this dependency. Trigger fetching of cfssl_trust via go get during first stage, then copy those files from 1st to 2nd stage.