### PR TITLE
Make reference to JavaScript relative

### DIFF
--- a/cli/serve/static/index.html
+++ b/cli/serve/static/index.html
@@ -10,7 +10,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mithril/0.2.5/mithril.min.js"
             integrity="sha256-fNsDgfj/euol0ZntptsnYiT+MtZut0GdwKpcd2PmNeY="
             crossorigin="anonymous"></script>
-    <script src="/assets/cfssl.js" async></script>
+    <script src="assets/cfssl.js" async></script>
   </head>
   <body>
     <div id="cfssl"></div>


### PR DESCRIPTION
Referencing static resources at root breaks the UI when cfssl is hosted behind a reverse proxy at a subpath.