### PR TITLE
Add a flag to support minimum TLS version for cli/serve

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -92,7 +92,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.IntBundleFile, "int-bundle", "", "path to intermediate certificate store")
 	f.StringVar(&c.Address, "address", "127.0.0.1", "Address to bind")
 	f.IntVar(&c.Port, "port", 8888, "Port to bind")
-	f.StringVar(&c.MinTLSVersion, "min-tls-version", "10", "Minimum version of TLS to use, defaults to 1.0")
+	f.StringVar(&c.MinTLSVersion, "min-tls-version", "", "Minimum version of TLS to use, defaults to 1.0")
 	f.StringVar(&c.ConfigFile, "config", "", "path to configuration file")
 	f.StringVar(&c.Profile, "profile", "", "signing profile to use")
 	f.BoolVar(&c.IsCA, "initca", false, "initialise new CA")

--- a/cli/config.go
+++ b/cli/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	IntBundleFile     string
 	Address           string
 	Port              int
+	MinTLSVersion     string
 	Password          string
 	ConfigFile        string
 	CFG               *config.Config
@@ -91,6 +92,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.IntBundleFile, "int-bundle", "", "path to intermediate certificate store")
 	f.StringVar(&c.Address, "address", "127.0.0.1", "Address to bind")
 	f.IntVar(&c.Port, "port", 8888, "Port to bind")
+	f.StringVar(&c.MinTLSVersion, "min-tls-version", "10", "Minimum version of TLS to use, defaults to 1.0")
 	f.StringVar(&c.ConfigFile, "config", "", "path to configuration file")
 	f.StringVar(&c.Profile, "profile", "", "signing profile to use")
 	f.BoolVar(&c.IsCA, "initca", false, "initialise new CA")

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -184,6 +184,17 @@ func HashAlgoString(alg x509.SignatureAlgorithm) string {
 	}
 }
 
+func StringTLSVersion(version string) uint16 {
+	switch version {
+	case "12":
+		return tls.VersionTLS12
+	case "11":
+		return tls.VersionTLS11
+	default:
+		return tls.VersionTLS10
+	}
+}
+
 // EncodeCertificatesPEM encodes a number of x509 certificates to PEM
 func EncodeCertificatesPEM(certs []*x509.Certificate) []byte {
 	var buffer bytes.Buffer

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -184,11 +184,13 @@ func HashAlgoString(alg x509.SignatureAlgorithm) string {
 	}
 }
 
+// StringTLSVersion returns underlying enum values from human names for TLS
+// versions, defaults to current golang default of TLS 1.0
 func StringTLSVersion(version string) uint16 {
 	switch version {
-	case "12":
+	case "1.2":
 		return tls.VersionTLS12
-	case "11":
+	case "1.1":
 		return tls.VersionTLS11
 	default:
 		return tls.VersionTLS10


### PR DESCRIPTION
Solution for #912 

* Keep 1.0 as the default to prevent breakage
* Allowed values are 12, 11 and anything else defaults to 10