### PR TITLE
project: require Go 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: go
 
 matrix:
   include:
-    - go: 1.11.x
-    - go: 1.12.1
+    - go: 1.12.7
     - go: master
       os: osx
       env: BUILD_TAGS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1
+FROM golang:1.12.7
 
 ENV USER root
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.9.2
+FROM golang:1.12.7
 
 ENV USER root
 

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-alpine3.9
+FROM golang:1.12.7-alpine3.9
 
 ENV GOPATH /go
 ENV USER root

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 CFSSL is CloudFlare's PKI/TLS swiss army knife. It is both a command line
 tool and an HTTP API server for signing, verifying, and bundling TLS
-certificates. It requires Go 1.11+ to build.
+certificates. It requires Go 1.12+ to build.
 
 Note that certain linux distributions have certain algorithms removed
 (RHEL-based distributions in particular), so the golang from the
@@ -30,7 +30,7 @@ CFSSL consists of:
 ### Building
 
 Building cfssl requires a
-[working Go 1.11+ installation](http://golang.org/doc/install) and a
+[working Go 1.12+ installation](http://golang.org/doc/install) and a
 properly set `GOPATH`.
 
 ```
@@ -62,7 +62,7 @@ You can set the `GOOS` and `GOARCH` environment variables to have Go cross compi
 ### Installation
 
 Installation requires a
-[working Go 1.11+ installation](http://golang.org/doc/install) and a
+[working Go 1.12+ installation](http://golang.org/doc/install) and a
 properly set `GOPATH`.
 
 ```


### PR DESCRIPTION
Dependencies are starting to require Go 1.12.x, Go 1.13 is near ready, and the project maintainers are comfortable dropping support for 1.11.x.

Ref: https://github.com/cloudflare/cfssl/pull/1025#issuecomment-519195077