### PR TITLE
allow endpoints to be disabled

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	AKI               string
 	DBConfigFile      string
 	CRLExpiration     time.Duration
+	Disable     	  string
 }
 
 // registerFlags defines all cfssl command flags and associates their values with variables.
@@ -128,6 +129,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.DBConfigFile, "db-config", "", "certificate db configuration file")
 	f.DurationVar(&c.CRLExpiration, "expiry", 7*helpers.OneDay, "time from now after which the CRL will expire (default: one week)")
 	f.IntVar(&log.Level, "loglevel", log.LevelInfo, "Log level (0 = DEBUG, 5 = FATAL)")
+	f.StringVar(&c.Disable, "disable", "", "endpoints to disable")
 }
 
 // RootFromConfig returns a universal signer Root structure that can

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -51,7 +51,7 @@ Usage of serve:
                     [-responder cert] [-responder-key key] [-tls-cert cert] [-tls-key key] \
                     [-mutual-tls-ca ca] [-mutual-tls-cn regex] \
                     [-tls-remote-ca ca] [-mutual-tls-client-cert cert] [-mutual-tls-client-key key] \
-                    [-db-config db-config]
+                    [-db-config db-config] [-disable endpoint[,endpoint]]
 
 Flags:
 `
@@ -59,7 +59,7 @@ Flags:
 // Flags used by 'cfssl serve'
 var serverFlags = []string{"address", "port", "ca", "ca-key", "ca-bundle", "int-bundle", "int-dir", "metadata",
 	"remote", "config", "responder", "responder-key", "tls-key", "tls-cert", "mutual-tls-ca", "mutual-tls-cn",
-	"tls-remote-ca", "mutual-tls-client-cert", "mutual-tls-client-key", "db-config"}
+	"tls-remote-ca", "mutual-tls-client-cert", "mutual-tls-client-key", "db-config", "disable"}
 
 var (
 	conf       cli.Config
@@ -245,9 +245,19 @@ var endpoints = map[string]func() (http.Handler, error){
 
 // registerHandlers instantiates various handlers and associate them to corresponding endpoints.
 func registerHandlers() {
+	disabled := make(map[string]bool)
+	if conf.Disable != "" {
+	    for _, endpoint := range strings.Split(conf.Disable, ",") {
+	        disabled[endpoint] = true
+	    }
+	}
+
 	for path, getHandler := range endpoints {
 		log.Debugf("getHandler for %s", path)
-		if handler, err := getHandler(); err != nil {
+
+		if _, ok := disabled[path]; ok {
+			log.Infof("endpoint '%s' is explicitly disabled", path)
+		} else if handler, err := getHandler(); err != nil {
 			log.Warningf("endpoint '%s' is disabled: %v", path, err)
 		} else {
 			if path, handler, err = wrapHandler(path, handler, err); err != nil {


### PR DESCRIPTION
```
$ cfssl serve -config=config/ca.json -db-config=config/db.json -disable=init_ca,revoke -address=0.0.0.0 -port=8888 -loglevel=1 -ca=data/intermediate.pem -ca-key=data/intermediate-key.pem -responder=data/ocsp.pem -responder-key=data/ocsp-key.pem
2018/05/17 02:34:22 [INFO] Initializing signer
...
2018/05/17 02:34:22 [INFO] endpoint 'init_ca' is explicitly disabled
2018/05/17 02:34:22 [INFO] endpoint '/api/v1/cfssl/crl' is enabled
2018/05/17 02:34:22 [INFO] endpoint 'revoke' is explicitly disabled
2018/05/17 02:34:22 [WARNING] endpoint 'sign' is disabled: {"code":5200,"message":"Invalid or unknown policy"}
...
2018/05/17 02:34:22 [INFO] Handler set up complete.
2018/05/17 02:34:22 [INFO] Now listening on 0.0.0.0:8888
```
