### PR TITLE
Handle reading from Windows filepaths

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -581,7 +581,7 @@ func ReadBytes(valFile string) ([]byte, error) {
 		case "file":
 			return ioutil.ReadFile(splitVal[1])
 		default:
-			return nil, fmt.Errorf("unknown prefix: %s", splitVal[0])
+			return ioutil.ReadFile(valFile)
 		}
 	default:
 		return nil, fmt.Errorf("multiple prefixes: %s",


### PR DESCRIPTION
In helpers.GetBytes, absolute paths starting with a Windows drive letter cause the function to attempt to parse the drive letter as a prefix.  For instance, on input such as `c:\certs\file` the function would return an error `unknown prefix: c`.

This can cause issues in the CLI as well, for instance, the following also causes an error:
```
> .\bin\cfssl.exe genscr -key c:\path\to\file.pem
unknown prefix c
```

The workaround in these cases is to prefix the path like: `file:c:\path\to\file.pem`.

To make this a bit more intuitive, this PR changes the function so that it will attempt to use the OS independent methods to read the file if the prefix is not explicitly file or env.