### PR TITLE
Fix yaml support for CertificateRequest objects, convert KeyRequest into concrete class

### DIFF
--- a/api/generator/generator.go
+++ b/api/generator/generator.go
@@ -115,7 +115,7 @@ func (g *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 	r.Body.Close()
 
 	req := new(csr.CertificateRequest)
-	req.KeyRequest = csr.NewBasicKeyRequest()
+	req.KeyRequest = csr.NewKeyRequest()
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		log.Warningf("failed to unmarshal request: %v", err)

--- a/api/generator/generator_test.go
+++ b/api/generator/generator_test.go
@@ -34,7 +34,7 @@ func csrData(t *testing.T) *bytes.Reader {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com"},
-		KeyRequest: csr.NewBasicKeyRequest(),
+		KeyRequest: csr.NewKeyRequest(),
 	}
 	csrBytes, err := json.Marshal(req)
 	if err != nil {
@@ -90,7 +90,7 @@ func TestCSRValidate(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{},
-		KeyRequest: csr.NewBasicKeyRequest(),
+		KeyRequest: csr.NewKeyRequest(),
 	}
 	err := CSRValidate(req)
 	if err != nil {

--- a/api/initca/initca.go
+++ b/api/initca/initca.go
@@ -34,7 +34,7 @@ func initialCAHandler(w http.ResponseWriter, r *http.Request) error {
 	r.Body.Close()
 
 	req := new(csr.CertificateRequest)
-	req.KeyRequest = csr.NewBasicKeyRequest()
+	req.KeyRequest = csr.NewKeyRequest()
 	err = json.Unmarshal(body, req)
 	if err != nil {
 		log.Warningf("failed to unmarshal request: %v", err)

--- a/api/initca/initca_test.go
+++ b/api/initca/initca_test.go
@@ -23,7 +23,7 @@ func csrData(t *testing.T) *bytes.Reader {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com"},
-		KeyRequest: csr.NewBasicKeyRequest(),
+		KeyRequest: csr.NewKeyRequest(),
 	}
 	csrBytes, err := json.Marshal(req)
 	if err != nil {

--- a/cli/gencert/gencert.go
+++ b/cli/gencert/gencert.go
@@ -64,7 +64,7 @@ func gencertMain(args []string, c cli.Config) error {
 	}
 
 	req := csr.CertificateRequest{
-		KeyRequest: csr.NewBasicKeyRequest(),
+		KeyRequest: csr.NewKeyRequest(),
 	}
 	err = json.Unmarshal(csrJSONFileBytes, &req)
 	if err != nil {

--- a/cli/gencsr/gencsr.go
+++ b/cli/gencsr/gencsr.go
@@ -42,7 +42,7 @@ func gencsrMain(args []string, c cli.Config) (err error) {
 
 	// prepare a stub CertificateRequest
 	req := &csr.CertificateRequest{
-		KeyRequest: csr.NewBasicKeyRequest(),
+		KeyRequest: csr.NewKeyRequest(),
 	}
 
 	if c.CertFile != "" {

--- a/cli/genkey/genkey.go
+++ b/cli/genkey/genkey.go
@@ -38,7 +38,7 @@ func genkeyMain(args []string, c cli.Config) (err error) {
 	}
 
 	req := csr.CertificateRequest{
-		KeyRequest: csr.NewBasicKeyRequest(),
+		KeyRequest: csr.NewKeyRequest(),
 	}
 	err = json.Unmarshal(csrFileBytes, &req)
 	if err != nil {

--- a/csr/csr.go
+++ b/csr/csr.go
@@ -30,12 +30,12 @@ const (
 
 // A Name contains the SubjectInfo fields.
 type Name struct {
-	C            string // Country
-	ST           string // State
-	L            string // Locality
-	O            string // OrganisationName
-	OU           string // OrganisationalUnitName
-	SerialNumber string
+	C            string `json:"C,omitempty" yaml:"C,omitempty"`   // Country
+	ST           string `json:"ST,omitempty" yaml:"ST,omitempty"` // State
+	L            string `json:"L,omitempty" yaml:"L,omitempty"`   // Locality
+	O            string `json:"O,omitempty" yaml:"O,omitempty"`   // OrganisationName
+	OU           string `json:"OU,omitempty" yaml:"OU,omitempty"` // OrganisationalUnitName
+	SerialNumber string `json:"SerialNumber,omitempty" yaml:"SerialNumber,omitempty"`
 }
 
 // A KeyRequest is a generic request for a new key.
@@ -140,7 +140,7 @@ type CAConfig struct {
 // A CertificateRequest encapsulates the API interface to the
 // certificate request functionality.
 type CertificateRequest struct {
-	CN           string
+	CN           string     `json:"CN" yaml:"CN"`
 	Names        []Name     `json:"names" yaml:"names"`
 	Hosts        []string   `json:"hosts" yaml:"hosts"`
 	KeyRequest   KeyRequest `json:"key,omitempty" yaml:"key,omitempty"`

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -15,20 +15,20 @@ import (
 	"github.com/cloudflare/cfssl/helpers"
 )
 
-//TestNew validate the CertificateRequest created to return with a BasicKeyRequest
+//TestNew validate the CertificateRequest created to return with a KeyRequest
 //in KeyRequest field
 
 func TestNew(t *testing.T) {
 
 	if cr := New(); cr.KeyRequest == nil {
-		t.Fatalf("Should create a new, empty certificate request with BasicKeyRequest")
+		t.Fatalf("Should create a new, empty certificate request with KeyRequest")
 	}
 }
 
-// TestBasicKeyRequest ensures that key generation returns the same type of
-// key specified in the BasicKeyRequest.
-func TestBasicKeyRequest(t *testing.T) {
-	kr := NewBasicKeyRequest()
+// TestKeyRequest ensures that key generation returns the same type of
+// key specified in the KeyRequest.
+func TestKeyRequest(t *testing.T) {
+	kr := NewKeyRequest()
 	priv, err := kr.Generate()
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -68,7 +68,7 @@ func TestPKIXName(t *testing.T) {
 			},
 		},
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com"},
-		KeyRequest: NewBasicKeyRequest(),
+		KeyRequest: NewKeyRequest(),
 	}
 
 	name := cr.Name()
@@ -109,7 +109,7 @@ func TestParseRequest(t *testing.T) {
 			},
 		},
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1", "jdoe@example.com", "https://www.cloudflare.com"},
-		KeyRequest: NewBasicKeyRequest(),
+		KeyRequest: NewKeyRequest(),
 	}
 
 	_, _, err := ParseRequest(cr)
@@ -143,7 +143,7 @@ func TestParseRequestCA(t *testing.T) {
 			PathLength:  0,
 			PathLenZero: true,
 		},
-		KeyRequest: NewBasicKeyRequest(),
+		KeyRequest: NewKeyRequest(),
 	}
 
 	csrBytes, _, err := ParseRequest(cr)
@@ -204,7 +204,7 @@ func TestParseRequestCANoPathlen(t *testing.T) {
 			PathLength:  0,
 			PathLenZero: false,
 		},
-		KeyRequest: NewBasicKeyRequest(),
+		KeyRequest: NewKeyRequest(),
 	}
 
 	csrBytes, _, err := ParseRequest(cr)
@@ -262,7 +262,7 @@ func TestECGeneration(t *testing.T) {
 	var eckey *ecdsa.PrivateKey
 
 	for _, sz := range []int{256, 384, 521} {
-		kr := &BasicKeyRequest{"ecdsa", sz}
+		kr := &KeyRequest{"ecdsa", sz}
 		priv, err := kr.Generate()
 		if err != nil {
 			t.Fatalf("%v", err)
@@ -281,7 +281,7 @@ func TestRSAKeyGeneration(t *testing.T) {
 	var rsakey *rsa.PrivateKey
 
 	for _, sz := range []int{2048, 3072, 4096} {
-		kr := &BasicKeyRequest{"rsa", sz}
+		kr := &KeyRequest{"rsa", sz}
 		priv, err := kr.Generate()
 		if err != nil {
 			t.Fatalf("%v", err)
@@ -296,12 +296,12 @@ func TestRSAKeyGeneration(t *testing.T) {
 	}
 }
 
-// TestBadBasicKeyRequest ensures that generating a key from a BasicKeyRequest
+// TestBadKeyRequest ensures that generating a key from a KeyRequest
 // fails with an invalid algorithm, or an invalid RSA or ECDSA key
 // size. An invalid ECDSA key size is any size other than 256, 384, or
 // 521; an invalid RSA key size is any size less than 2048 bits.
-func TestBadBasicKeyRequest(t *testing.T) {
-	kr := &BasicKeyRequest{"yolocrypto", 1024}
+func TestBadKeyRequest(t *testing.T) {
+	kr := &KeyRequest{"yolocrypto", 1024}
 
 	if _, err := kr.Generate(); err == nil {
 		t.Fatal("Key generation should fail with invalid algorithm")
@@ -323,7 +323,7 @@ func TestBadBasicKeyRequest(t *testing.T) {
 		t.Fatal("The wrong signature algorithm was returned from SigAlgo!")
 	}
 
-	kr = &BasicKeyRequest{"tobig", 9216}
+	kr = &KeyRequest{"tobig", 9216}
 
 	kr.A = "rsa"
 	if _, err := kr.Generate(); err == nil {
@@ -333,9 +333,9 @@ func TestBadBasicKeyRequest(t *testing.T) {
 	}
 }
 
-// TestDefaultBasicKeyRequest makes sure that certificate requests without
+// TestDefaultKeyRequest makes sure that certificate requests without
 // explicit key requests fall back to the default key request.
-func TestDefaultBasicKeyRequest(t *testing.T) {
+func TestDefaultKeyRequest(t *testing.T) {
 	var req = &CertificateRequest{
 		Names: []Name{
 			{
@@ -360,7 +360,7 @@ func TestDefaultBasicKeyRequest(t *testing.T) {
 		t.Fatal("Bad private key was generated!")
 	}
 
-	DefaultKeyRequest := NewBasicKeyRequest()
+	DefaultKeyRequest := NewKeyRequest()
 	switch block.Type {
 	case "RSA PRIVATE KEY":
 		if DefaultKeyRequest.Algo() != "rsa" {
@@ -388,7 +388,7 @@ func TestRSACertRequest(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "jdoe@example.com", "https://www.cloudflare.com"},
-		KeyRequest: &BasicKeyRequest{"rsa", 2048},
+		KeyRequest: &KeyRequest{"rsa", 2048},
 	}
 	_, _, err := ParseRequest(req)
 	if err != nil {
@@ -410,7 +410,7 @@ func TestBadCertRequest(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com"},
-		KeyRequest: &BasicKeyRequest{"yolo-crypto", 2048},
+		KeyRequest: &KeyRequest{"yolo-crypto", 2048},
 	}
 	_, _, err := ParseRequest(req)
 	if err == nil {
@@ -445,7 +445,7 @@ func TestGenerator(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1", "jdoe@example.com", "https://www.cloudflare.com"},
-		KeyRequest: &BasicKeyRequest{"rsa", 2048},
+		KeyRequest: &KeyRequest{"rsa", 2048},
 	}
 
 	csrBytes, _, err := g.ProcessRequest(req)
@@ -501,7 +501,7 @@ func TestBadGenerator(t *testing.T) {
 		},
 		// Missing CN
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com"},
-		KeyRequest: &BasicKeyRequest{"rsa", 2048},
+		KeyRequest: &KeyRequest{"rsa", 2048},
 	}
 
 	_, _, err := g.ProcessRequest(missingCN)
@@ -523,7 +523,7 @@ func TestWeakCSR(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "jdoe@example.com", "https://www.cloudflare.com"},
-		KeyRequest: &BasicKeyRequest{"rsa", 1024},
+		KeyRequest: &KeyRequest{"rsa", 1024},
 	}
 	g := &Generator{testValidator}
 
@@ -584,7 +584,7 @@ func TestGenerate(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1", "jdoe@example.com", "https://www.cloudflare.com"},
-		KeyRequest: &BasicKeyRequest{"ecdsa", 256},
+		KeyRequest: &KeyRequest{"ecdsa", 256},
 	}
 
 	key, err := req.KeyRequest.Generate()
@@ -639,7 +639,7 @@ func TestReGenerate(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1"},
-		KeyRequest: &BasicKeyRequest{"ecdsa", 256},
+		KeyRequest: &KeyRequest{"ecdsa", 256},
 	}
 
 	_, key, err := ParseRequest(req)
@@ -682,7 +682,7 @@ func TestBadReGenerate(t *testing.T) {
 		},
 		CN:         "cloudflare.com",
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1"},
-		KeyRequest: &BasicKeyRequest{"ecdsa", 256},
+		KeyRequest: &KeyRequest{"ecdsa", 256},
 	}
 
 	_, key, err := ParseRequest(req)

--- a/helpers/testsuite/testing_helpers_test.go
+++ b/helpers/testsuite/testing_helpers_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	keyRequest = csr.BasicKeyRequest{
+	keyRequest = csr.KeyRequest{
 		A: "rsa",
 		S: 2048,
 	}

--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cloudflare/cfssl/signer/local"
 )
 
-var validKeyParams = []csr.BasicKeyRequest{
+var validKeyParams = []csr.KeyRequest{
 	{A: "rsa", S: 2048},
 	{A: "rsa", S: 3072},
 	{A: "rsa", S: 4096},
@@ -53,7 +53,7 @@ var testRSACAKeyFile = "testdata/5min-rsa-key.pem"
 var testECDSACAFile = "testdata/5min-ecdsa.pem"
 var testECDSACAKeyFile = "testdata/5min-ecdsa-key.pem"
 
-var invalidCryptoParams = []csr.BasicKeyRequest{
+var invalidCryptoParams = []csr.KeyRequest{
 	// Weak Key
 	{A: "rsa", S: 1024},
 	// Bad param

--- a/transport/ca/localca/signer.go
+++ b/transport/ca/localca/signer.go
@@ -107,7 +107,7 @@ func (lca *CA) SignCSR(csrPEM []byte) ([]byte, error) {
 func ExampleRequest() *csr.CertificateRequest {
 	return &csr.CertificateRequest{
 		Hosts: []string{"localhost"},
-		KeyRequest: &csr.BasicKeyRequest{
+		KeyRequest: &csr.KeyRequest{
 			A: "ecdsa",
 			S: 256,
 		},

--- a/transport/ca/localca/signer_test.go
+++ b/transport/ca/localca/signer_test.go
@@ -111,7 +111,7 @@ func TestLoadSigner(t *testing.T) {
 
 var testRequest = &csr.CertificateRequest{
 	CN: "Transport Test Identity",
-	KeyRequest: &csr.BasicKeyRequest{
+	KeyRequest: &csr.KeyRequest{
 		A: "ecdsa",
 		S: 256,
 	},

--- a/transport/client.go
+++ b/transport/client.go
@@ -207,7 +207,7 @@ func (tr *Transport) RefreshKeys() (err error) {
 			log.Debugf("failed to load keypair: %v", err)
 			kr := tr.Identity.Request.KeyRequest
 			if kr == nil {
-				kr = csr.NewBasicKeyRequest()
+				kr = csr.NewKeyRequest()
 			}
 
 			err = tr.Provider.Generate(kr.Algo(), kr.Size())


### PR DESCRIPTION
Two main things here:
* add explicit yaml tag's for the various objects of a CertificateRequest.  yaml.v2 requires explicit tagging for this sort of thing, thus add it to make it happy.
* Drop the KeyRequest interface and instead just rename BasicKeyRequest as it.  Asking yaml.v2 to unmarshal through that interface triggers a panic- unlike json, it can't see through to the underlying type thus unhappily panics in that case.
  Nothing in the codebase provides an alternative implementation of KeyRequest, thus- via discussion with @cbroglie - it seems best to just drop the interface altogether.