### PR TITLE
Add ability to return precerts from Signer.Sign and create certs from precerts with new API

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -201,8 +201,6 @@ const (
 	// and has a invalid CT poison extension value or the extension is not
 	// critical.
 	PrecertInvalidPoison
-	// SCTInvalid occurs when attempting to parse a SCT with trailing garbage
-	SCTInvalid
 )
 
 // Certificate persistence related errors specified with CertStoreError
@@ -378,6 +376,10 @@ func New(category Category, reason Reason) *Error {
 			msg = "Certificate transparency parsing failed due to unknown error"
 		case PrecertSubmissionFailed:
 			msg = "Certificate transparency precertificate submission failed"
+		case PrecertMissingPoison:
+			msg = "Precertificate is missing CT poison extension"
+		case PrecertInvalidPoison:
+			msg = "Precertificate contains an invalid CT poison extension"
 		default:
 			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category CTError.", reason))
 		}

--- a/errors/error.go
+++ b/errors/error.go
@@ -194,6 +194,15 @@ const (
 	// CTClientConstructionFailed occurs when the construction of a new
 	// github.com/google/certificate-transparency client fails.
 	CTClientConstructionFailed
+	// PrecertMissingPoison occurs when a precert is passed to SignFromPrecert
+	// and is missing the CT poison extension.
+	PrecertMissingPoison
+	// PrecertInvalidPoison occurs when a precert is pass to SignFromPrecert
+	// and has a invalid CT poison extension value or the extension is not
+	// critical.
+	PrecertInvalidPoison
+	// SCTInvalid occurs when attempting to parse a SCT with trailing garbage
+	SCTInvalid
 )
 
 // Certificate persistence related errors specified with CertStoreError

--- a/errors/error.go
+++ b/errors/error.go
@@ -197,7 +197,7 @@ const (
 	// PrecertMissingPoison occurs when a precert is passed to SignFromPrecert
 	// and is missing the CT poison extension.
 	PrecertMissingPoison
-	// PrecertInvalidPoison occurs when a precert is pass to SignFromPrecert
+	// PrecertInvalidPoison occurs when a precert is passed to SignFromPrecert
 	// and has a invalid CT poison extension value or the extension is not
 	// critical.
 	PrecertInvalidPoison

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -442,7 +441,6 @@ func (s *Signer) SignFromPrecert(precert *x509.Certificate, scts []ct.SignedCert
 			}
 			// Check extension contains ASN.1 NULL
 			if bytes.Compare(ext.Value, []byte{0x05, 0x00}) != 0 {
-				fmt.Println("AHHHH")
 				return nil, cferr.New(cferr.CTError, cferr.PrecertInvalidPoison)
 			}
 			isPrecert = true
@@ -483,82 +481,6 @@ func (s *Signer) SignFromPrecert(precert *x509.Certificate, scts []ct.SignedCert
 	if len(precert.Extensions) > 0 {
 		tbsCert.ExtraExtensions = make([]pkix.Extension, len(precert.Extensions))
 		copy(tbsCert.ExtraExtensions, precert.Extensions)
-	}
-	if len(precert.ExtKeyUsage) > 0 {
-		tbsCert.ExtKeyUsage = make([]x509.ExtKeyUsage, len(precert.ExtKeyUsage))
-		copy(tbsCert.ExtKeyUsage, precert.ExtKeyUsage)
-	}
-	if len(precert.SubjectKeyId) > 0 {
-		tbsCert.SubjectKeyId = make([]byte, len(precert.SubjectKeyId))
-		copy(tbsCert.SubjectKeyId, precert.SubjectKeyId)
-	}
-	if len(precert.AuthorityKeyId) > 0 {
-		tbsCert.AuthorityKeyId = make([]byte, len(precert.AuthorityKeyId))
-		copy(tbsCert.AuthorityKeyId, precert.AuthorityKeyId)
-	}
-	if len(precert.OCSPServer) > 0 {
-		tbsCert.OCSPServer = make([]string, len(precert.OCSPServer))
-		copy(tbsCert.OCSPServer, precert.OCSPServer)
-	}
-	if len(precert.IssuingCertificateURL) > 0 {
-		tbsCert.IssuingCertificateURL = make([]string, len(precert.IssuingCertificateURL))
-		copy(tbsCert.IssuingCertificateURL, precert.IssuingCertificateURL)
-	}
-	if len(precert.DNSNames) > 0 {
-		tbsCert.DNSNames = make([]string, len(precert.DNSNames))
-		copy(tbsCert.DNSNames, precert.DNSNames)
-	}
-	if len(precert.PermittedDNSDomains) > 0 {
-		tbsCert.PermittedDNSDomains = make([]string, len(precert.PermittedDNSDomains))
-		copy(tbsCert.PermittedDNSDomains, precert.PermittedDNSDomains)
-	}
-	if len(precert.ExcludedDNSDomains) > 0 {
-		tbsCert.ExcludedDNSDomains = make([]string, len(precert.ExcludedDNSDomains))
-		copy(tbsCert.ExcludedDNSDomains, precert.ExcludedDNSDomains)
-	}
-	if len(precert.EmailAddresses) > 0 {
-		tbsCert.EmailAddresses = make([]string, len(precert.EmailAddresses))
-		copy(tbsCert.EmailAddresses, precert.EmailAddresses)
-	}
-	// if len(precert.PermittedEmailAddresses) > 0 {
-	// 	tbsCert.PermittedEmailAddresses = make([]string, len(precert.PermittedEmailAddresses))
-	// 	copy(tbsCert.PermittedEmailAddresses, precert.PermittedEmailAddresses)
-	// }
-	// if len(precert.ExcludedEmailAddresses) > 0 {
-	// 	tbsCert.ExcludedEmailAddresses = make([]string, len(precert.ExcludedEmailAddresses))
-	// 	copy(tbsCert.ExcludedEmailAddresses, precert.ExcludedEmailAddresses)
-	// }
-	if len(precert.IPAddresses) > 0 {
-		tbsCert.IPAddresses = make([]net.IP, len(precert.IPAddresses))
-		copy(tbsCert.IPAddresses, precert.IPAddresses)
-	}
-	// if len(precert.PermittedIPRanges) > 0 {
-	// 	tbsCert.PermittedIPRanges = make([]string, len(precert.PermittedIPRanges))
-	// 	copy(tbsCert.PermittedIPRanges, precert.PermittedIPRanges)
-	// }
-	// if len(precert.ExcludedIPRanges) > 0 {
-	// 	tbsCert.ExcludedIPRanges = make([]string, len(precert.ExcludedIPRanges))
-	// 	copy(tbsCert.ExcludedIPRanges, precert.ExcludedIPRanges)
-	// }
-	// if len(precert.URIs) > 0 {
-	// 	tbsCert.URIs = make([]*url.URL, len(precert.URIs))
-	// 	copy(tbsCert.URIs, precert.URIs)
-	// }
-	// if len(precert.PermittedURIDomains) > 0 {
-	// 	tbsCert.PermittedURIDomains = make([]string, len(precert.PermittedURIDomains))
-	// 	copy(tbsCert.PermittedURIDomains, precert.PermittedURIDomains)
-	// }
-	// if len(precert.ExcludedURIDomains) > 0 {
-	// 	tbsCert.ExcludedURIDomains = make([]string, len(precert.ExcludedURIDomains))
-	// 	copy(tbsCert.ExcludedURIDomains, precert.ExcludedURIDomains)
-	// }
-	if len(precert.CRLDistributionPoints) > 0 {
-		tbsCert.CRLDistributionPoints = make([]string, len(precert.CRLDistributionPoints))
-		copy(tbsCert.CRLDistributionPoints, precert.CRLDistributionPoints)
-	}
-	if len(precert.PolicyIdentifiers) > 0 {
-		tbsCert.PolicyIdentifiers = make([]asn1.ObjectIdentifier, len(precert.PolicyIdentifiers))
-		copy(tbsCert.PolicyIdentifiers, precert.PolicyIdentifiers)
 	}
 
 	// Remove the poison extension from ExtraExtensions

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -418,12 +418,12 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 	return signedCert, nil
 }
 
-// SignFromPrecert creates and signs a certificarte from an existing precertificate
+// SignFromPrecert creates and signs a certificate from an existing precertificate
 // that was previously signed by Signer.ca and inserts the provided SCTs into the
 // new certificate. The resulting certificate will be a exact copy of the precert
 // except for the removal of the poison extension and the addition of the SCT list
 // extension. SignFromPrecert does not verify that the contents of the certificate
-// still match the signing profile of the signer, it simply requires that the precert
+// still match the signing profile of the signer, it only requires that the precert
 // was previously signed by the Signers CA.
 func (s *Signer) SignFromPrecert(precert *x509.Certificate, scts []ct.SignedCertificateTimestamp) ([]byte, error) {
 	// Verify certificate was signed by s.ca

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -2,12 +2,16 @@ package local
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
 	"io/ioutil"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -23,6 +27,7 @@ import (
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/signer"
+	"github.com/google/certificate-transparency-go"
 )
 
 const (
@@ -1257,5 +1262,164 @@ func TestCTSuccess(t *testing.T) {
 
 	if err != nil {
 		t.Fatal("Expected CT log submission success")
+	}
+}
+
+func TestReturnPrecert(t *testing.T) {
+	var config = &config.Signing{
+		Default: &config.SigningProfile{
+			Expiry:       helpers.OneYear,
+			CAConstraint: config.CAConstraint{IsCA: true},
+			Usage:        []string{"signing", "key encipherment", "server auth", "client auth"},
+			ExpiryString: "8760h",
+		},
+	}
+	testSigner, err := NewSignerFromFile(testCaFile, testCaKeyFile, config)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	csr, err := ioutil.ReadFile("testdata/ex.csr")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	validReq := signer.SignRequest{
+		Request:       string(csr),
+		Hosts:         []string{"example.com"},
+		ReturnPrecert: true,
+	}
+
+	certBytes, err := testSigner.Sign(validReq)
+	if err != nil {
+		t.Fatal("Failed to sign request")
+	}
+	block, _ := pem.Decode(certBytes)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse signed cert: %s", err)
+	}
+
+	// check cert with poison extension was returned
+	poisoned := false
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(signer.CTPoisonOID) {
+			poisoned = true
+			break
+		}
+	}
+	if !poisoned {
+		t.Fatal("Certificate without poison CT extension was returned")
+	}
+}
+
+func TestSignFromPrecert(t *testing.T) {
+	var config = &config.Signing{
+		Default: &config.SigningProfile{
+			Expiry:       helpers.OneYear,
+			CAConstraint: config.CAConstraint{IsCA: true},
+			Usage:        []string{"signing", "key encipherment", "server auth", "client auth"},
+			ExpiryString: "8760h",
+		},
+	}
+	testSigner, err := NewSignerFromFile(testCaFile, testCaKeyFile, config)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Generate a precert
+	k, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("Failed to generate test key: %s", err)
+	}
+	precertBytes, err := testSigner.sign(&x509.Certificate{
+		SignatureAlgorithm: x509.SHA512WithRSA,
+		PublicKey:          k.Public(),
+		SerialNumber:       big.NewInt(10),
+		Subject:            pkix.Name{CommonName: "CN"},
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour),
+		ExtraExtensions: []pkix.Extension{
+			{Id: signer.CTPoisonOID, Critical: true, Value: []byte{0x05, 0x00}},
+		},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		SubjectKeyId:          []byte{0, 1},
+		AuthorityKeyId:        []byte{1, 0},
+		OCSPServer:            []string{"ocsp?"},
+		IssuingCertificateURL: []string{"url"},
+		DNSNames:              []string{"example.com"},
+		EmailAddresses:        []string{"email@example.com"},
+		IPAddresses:           []net.IP{net.ParseIP("1.1.1.1")},
+		PermittedDNSDomains:   []string{"example.com"},
+		ExcludedDNSDomains:    []string{"not-example.com"},
+		CRLDistributionPoints: []string{"crl"},
+		PolicyIdentifiers:     []asn1.ObjectIdentifier{{1, 2, 3}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to sign request: %s", err)
+	}
+	block, _ := pem.Decode(precertBytes)
+	precert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse signed cert: %s", err)
+	}
+
+	// Create a cert from the precert
+	scts := []ct.SignedCertificateTimestamp{}
+	certBytes, err := testSigner.SignFromPrecert(precert, scts)
+	if err != nil {
+		t.Fatal("Failed to sign cert from precert")
+	}
+	block, _ = pem.Decode(certBytes)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse signed cert: %s", err)
+	}
+
+	// check cert doesn't contains poison extension
+	poisoned := false
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(signer.CTPoisonOID) {
+			poisoned = true
+			break
+		}
+	}
+	if poisoned {
+		t.Fatal("Certificate with poison CT extension was returned")
+	}
+
+	// check cert contains SCT list extension
+	list := false
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(signer.SCTListOID) {
+			list = true
+			break
+		}
+	}
+	if !list {
+		t.Fatal("Certificate without SCT list extension was returned")
+	}
+
+	// Break poison extension
+	precert.Extensions[8].Value = []byte{1, 3, 3, 7}
+	_, err = testSigner.SignFromPrecert(precert, scts)
+	if err == nil {
+		t.Fatal("SignFromPrecert didn't fail with invalid poison extension")
+	}
+
+	precert.Extensions[8].Critical = false
+	_, err = testSigner.SignFromPrecert(precert, scts)
+	if err == nil {
+		t.Fatal("SignFromPrecert didn't fail with non-critical poison extension")
+	}
+
+	precert.Extensions = append(precert.Extensions[:8], precert.Extensions[9:]...)
+	_, err = testSigner.SignFromPrecert(precert, scts)
+	if err == nil {
+		t.Fatal("SignFromPrecert didn't fail with missing poison extension")
+	}
+
+	precert.Signature = []byte("nop")
+	_, err = testSigner.SignFromPrecert(precert, scts)
+	if err == nil {
+		t.Fatal("SignFromPrecert didn't fail with signature not from CA")
 	}
 }

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -1348,8 +1348,6 @@ func TestSignFromPrecert(t *testing.T) {
 		DNSNames:              []string{"example.com"},
 		EmailAddresses:        []string{"email@example.com"},
 		IPAddresses:           []net.IP{net.ParseIP("1.1.1.1")},
-		PermittedDNSDomains:   []string{"example.com"},
-		ExcludedDNSDomains:    []string{"not-example.com"},
 		CRLDistributionPoints: []string{"crl"},
 		PolicyIdentifiers:     []asn1.ObjectIdentifier{{1, 2, 3}},
 	})
@@ -1399,19 +1397,19 @@ func TestSignFromPrecert(t *testing.T) {
 	}
 
 	// Break poison extension
-	precert.Extensions[8].Value = []byte{1, 3, 3, 7}
+	precert.Extensions[7].Value = []byte{1, 3, 3, 7}
 	_, err = testSigner.SignFromPrecert(precert, scts)
 	if err == nil {
 		t.Fatal("SignFromPrecert didn't fail with invalid poison extension")
 	}
 
-	precert.Extensions[8].Critical = false
+	precert.Extensions[7].Critical = false
 	_, err = testSigner.SignFromPrecert(precert, scts)
 	if err == nil {
 		t.Fatal("SignFromPrecert didn't fail with non-critical poison extension")
 	}
 
-	precert.Extensions = append(precert.Extensions[:8], precert.Extensions[9:]...)
+	precert.Extensions = append(precert.Extensions[:7], precert.Extensions[8:]...)
 	_, err = testSigner.SignFromPrecert(precert, scts)
 	if err == nil {
 		t.Fatal("SignFromPrecert didn't fail with missing poison extension")

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -64,6 +64,12 @@ type SignRequest struct {
 	// for canonicalization) as the value of the notAfter field of the
 	// certificate.
 	NotAfter time.Time
+	// If ReturnPrecert is true a certificate with the CT poison extension
+	// will be returned from the Signer instead of attempting to retrieve
+	// SCTs and populate the tbsCert with them itself. This precert can then
+	// be passed to SignFromPrecert with the SCTs in order to create a
+	// valid certificate.
+	ReturnPrecert bool
 }
 
 // appendIf appends to a if s is not an empty string.


### PR DESCRIPTION
This PR makes two changes:
* Adds the ability to request a poisoned precert be returned from `Signer.Sign` instead of attempting to retrieve SCTs and incorporate them within the method. This allows callers who may have their own SCT retrieval logic to get SCTs for precerts
* Add a new method `Signer.SignFromPrecert` that accepts a poisoned precert and a list of SCTs and creates a certificate from them

`SignFromPrecert` doesn't do any template filling or checks that the certificate matches the signing profile, it only checks that the passed in precert was properly poisoned and signed by the signer CA. The rationale for this is that the caller should have checks in place to verify if they really want to turn the poisoned precert into a certificate that can be used for trust decisions (i.e. in the case where the signing profile has changed and the precert no longer matches it).

This allows users of cfssl to manage SCT retrieval for certificates themselves in cases where they may want to use a different method to the internally specified one in `Signer.Sign`.