### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,52 @@
+name: cfssl
+version: '1.0'
+summary: Cloudflare's PKI and TLS toolkit 
+description: |
+  CFSSL: Cloudflare's PKI and TLS toolkit 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  cfssl:
+    plugin: go
+    source: https://github.com/cloudflare/cfssl.git
+    go-importpath: github.com/cloudflare/cfssl
+    build-packages:
+      - build-essential
+apps:
+  cfssl:
+    command: bin/cfssl
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind
+  cfssl-bundle:
+    command: bin/cfssl-bundle
+    plugs:
+      - home
+  cfssl-certinfo:
+    command: bin/cfssl-certinfo
+    plugs:
+      - home
+  cfssl-newkey:
+    command: bin/cfssl-newkey
+    plugs:
+      - home
+  cfssl-scan:
+    command: bin/cfssl-scan
+    plugs:
+      - home
+  cfssljson:
+    command: bin/cfssljson
+    plugs:
+      - home
+  mkbundle:
+    command: bin/mkbundle
+    plugs:
+      - home
+  multirootca:
+    command: bin/multirootca
+    plugs:
+      - home


### PR DESCRIPTION
Hi guys,

I've created this PR to request support for building a snap package of cfssl.

Snaps are cross-distro Linux software packages, supported on LTS and non-LTS Ubuntu, as well as many others distributions.

I think you might find this interesting as snap support is also enabled on Ubuntu server, so this could be quite useful for cloud deployments. Moreover, making a snap of cfssl will enable you to provide automatic updates via the Snap Store (snapcraft.io/store).

Snaps come with  useful security features, including the concept of confinement - fine-tuned control that selectively allows access to system resources (like network, home, x11, etc). Broadly, snaps can be 'strictly' confinement - limited access - or 'classic' - which gives them access equivalent to the host.

I built and tested cfssl with strict confinement, taking security into consideration. It is also possible to build snaps with classic confinement if the isolation/reduced vector of access proves too limiting. I can help you with that if needed, provided you want to move forward with this PR, of course.

Now, the technical details:

Install snapcraft - a command-line to build snaps. I used Ubuntu 18.04 LTS as the build system.

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/cfssl.git
cd cfssl
git checkout add-snapcraft
snapcraft

The last command creates a <cfssl-version>.snap file, something like cfssl_1.0_amd64.snap.

This snap can be installed and tested locally with:

snap install cfssl_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the snap hasn’t yet gone through the snap store review process and is not signed.

Once installed, the cfssl command can be executed, e.g.: snap run cfssl serve or snap run cfssl.cfssl-bundle <options>.

Next, you will need to complete a couple more steps:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the cfssl name in the store. 

snapcraft login
snapcraft register

- Upload a built snap to the store. The store supports multiple risk levels as “channels” with the 'edge' channel typically used to host the latest build from git master. Stable is for releases that have been tested and are considered stable for production. You can also use beta and candidate channels can also be used, for different levels of stability and testing.

snapcraft push cfssl_1.0_amd64.snap --release edge

- Test installing on a clean machine

snap install cfssl --edge

After you have completed your testing and you're happy, you can push a stable release to the stable channel, update the store page, and promote the application online.

We can help there, and we'd be happy to feature your application in our store.
