### PR TITLE
feat(ocsp): add parameter to control max-age of OCSP responses

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -69,7 +69,8 @@ type Config struct {
 	AKI               string
 	DBConfigFile      string
 	CRLExpiration     time.Duration
-	Disable     	  string
+	Disable           string
+	MaxAge            time.Duration
 }
 
 // registerFlags defines all cfssl command flags and associates their values with variables.
@@ -132,6 +133,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.DurationVar(&c.CRLExpiration, "expiry", 7*helpers.OneDay, "time from now after which the CRL will expire (default: one week)")
 	f.IntVar(&log.Level, "loglevel", log.LevelInfo, "Log level (0 = DEBUG, 5 = FATAL)")
 	f.StringVar(&c.Disable, "disable", "", "endpoints to disable")
+	f.DurationVar(&c.MaxAge, "max-age", 0, "max-age for OCSP responses")
 }
 
 // RootFromConfig returns a universal signer Root structure that can

--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -227,7 +227,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	// is only returned to the client if a valid authorized OCSP response
 	// is not found or an error is returned. If a response if found the header
 	// will be altered to contain the proper max-age and modifiers.
-	response.Header().Add("Cache-Control", "max-age=0, no-cache")
+	response.Header().Set("Cache-Control", "max-age=0, no-cache")
 	// Read response from request
 	var requestBody []byte
 	var err error
@@ -330,8 +330,8 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 	}
 
 	// Write OCSP response to response
-	response.Header().Add("Last-Modified", parsedResponse.ThisUpdate.Format(time.RFC1123))
-	response.Header().Add("Expires", parsedResponse.NextUpdate.Format(time.RFC1123))
+	response.Header().Set("Last-Modified", parsedResponse.ThisUpdate.Format(time.RFC1123))
+	response.Header().Set("Expires", parsedResponse.NextUpdate.Format(time.RFC1123))
 	now := rs.clk.Now()
 	maxAge := 0
 	if now.Before(parsedResponse.NextUpdate) {
@@ -349,7 +349,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 		),
 	)
 	responseHash := sha256.Sum256(ocspResponse)
-	response.Header().Add("ETag", fmt.Sprintf("\"%X\"", responseHash))
+	response.Header().Set("ETag", fmt.Sprintf("\"%X\"", responseHash))
 
 	if headers != nil {
 		overrideHeaders(response, headers)

--- a/ocsp/responder_test.go
+++ b/ocsp/responder_test.go
@@ -174,6 +174,70 @@ func TestCacheHeaders(t *testing.T) {
 	}
 }
 
+func TestCacheHeadersWithMaxAge(t *testing.T) {
+	source, err := NewSourceFromFile(responseFile)
+	if err != nil {
+		t.Fatalf("Error constructing source: %s", err)
+	}
+
+	fc := clock.NewFake()
+	fc.Set(time.Date(2015, 11, 12, 0, 0, 0, 0, time.UTC))
+	responder := Responder{
+		Source: source,
+		clk:    fc,
+	}
+	responder.MaxAge = 3 * 24 * time.Hour
+
+	rw := httptest.NewRecorder()
+	responder.ServeHTTP(rw, &http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Path: "MEMwQTA/MD0wOzAJBgUrDgMCGgUABBSwLsMRhyg1dJUwnXWk++D57lvgagQU6aQ/7p6l5vLV13lgPJOmLiSOl6oCAhJN",
+		},
+	})
+	if rw.Code != http.StatusOK {
+		t.Errorf("Unexpected HTTP status code %d", rw.Code)
+	}
+	testCases := []struct {
+		header string
+		value  string
+	}{
+		{"Last-Modified", "Tue, 20 Oct 2015 00:00:00 UTC"},
+		{"Expires", "Sun, 15 Nov 2015 00:00:00 UTC"},                               // 3 days from the fake clock time
+		{"Cache-Control", "max-age=259200, public, no-transform, must-revalidate"}, // 3 days per responder.MaxAge set above
+		{"Etag", "\"8169FB0843B081A76E9F6F13FD70C8411597BEACF8B182136FFDD19FBD26140A\""},
+	}
+	for _, tc := range testCases {
+		headers, ok := rw.HeaderMap[tc.header]
+		if !ok {
+			t.Errorf("Header %s missing from HTTP response", tc.header)
+			continue
+		}
+		if len(headers) != 1 {
+			t.Errorf("Wrong number of headers in HTTP response. Wanted 1, got %d", len(headers))
+			continue
+		}
+		actual := headers[0]
+		if actual != tc.value {
+			t.Errorf("Got header %s: %s. Expected %s", tc.header, actual, tc.value)
+		}
+	}
+
+	rw = httptest.NewRecorder()
+	headers := http.Header{}
+	headers.Add("If-None-Match", "\"8169FB0843B081A76E9F6F13FD70C8411597BEACF8B182136FFDD19FBD26140A\"")
+	responder.ServeHTTP(rw, &http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Path: "MEMwQTA/MD0wOzAJBgUrDgMCGgUABBSwLsMRhyg1dJUwnXWk++D57lvgagQU6aQ/7p6l5vLV13lgPJOmLiSOl6oCAhJN",
+		},
+		Header: headers,
+	})
+	if rw.Code != http.StatusNotModified {
+		t.Fatalf("Got wrong status code: expected %d, got %d", http.StatusNotModified, rw.Code)
+	}
+}
+
 func TestNewSourceFromFile(t *testing.T) {
 	_, err := NewSourceFromFile("")
 	if err == nil {


### PR DESCRIPTION
The previous behaviour of the OCSP responder would set the `Expires` and `Cache-Control` headers for OCSP responses to the `NextUpdate` value. This caused some providers to experience problems with their CDN caching the responses up until the last possible moment, which was undesirable.
    
This change allows users to set a max-age for OCSP responses to address this issue.

Fixes #623.
