### PR TITLE
add support for multi AKI in ocsprefresh. only one DB is needed for ocspserver

### DIFF
--- a/certdb/certdb.go
+++ b/certdb/certdb.go
@@ -31,6 +31,7 @@ type Accessor interface {
 	InsertCertificate(cr CertificateRecord) error
 	GetCertificate(serial, aki string) ([]CertificateRecord, error)
 	GetUnexpiredCertificates() ([]CertificateRecord, error)
+	GetUnexpiredCertificatesByAKI( aki string) ([]CertificateRecord, error)
 	GetRevokedAndUnexpiredCertificates() ([]CertificateRecord, error)
 	GetRevokedAndUnexpiredCertificatesByLabel(label string) ([]CertificateRecord, error)
 	RevokeCertificate(serial, aki string, reasonCode int) error

--- a/certdb/sql/database_accessor.go
+++ b/certdb/sql/database_accessor.go
@@ -30,6 +30,10 @@ SELECT %s FROM certificates
 SELECT %s FROM certificates
 	WHERE CURRENT_TIMESTAMP < expiry;`
 
+	selectAllUnexpiredByAKISQL = `
+SELECT %s FROM certificates
+	WHERE (CURRENT_TIMESTAMP < expiry AND authority_key_identifier = ?);`
+
 	selectAllRevokedAndUnexpiredWithLabelSQL = `
 SELECT %s FROM certificates
 	WHERE CURRENT_TIMESTAMP < expiry AND status='revoked' AND ca_label= ?;`
@@ -149,6 +153,21 @@ func (d *Accessor) GetUnexpiredCertificates() (crs []certdb.CertificateRecord, e
 	}
 
 	err = d.db.Select(&crs, fmt.Sprintf(d.db.Rebind(selectAllUnexpiredSQL), sqlstruct.Columns(certdb.CertificateRecord{})))
+	if err != nil {
+		return nil, wrapSQLError(err)
+	}
+
+	return crs, nil
+}
+
+// GetUnexpiredCertificates gets all unexpired certificate from db.
+func (d *Accessor) GetUnexpiredCertificatesByAKI(aki string) (crs []certdb.CertificateRecord, err error) {
+	err = d.checkDB()
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.db.Select(&crs, fmt.Sprintf(d.db.Rebind(selectAllUnexpiredByAKISQL), sqlstruct.Columns(certdb.CertificateRecord{})), aki)
 	if err != nil {
 		return nil, wrapSQLError(err)
 	}

--- a/cli/ocsprefresh/ocsprefresh.go
+++ b/cli/ocsprefresh/ocsprefresh.go
@@ -56,8 +56,16 @@ func ocsprefreshMain(args []string, c cli.Config) error {
 		return err
 	}
 
+	ca, err := helpers.ReadBytes(c.CAFile)
+	if err != nil {
+		return err
+	}
+	CACert, err := helpers.ParseCertificatePEM(ca)
+	if err != nil {
+		return err
+	}
 	dbAccessor := sql.NewAccessor(db)
-	certs, err := dbAccessor.GetUnexpiredCertificates()
+	certs, err := dbAccessor.GetUnexpiredCertificatesByAKI(hex.EncodeToString(CACert.SubjectKeyId))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi,

I've added support for ocsprefresh based on the SKI of the cert given with ocsprefresh command.
`cfssl ocsprefresh -db-config db-config -ca cert -responder....`

With multiple AKI in DB table certificates i got allways
```
./cfssl ocsprefresh -db-config db-maria.json -ca $ROOTCA.pem -responder $OCSPCERT.pem -responder-key $OCSPCERT-key.pem -loglevel=0
2018/12/05 13:43:08 [DEBUG] Loading issuer cert: xxx-root-cai.pem
2018/12/05 13:43:08 [DEBUG] Loading responder cert: cert_ocsp.pem
2018/12/05 13:43:08 [DEBUG] Loading responder key: cert_ocsp-key.pem
2018/12/05 13:43:08 [DEBUG] loading db configuration file from db-maria.json
2018/12/05 13:43:08 [CRITICAL] Unable to sign OCSP response: {"code":8100,"message":"Certificate not issued by this issuer"}
{"code":8100,"message":"Certificate not issued by this issuer"}
```
when I tried to refresh the ocsp DB.
Because I had certs from RootCA and IntermediateCA in my DB.

`cfssl2 ocspserve ...`
works also very well and can service both CA (root and intermediate).

```
Root
|--- Intermediate I
      |--- Entity1
      |--- Entity2
|--- Intermediate II
      |--- Entity1
```

Of cource, the patch might not be very well coded. Sorry for that, I'm new with go.

Best regards 
Thomas