### PR TITLE
Add SANs support for self signed certificate

### DIFF
--- a/selfsign/selfsign.go
+++ b/selfsign/selfsign.go
@@ -42,6 +42,7 @@ func parseCertificateRequest(priv crypto.Signer, csrBytes []byte) (template *x50
 		Subject:            csr.Subject,
 		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
 		PublicKey:          csr.PublicKey,
+		DNSNames:           csr.DNSNames,
 		SignatureAlgorithm: signer.DefaultSigAlgo(priv),
 	}
 


### PR DESCRIPTION
Fixed #777 

Currently the `cfssl selfsign` command ignores `hosts` config, and produces certificate excluding Subject Alternative Names.

Now modern browsers require to inlclude SANs in the certificate, common name is no longer supported.
Self-signed certificate should also include SANs inside.