### PR TITLE
Expose errors from CheckSignatureFrom()

### DIFF
--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -164,8 +164,10 @@ func (s StandardSigner) Sign(req SignRequest) ([]byte, error) {
 	if bytes.Compare(req.Certificate.RawIssuer, s.issuer.RawSubject) != 0 {
 		return nil, cferr.New(cferr.OCSPError, cferr.IssuerMismatch)
 	}
-	if req.Certificate.CheckSignatureFrom(s.issuer) != nil {
-		return nil, cferr.New(cferr.OCSPError, cferr.IssuerMismatch)
+
+	err := req.Certificate.CheckSignatureFrom(s.issuer)
+	if err != nil {
+		return nil, err
 	}
 
 	var thisUpdate, nextUpdate time.Time


### PR DESCRIPTION
Signature verification failures are asked behind a generic "IssuerMismatch" error which is not accurate. Instead, check the return value and propagate the error to the caller to inform the user about the true nature of the failure.