### PR TITLE
Performance optimization for local Signer Sign()

### DIFF
--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -391,12 +391,11 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 		return nil, err
 	}
 
-	// Get the AKI from signedCert.  This is required to support Go 1.9+.
-	// In prior versions of Go, x509.CreateCertificate updated the
-	// AuthorityKeyId of certTBS.
-	parsedCert, _ := helpers.ParseCertificatePEM(signedCert)
-
 	if s.dbAccessor != nil {
+		// Get the AKI from signedCert.  This is required to support Go 1.9+.
+		// In prior versions of Go, x509.CreateCertificate updated the
+		// AuthorityKeyId of certTBS.
+		parsedCert, _ := helpers.ParseCertificatePEM(signedCert)
 		var certRecord = certdb.CertificateRecord{
 			Serial: certTBS.SerialNumber.String(),
 			// this relies on the specific behavior of x509.CreateCertificate


### PR DESCRIPTION
When the local signer does not have a dbAccessor set, It does not need to get a AuthorityKeyId (the only reason ParseCertificatePEM is called). ParseCertificatePEM is expensive with ECC since it involves doing a verification. Moving this call into the if statement means that the Sign function runs nearly twice as fast on my machine when no dbAccessor is set (it likely doesn't matter as much for RSA since verification on RSA is relatively cheap).