### PR TITLE
Add -cipher-suites flag for serve option

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Address           string
 	Port              int
 	MinTLSVersion     string
+	CipherSuites      string
 	Password          string
 	ConfigFile        string
 	CFG               *config.Config
@@ -69,7 +70,7 @@ type Config struct {
 	AKI               string
 	DBConfigFile      string
 	CRLExpiration     time.Duration
-	Disable     	  string
+	Disable           string
 }
 
 // registerFlags defines all cfssl command flags and associates their values with variables.
@@ -93,6 +94,7 @@ func registerFlags(c *Config, f *flag.FlagSet) {
 	f.StringVar(&c.Address, "address", "127.0.0.1", "Address to bind")
 	f.IntVar(&c.Port, "port", 8888, "Port to bind")
 	f.StringVar(&c.MinTLSVersion, "min-tls-version", "", "Minimum version of TLS to use, defaults to 1.0")
+	f.StringVar(&c.CipherSuites, "cipher-suites", "", "Comma-separated list of supported TLS cipher suites, defaults to auto-populated by Go")
 	f.StringVar(&c.ConfigFile, "config", "", "path to configuration file")
 	f.StringVar(&c.Profile, "profile", "", "signing profile to use")
 	f.BoolVar(&c.IsCA, "initca", false, "initialise new CA")

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -46,7 +46,7 @@ import (
 var serverUsageText = `cfssl serve -- set up a HTTP server handles CF SSL requests
 
 Usage of serve:
-        cfssl serve [-address address] [-min-tls-version version] [-ca cert] [-ca-bundle bundle] \
+        cfssl serve [-address address] [-min-tls-version version] [cipher-suites ciphers] [-ca cert] [-ca-bundle bundle] \
                     [-ca-key key] [-int-bundle bundle] [-int-dir dir] [-port port] \
                     [-metadata file] [-remote remote_host] [-config config] \
                     [-responder cert] [-responder-key key] \
@@ -58,7 +58,7 @@ Flags:
 `
 
 // Flags used by 'cfssl serve'
-var serverFlags = []string{"address", "port", "min-tls-version", "ca", "ca-key", "ca-bundle", "int-bundle", "int-dir",
+var serverFlags = []string{"address", "port", "min-tls-version", "cipher-suites", "ca", "ca-key", "ca-bundle", "int-bundle", "int-dir",
 	"metadata", "remote", "config", "responder", "responder-key", "tls-key", "tls-cert", "mutual-tls-ca",
 	"mutual-tls-cn", "tls-remote-ca", "mutual-tls-client-cert", "mutual-tls-client-key", "db-config", "disable"}
 
@@ -325,6 +325,14 @@ func serverMain(args []string, c cli.Config) error {
 	if conf.TLSCertFile == "" || conf.TLSKeyFile == "" {
 		log.Info("Now listening on ", addr)
 		return http.ListenAndServe(addr, nil)
+	}
+	if conf.CipherSuites != "" {
+		log.Info("CipherSuites selected : ", conf.CipherSuites)
+		cipherSuites, err := helpers.LoadCipherSuites(conf.CipherSuites)
+		if err != nil {
+			return fmt.Errorf("failed to load cipher-suites: %s", err)
+		}
+		tlscfg.CipherSuites = cipherSuites
 	}
 	if conf.MutualTLSCAFile != "" {
 		clientPool, err := helpers.LoadPEMCertPool(conf.MutualTLSCAFile)

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -588,3 +588,101 @@ func ReadBytes(valFile string) ([]byte, error) {
 			strings.Join(splitVal[:len(splitVal)-1], ", "))
 	}
 }
+
+// LoadCipherSuites reads cipher suite names from a comma separated list and converts
+// them to a uint16[] of CipherSuite ids that can be used in tls.Config.CipherSuites
+func LoadCipherSuites(cipherSuitesString string) ([]uint16, error) {
+	lines := strings.Split(cipherSuitesString, ",")
+	cipherSuiteNames := GetNamesForCipherSuites()
+	cipherSuites := make([]uint16, 0)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			cipher := cipherSuiteNames[line]
+			if cipher == 0 {
+				log.Warningf("CipherSuite name %s is unknown", line)
+			} else {
+				cipherSuites = append(cipherSuites, cipher)
+			}
+		}
+	}
+	return cipherSuites, nil
+}
+
+// This code for GetNamesForCipherSuites() and GetCipherSuitesForNames has been copied from
+// is plucked from https://github.com/golang/go/pull/30326
+// A better variation of that will be available from https://github.com/golang/go/issues/30325
+// when that is closed
+func GetNamesForCipherSuites() map[string]uint16 {
+	return map[string]uint16{
+		// TLS 1.0 - 1.2 cipher suites.
+		"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+
+		// TLS 1.3 cipher suites.
+		"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
+		"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
+		"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
+
+		// TLS_FALLBACK_SCSV isn't a standard cipher suite but an indicator
+		// that the client is doing version fallback. See RFC 7507.
+		"TLS_FALLBACK_SCSV": tls.TLS_FALLBACK_SCSV,
+	}
+}
+
+func GetCipherSuitesForNames() map[uint16]string {
+	return map[uint16]string{
+		// TLS 1.0 - 1.2 cipher suites.
+		tls.TLS_RSA_WITH_RC4_128_SHA:                "TLS_RSA_WITH_RC4_128_SHA",
+		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:           "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA:            "TLS_RSA_WITH_AES_128_CBC_SHA",
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA:            "TLS_RSA_WITH_AES_256_CBC_SHA",
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA256:         "TLS_RSA_WITH_AES_128_CBC_SHA256",
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256:         "TLS_RSA_WITH_AES_128_GCM_SHA256",
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384:         "TLS_RSA_WITH_AES_256_GCM_SHA384",
+		tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA:        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+		tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA:          "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:     "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:   "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305:    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305:  "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+
+		// TLS 1.3 cipher suites.
+		tls.TLS_AES_128_GCM_SHA256:       "TLS_AES_128_GCM_SHA256",
+		tls.TLS_AES_256_GCM_SHA384:       "TLS_AES_256_GCM_SHA384",
+		tls.TLS_CHACHA20_POLY1305_SHA256: "TLS_CHACHA20_POLY1305_SHA256",
+
+		// TLS_FALLBACK_SCSV isn't a standard cipher suite but an indicator
+		// that the client is doing version fallback. See RFC 7507.
+		tls.TLS_FALLBACK_SCSV: "TLS_FALLBACK_SCSV",
+	}
+}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -649,3 +649,30 @@ func TestSCTListFromOCSPResponse(t *testing.T) {
 		t.Fatal("SCTs don't match")
 	}
 }
+
+const cipherSuitesString = "TLS_AES_128_GCM_SHA256," +
+	"TLS_AES_256_GCM_SHA384," +
+	"TLS_CHACHA20_POLY1305_SHA256," +
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384," +
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA," +
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA," +
+	"TLS_RSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_RSA_WITH_AES_256_GCM_SHA384," +
+	"TLS_RSA_WITH_AES_128_CBC_SHA," +
+	"TLS_RSA_WITH_AES_256_CBC_SHA," +
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA," +
+	"TLS_NOT_A CIPHER_SUITE"
+
+func TestLoadCipherSuites(t *testing.T) {
+	cipherSuites, err := LoadCipherSuites(cipherSuitesString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cipherSuites == nil {
+		t.Fatal("cipher suites not read")
+	}
+	if len(cipherSuites) != 12 {
+		t.Fatalf("Cipher suites count %d is not 12", len(cipherSuites))
+	}
+}


### PR DESCRIPTION
This change allows the selection of cipher suites for serve option that will allow a user to avoid weak cipher suites being exposed.