### PR TITLE
Inserted auth-key whitespace stripping after ReadFile

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -56,7 +56,7 @@ func New(key string, ad []byte) (*Standard, error) {
 			if err != nil {
 				return nil, err
 			}
-			key = string(data)
+			key = strings.TrimSpace(string(data))
 		default:
 			return nil, fmt.Errorf("unknown key prefix: %s", splitKey[0])
 		}


### PR DESCRIPTION
Lines in POSIX compliant text files often end with a LF (linefeed char)
This unfortunately causes the auth key decoder to die with err msg "Unknown character U+000A"

Compiled and tested on NixOS 18.03 in combination with certmgr.