### PR TITLE
Add support for Subject Alternative Names in selfsign

### DIFF
--- a/selfsign/selfsign.go
+++ b/selfsign/selfsign.go
@@ -43,6 +43,10 @@ func parseCertificateRequest(priv crypto.Signer, csrBytes []byte) (template *x50
 		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
 		PublicKey:          csr.PublicKey,
 		SignatureAlgorithm: signer.DefaultSigAlgo(priv),
+		DNSNames:           csr.DNSNames,
+		EmailAddresses:     csr.EmailAddresses,
+		IPAddresses:        csr.IPAddresses,
+		URIs:               csr.URIs,
 	}
 
 	return

--- a/selfsign/selfsign_test.go
+++ b/selfsign/selfsign_test.go
@@ -1,7 +1,12 @@
 package selfsign
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"io/ioutil"
+	"net"
+	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,6 +17,8 @@ import (
 const (
 	keyFile = "testdata/localhost.key"
 	csrFile = "testdata/localhost.csr"
+
+	csr2File = "testdata/sans.csr"
 )
 
 func TestDefaultSign(t *testing.T) {
@@ -36,4 +43,60 @@ func TestDefaultSign(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestSANs(t *testing.T) {
+	csrBytes, err := ioutil.ReadFile(csr2File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyBytes, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	priv, err := helpers.ParsePrivateKeyPEM(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	profile := config.DefaultConfig()
+	profile.Expiry = 10 * time.Hour
+
+	certPEM, err := Sign(priv, csrBytes, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, _ := pem.Decode(certPEM)
+	if p == nil || p.Type != "CERTIFICATE" {
+		// this seems unlikely
+		t.Fatalf("failed creating certificate")
+	}
+
+	cert, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedEmailAddresses := []string{"jdoe@example.com"}
+	if !reflect.DeepEqual(cert.EmailAddresses, expectedEmailAddresses) {
+		t.Errorf("cert should have contained EmailAddresses %#v but had %#v", expectedEmailAddresses, cert.EmailAddresses)
+	}
+
+	expectedDNSNames := []string{"cloudflare.com", "www.cloudflare.com"}
+	if !reflect.DeepEqual(cert.DNSNames, expectedDNSNames) {
+		t.Errorf("cert should have contained DNSNames %#v but had %#v", expectedDNSNames, cert.DNSNames)
+	}
+
+	expectedIPAddresses := []net.IP{net.IP{0xc0, 0xa8, 0x0, 0x1}}
+	if !reflect.DeepEqual(cert.IPAddresses, expectedIPAddresses) {
+		t.Errorf("cert should have contained IPAddresses %#v but had %#v", expectedIPAddresses, cert.IPAddresses)
+	}
+
+	expectedURIs := []*url.URL{&url.URL{Scheme: "https", Host: "www.cloudflare.com"}}
+	if !reflect.DeepEqual(cert.URIs, expectedURIs) {
+		t.Errorf("cert should have contained URIs %#v but had %#v", expectedURIs, cert.URIs)
+	}
+
 }

--- a/selfsign/testdata/sans.csr
+++ b/selfsign/testdata/sans.csr
@@ -1,0 +1,32 @@
+Certificate Request:
+    Data:
+        Version: 0 (0x0)
+        Subject: CN=irrelevant
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+            EC Public Key: 
+                pub: 
+                    04:9f:e6:ab:90:2a:dc:22:c8:d3:f5:30:9c:0d:8a:
+                    35:9c:6e:e3:ab:1b:e4:4c:35:3f:a6:de:c6:96:a0:
+                    25:2c:80:df:95:cd:f7:8e:49:f3:d9:8a:c8:9e:3f:
+                    3b:64:c8:37:51:30:ed:97:6f:83:27:cc:59:39:12:
+                    a5:e5:75:5e:5b
+                ASN1 OID: prime256v1
+        Attributes:
+        Requested Extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:cloudflare.com, DNS:www.cloudflare.com, email:jdoe@example.com, IP Address:192.168.0.1, URI:https://www.cloudflare.com
+    Signature Algorithm: ecdsa-with-SHA256
+        30:46:02:21:00:c8:98:66:6c:e6:98:83:89:72:b7:c0:64:f7:
+        5d:b7:ed:5a:0c:e2:90:16:a4:70:92:ac:d2:26:c5:4c:6a:7e:
+        1a:02:21:00:e2:3a:2a:7c:3b:7c:c3:f4:7b:01:89:3d:67:63:
+        c8:84:ea:52:0d:29:b1:8a:22:ef:26:ed:6f:a6:3d:d5:0e:2e
+-----BEGIN CERTIFICATE REQUEST-----
+MIIBRTCB6wIBADAVMRMwEQYDVQQDEwppcnJlbGV2YW50MFkwEwYHKoZIzj0CAQYI
+KoZIzj0DAQcDQgAEn+arkCrcIsjT9TCcDYo1nG7jqxvkTDU/pt7GlqAlLIDflc33
+jknz2YrInj87ZMg3UTDtl2+DJ8xZORKl5XVeW6B0MHIGCSqGSIb3DQEJDjFlMGMw
+YQYDVR0RBFowWIIOY2xvdWRmbGFyZS5jb22CEnd3dy5jbG91ZGZsYXJlLmNvbYEQ
+amRvZUBleGFtcGxlLmNvbYcEwKgAAYYaaHR0cHM6Ly93d3cuY2xvdWRmbGFyZS5j
+b20wCgYIKoZIzj0EAwIDSQAwRgIhAMiYZmzmmIOJcrfAZPddt+1aDOKQFqRwkqzS
+JsVMan4aAiEA4joqfDt8w/R7AYk9Z2PIhOpSDSmxiiLvJu1vpj3VDi4=
+-----END CERTIFICATE REQUEST-----


### PR DESCRIPTION
This adds support for `DNSNames`, `EmailAddresses`, `IPAddresses`, and `URIs` in the SAN parsed from the `hosts` attribute of the CSR JSON.

Fixes #777. Related: #891 (I discovered that PR when searching for pre-existing issues that matched what I'd developed independently).