### PR TITLE
Fix formatted logging calls.

### DIFF
--- a/api/crl/crl.go
+++ b/api/crl/crl.go
@@ -51,7 +51,7 @@ func NewHandler(dbAccessor certdb.Accessor, caPath string, caKeyPath string) (ht
 	// Parse the key given
 	key, err := helpers.ParsePrivateKeyPEMWithPassword(caKey, password)
 	if err != nil {
-		log.Debug("malformed private key %v", err)
+		log.Debugf("malformed private key %v", err)
 		return nil, err
 	}
 

--- a/api/gencrl/gencrl.go
+++ b/api/gencrl/gencrl.go
@@ -80,13 +80,13 @@ func gencrlHandler(w http.ResponseWriter, r *http.Request) error {
 
 	key, err := helpers.ParsePrivateKeyPEM([]byte(req.PrivateKey))
 	if err != nil {
-		log.Debug("malformed private key %v", err)
+		log.Debugf("malformed private key %v", err)
 		return errors.NewBadRequestString("malformed Private Key")
 	}
 
 	result, err := cert.CreateCRL(rand.Reader, key, revokedCerts, time.Now(), newExpiryTime)
 	if err != nil {
-		log.Debug("unable to create CRL: %v", err)
+		log.Debugf("unable to create CRL: %v", err)
 		return err
 	}
 

--- a/cli/crl/crl.go
+++ b/cli/crl/crl.go
@@ -74,7 +74,7 @@ func generateCRL(c cli.Config) (crlBytes []byte, err error) {
 	// Parse the key given
 	key, err := helpers.ParsePrivateKeyPEMWithPassword(cakey, password)
 	if err != nil {
-		log.Debug("malformed private key %v", err)
+		log.Debugf("malformed private key %v", err)
 		return nil, err
 	}
 

--- a/crl/crl.go
+++ b/crl/crl.go
@@ -67,7 +67,7 @@ func NewCRLFromFile(serialList, issuerFile, keyFile []byte, expiryTime string) (
 	// Parse the key given
 	key, err := helpers.ParsePrivateKeyPEMWithPassword(keyFile, password)
 	if err != nil {
-		log.Debug("Malformed private key %v", err)
+		log.Debugf("Malformed private key %v", err)
 		return nil, err
 	}
 
@@ -100,7 +100,7 @@ func NewCRLFromDB(certs []certdb.CertificateRecord, issuerCert *x509.Certificate
 func CreateGenericCRL(certList []pkix.RevokedCertificate, key crypto.Signer, issuingCert *x509.Certificate, expiryTime time.Time) ([]byte, error) {
 	crlBytes, err := issuingCert.CreateCRL(rand.Reader, key, certList, time.Now(), expiryTime)
 	if err != nil {
-		log.Debug("error creating CRL: %s", err)
+		log.Debugf("error creating CRL: %s", err)
 	}
 
 	return crlBytes, err

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -473,7 +473,7 @@ func LoadClientCertificate(certFile string, keyFile string) (*tls.Certificate, e
 	if certFile != "" && keyFile != "" {
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
-			log.Critical("Unable to read client certificate from file: %s or key from file: %s", certFile, keyFile)
+			log.Criticalf("Unable to read client certificate from file: %s or key from file: %s", certFile, keyFile)
 			return nil, err
 		}
 		log.Debug("Client certificate loaded ")

--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -135,7 +135,7 @@ func NewSignerFromFile(issuerFile, responderFile, keyFile string, interval time.
 
 	key, err := helpers.ParsePrivateKeyPEM(keyBytes)
 	if err != nil {
-		log.Debug("Malformed private key %v", err)
+		log.Debugf("Malformed private key %v", err)
 		return nil, err
 	}
 

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -119,7 +119,7 @@ func NewSignerFromFile(caFile, caKeyFile string, policy *config.Signing) (*Signe
 
 	priv, err := helpers.ParsePrivateKeyPEMWithPassword(cakey, password)
 	if err != nil {
-		log.Debug("Malformed private key %v", err)
+		log.Debugf("Malformed private key %v", err)
 		return nil, err
 	}
 

--- a/transport/listener.go
+++ b/transport/listener.go
@@ -94,7 +94,7 @@ func (l *Listener) AutoUpdate(certUpdates chan<- time.Time, errChan chan<- error
 
 		config, err := l.getConfig()
 		if err != nil {
-			log.Debug("immediately after getting a new certificate, the Transport is reporting errors: %v", err)
+			log.Debugf("immediately after getting a new certificate, the Transport is reporting errors: %v", err)
 			if errChan != nil {
 				errChan <- err
 			}
@@ -104,7 +104,7 @@ func (l *Listener) AutoUpdate(certUpdates chan<- time.Time, errChan chan<- error
 		lnet := l.Listener.Addr().Network()
 		l.Listener, err = tls.Listen(lnet, address, config)
 		if err != nil {
-			log.Debug("immediately after getting a new certificate, the Transport is reporting errors: %v", err)
+			log.Debugf("immediately after getting a new certificate, the Transport is reporting errors: %v", err)
 			if errChan != nil {
 				errChan <- err
 			}


### PR DESCRIPTION
These pass format strings, but don't call the formatting version of the function.