### PR TITLE
include go 1.12 in Travis CI and drop support for go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 
 matrix:
   include:
-    - go: 1.10.x
     - go: 1.11.x
     - go: 1.12.x
     - go: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
     - go: 1.10.x
     - go: 1.11.x
+    - go: 1.12.x
     - go: master
       os: osx
       env: BUILD_TAGS=

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 CFSSL is CloudFlare's PKI/TLS swiss army knife. It is both a command line
 tool and an HTTP API server for signing, verifying, and bundling TLS
-certificates. It requires Go 1.10+ to build.
+certificates. It requires Go 1.11+ to build.
 
 Note that certain linux distributions have certain algorithms removed
 (RHEL-based distributions in particular), so the golang from the
@@ -30,7 +30,7 @@ CFSSL consists of:
 ### Building
 
 Building cfssl requires a
-[working Go 1.10+ installation](http://golang.org/doc/install) and a
+[working Go 1.11+ installation](http://golang.org/doc/install) and a
 properly set `GOPATH`.
 
 ```
@@ -62,7 +62,7 @@ You can set the `GOOS` and `GOARCH` environment variables to have Go cross compi
 ### Installation
 
 Installation requires a
-[working Go 1.10+ installation](http://golang.org/doc/install) and a
+[working Go 1.11+ installation](http://golang.org/doc/install) and a
 properly set `GOPATH`.
 
 ```


### PR DESCRIPTION
1.12 is the latest stable version of Golang and should be supported, whereas go 1.10 is now archived