### PR TITLE
Fix typo of genkey to gencsr

### DIFF
--- a/cli/gencsr/gencsr.go
+++ b/cli/gencsr/gencsr.go
@@ -13,7 +13,7 @@ import (
 
 var gencsrUsageText = `cfssl gencsr -- generate a csr from a private key with existing CSR json specification or certificate
 
-Usage of genkey:
+Usage of gencsr:
         cfssl gencsr -key private_key_file [-host hostname_override] CSRJSON
         cfssl gencsr -key private_key_file [-host hostname_override] -cert certificate_file
 


### PR DESCRIPTION
Fixes #1009 

Also addresses part of my own issue #1026 where I also mentioned the typo while talking about another issue.