### PR TITLE
Check IP Addresses in name_whitelist

### DIFF
--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -290,6 +290,11 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
 			}
 		}
+		for _, name := range safeTemplate.IPAddresses {
+			if profile.NameWhitelist.Find([]byte(name)) == nil {
+				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
+			}
+		}
 	}
 
 	if profile.ClientProvidesSerialNumbers {

--- a/signer/local/local_test.go
+++ b/signer/local/local_test.go
@@ -1048,7 +1048,7 @@ func TestNameWhitelistSign(t *testing.T) {
 		CN: "1lab41.cf",
 	}
 
-	wl := regexp.MustCompile("^1[a-z]*[0-9]*\\.cf$")
+	wl := regexp.MustCompile("^(1[a-z]*[0-9]*\\.cf|127\\.0\\.0\\.1)$")
 
 	s := newCustomSigner(t, testECDSACaFile, testECDSACaKeyFile)
 	// Whitelist only key-related fields. Subject, DNSNames, etc shouldn't get


### PR DESCRIPTION
The name_whitlist in the cfssl ca config ignores IP addresses completely therefore any IP could be requested by the client even if a white list was used on the server side.

All the groundwork seems to be in there yet an IP is never checked.