### PR TITLE
Adds a basic healthz endpoint

### DIFF
--- a/api/health/health.go
+++ b/api/health/health.go
@@ -1,4 +1,4 @@
-package healthz
+package health
 
 import (
 	"encoding/json"
@@ -7,18 +7,18 @@ import (
 	"github.com/cloudflare/cfssl/api"
 )
 
-type HealthzResponse struct {
+type HealthResponse struct {
 	Healthy bool `json:"healthy"`
 }
 
-func healthzHandler(w http.ResponseWriter, r *http.Request) error {
-	response := api.NewSuccessResponse(&HealthzResponse{Healthy: true})
+func healthHandler(w http.ResponseWriter, r *http.Request) error {
+	response := api.NewSuccessResponse(&HealthResponse{Healthy: true})
 	return json.NewEncoder(w).Encode(response)
 }
 
 func NewHealthCheck() http.Handler {
 	return api.HTTPHandler{
-		Handler: api.HandlerFunc(healthzHandler),
+		Handler: api.HandlerFunc(healthHandler),
 		Methods: []string{"GET"},
 	}
 }

--- a/api/healthz/healthz.go
+++ b/api/healthz/healthz.go
@@ -1,0 +1,24 @@
+package healthz
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/cloudflare/cfssl/api"
+)
+
+type HealthzResponse struct {
+	Healthy bool `json:"healthy"`
+}
+
+func healthzHandler(w http.ResponseWriter, r *http.Request) error {
+	response := api.NewSuccessResponse(&HealthzResponse{Healthy: true})
+	return json.NewEncoder(w).Encode(response)
+}
+
+func NewHealthCheck() http.Handler {
+	return api.HTTPHandler{
+		Handler: api.HandlerFunc(healthzHandler),
+		Methods: []string{"GET"},
+	}
+}

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cloudflare/cfssl/api/crl"
 	"github.com/cloudflare/cfssl/api/gencrl"
 	"github.com/cloudflare/cfssl/api/generator"
-	"github.com/cloudflare/cfssl/api/healthz"
+	"github.com/cloudflare/cfssl/api/health"
 	"github.com/cloudflare/cfssl/api/info"
 	"github.com/cloudflare/cfssl/api/initca"
 	apiocsp "github.com/cloudflare/cfssl/api/ocsp"
@@ -243,8 +243,8 @@ var endpoints = map[string]func() (http.Handler, error){
 		return http.FileServer(staticBox), nil
 	},
 
-	"healthz": func() (http.Handler, error) {
-		return healthz.NewHealthCheck(), nil
+	"health": func() (http.Handler, error) {
+		return health.NewHealthCheck(), nil
 	},
 }
 

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cloudflare/cfssl/api/crl"
 	"github.com/cloudflare/cfssl/api/gencrl"
 	"github.com/cloudflare/cfssl/api/generator"
+	"github.com/cloudflare/cfssl/api/healthz"
 	"github.com/cloudflare/cfssl/api/info"
 	"github.com/cloudflare/cfssl/api/initca"
 	apiocsp "github.com/cloudflare/cfssl/api/ocsp"
@@ -240,6 +241,10 @@ var endpoints = map[string]func() (http.Handler, error){
 		}
 
 		return http.FileServer(staticBox), nil
+	},
+
+	"healthz": func() (http.Handler, error) {
+		return healthz.NewHealthCheck(), nil
 	},
 }
 


### PR DESCRIPTION
Addresses #834 by adding a basic health check

    $ curl -s http://localhost:8888/api/v1/cfssl/healthz
    {"success":true,"result":{"healthy":true},"errors":[],"messages":[]}

