### PR TITLE
Remove remnants of PKCS #11 support in README.md and comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ services:
   - postgresql
 before_install:
   # CFSSL consists of multiple Go packages, which refer to each other by
-  # their absolute GitHub path, e.g. github.com/cloudflare/crypto/pkcs11key.
+  # their absolute GitHub path, e.g. github.com/cloudflare/crypto/pkcs7.
   # That means, by default, if someone forks the repo and makes changes across
   # multiple packages within CFSSL, Travis won't pass for the branch on their
   # own repo. To fix that, we move the directory

--- a/README.md
+++ b/README.md
@@ -381,52 +381,6 @@ pushd cli/serve && rice embed-go && popd
 
 Then building with `go build` will use the embedded resources.
 
-### Using a PKCS#11 hardware token / HSM
-
-For better security, you may wish to store your private key in an HSM or
-smartcard. The interface to both of these categories of device is described by
-the PKCS#11 spec. If you need to do approximately one signing operation per
-second or fewer, the Yubikey NEO and NEO-n are inexpensive smartcard options:
-
-        https://www.yubico.com/products/yubikey-hardware/yubikey-neo/
-
-In general you should look for a product that supports PIV (personal identity verification). If
-your signing needs are in the hundreds of signatures per second, you will need
-to purchase an expensive HSM (in the thousands to many thousands of USD).
-
-If you wish to try out the PKCS#11 signing modes without a hardware token, you
-can use the [SoftHSM](https://github.com/opendnssec/SoftHSMv1#softhsm)
-implementation. Please note that using SoftHSM simply stores your private key in
-a file on disk and does not increase security.
-
-To get started with your PKCS#11 token you will need to initialize it with a
-private key, PIN, and token label. The instructions to do this will be specific
-to each hardware device, and you should follow the instructions provided by your
-vendor. You will also need to find the path to your `module`, a shared object
-file (.so). Having initialized your device, you can query it to check your token
-label with:
-
-    pkcs11-tool --module <module path> --list-token-slots
-
-You'll also want to check the label of the private key you imported (or
-generated). Run the following command and look for a `Private Key Object`:
-
-    pkcs11-tool --module <module path> --pin <pin> \
-      --list-token-slots --login --list-objects
-
-You now have all the information you need to use your PKCS#11 token with CFSSL.
-CFSSL supports PKCS#11 for certificate signing and OCSP signing. To create a
-Signer (for certificate signing), import `signer/universal` and call NewSigner
-with a Root object containing the module, pin, token label and private label
-from above, plus a path to your certificate. The structure of the Root object is
-documented in `universal.go`.
-
-Alternately, you can construct a pkcs11key.Key or pkcs11key.Pool yourself, and
-pass it to ocsp.NewSigner (for OCSP) or local.NewSigner (for certificate
-signing). This will be necessary, for example, if you are using a single-session
-token like the Yubikey and need both OCSP signing and certificate signing at the
-same time.
-
 ### Additional Documentation
 
 Additional documentation can be found in the "doc" directory:

--- a/signer/universal/universal.go
+++ b/signer/universal/universal.go
@@ -63,13 +63,10 @@ func newLocalSigner(root Root, policy *config.Signing) (s signer.Signer, err err
 	// signers.
 	var shouldProvide bool
 
-	// localSignerList is defined in the
-	// universal_signers*.go files. These activate
-	// and deactivate signers based on build
-	// flags; for example,
-	// universal_signers_pkcs11.go contains a list
-	// of valid signers when PKCS #11 is turned
-	// on.
+	// localSignerList is a list of signers defined
+	// here or in the universal_signers*.go files.
+	// These activate and deactivate signers based
+	// on build flags.
 	for _, possibleSigner := range localSignerList {
 		s, shouldProvide, err = possibleSigner(&root, policy)
 		if shouldProvide {


### PR DESCRIPTION
https://github.com/cloudflare/cfssl/pull/522 removed PKCS11 code vendored from `miekg/pkcs11` and `letsencrypt/pkcs11key` 2 years ago, but the README still talked about it. Those remnants are removed until they need to be added.

ps: `gokeyless` now supports PKCS11, so maybe that code can move here, since `gokeyless` already vendors `cfssl`.