### PR TITLE
Database support added for CFSSL in remote mode

### DIFF
--- a/api/signhandler/signhandler.go
+++ b/api/signhandler/signhandler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudflare/cfssl/auth"
 	"github.com/cloudflare/cfssl/bundler"
 	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/signer"
 )
@@ -112,7 +113,7 @@ func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
 // provided, subject information from the "subject" parameter will be used
 // in place of the subject information from the CSR.
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
-	log.Info("signature request received")
+	log.Infof("signature request: requester=%s", r.RemoteAddr)
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -164,7 +165,9 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 
 		result["bundle"] = bundle
 	}
-	log.Info("wrote response")
+	parsedCert, _ := helpers.ParseCertificatePEM(cert)
+	log.Infof("signature response: requester=%s, label=%s, profile=%s, serialno=%s",
+        r.RemoteAddr, signReq.Label, signReq.Profile, parsedCert.SerialNumber)
 	return api.SendResponse(w, result)
 }
 
@@ -217,7 +220,7 @@ func (h *AuthHandler) SetBundler(caBundleFile, intBundleFile string) (err error)
 
 // Handle receives the incoming request, validates it, and processes it.
 func (h *AuthHandler) Handle(w http.ResponseWriter, r *http.Request) error {
-	log.Info("signature request received")
+	log.Infof("signature request: requester=%s", r.RemoteAddr)
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -295,6 +298,8 @@ func (h *AuthHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 
 		result["bundle"] = bundle
 	}
-	log.Info("wrote response")
+	parsedCert, _ := helpers.ParseCertificatePEM(cert)
+	log.Infof("signature response: requester=%s, label=%s, profile=%s, serialno=%s",
+        r.RemoteAddr, signReq.Label, signReq.Profile, parsedCert.SerialNumber)
 	return api.SendResponse(w, result)
 }

--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -38,7 +38,7 @@ import (
 	"github.com/cloudflare/cfssl/cli/ocsprefresh"
 	"github.com/cloudflare/cfssl/cli/ocspserve"
 	"github.com/cloudflare/cfssl/cli/ocspsign"
-	"github.com/cloudflare/cfssl/cli/printdefault"
+	printdefaults "github.com/cloudflare/cfssl/cli/printdefault"
 	"github.com/cloudflare/cfssl/cli/revoke"
 	"github.com/cloudflare/cfssl/cli/scan"
 	"github.com/cloudflare/cfssl/cli/selfsign"

--- a/signer/remote/remote.go
+++ b/signer/remote/remote.go
@@ -72,7 +72,8 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 			if err != nil {
 				return nil, err
 			}
-			log.Debug("saved certificate with serial number ", parsedCert.SerialNumber)
+
+			log.Infof("saved certificate with serial number %s", parsedCert.SerialNumber)
 		}
 
 		return cert, nil

--- a/signer/remote/remote.go
+++ b/signer/remote/remote.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	cferr "github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/info"
+	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/signer"
 )
 
@@ -20,6 +22,7 @@ import (
 type Signer struct {
 	policy      *config.Signing
 	reqModifier func(*http.Request, []byte)
+	dbAccessor  certdb.Accessor
 }
 
 // NewSigner creates a new remote Signer directly from a
@@ -47,6 +50,31 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 		return
 	}
 	if cert, ok := resp.([]byte); ok {
+
+		// Get the AKI from signedCert.  This is required to support Go 1.9+.
+		// In prior versions of Go, x509.CreateCertificate updated the
+		// AuthorityKeyId of certTBS.
+		parsedCert, _ := helpers.ParseCertificatePEM(cert)
+
+		if s.dbAccessor != nil {
+			var certRecord = certdb.CertificateRecord{
+				Serial: parsedCert.SerialNumber.String(),
+				// this relies on the specific behavior of x509.CreateCertificate
+				// which sets the AuthorityKeyId from the signer's SubjectKeyId
+				AKI:     hex.EncodeToString(parsedCert.AuthorityKeyId),
+				CALabel: req.Label,
+				Status:  "good",
+				Expiry:  parsedCert.NotAfter,
+				PEM:     string(cert),
+			}
+
+			err = s.dbAccessor.InsertCertificate(certRecord)
+			if err != nil {
+				return nil, err
+			}
+			log.Debug("saved certificate with serial number ", parsedCert.SerialNumber)
+		}
+
 		return cert, nil
 	}
 	return
@@ -114,12 +142,12 @@ func (s *Signer) SetPolicy(policy *config.Signing) {
 
 // SetDBAccessor sets the signers' cert db accessor, currently noop.
 func (s *Signer) SetDBAccessor(dba certdb.Accessor) {
-	// noop
+	s.dbAccessor = dba
 }
 
 // GetDBAccessor returns the signers' cert db accessor, currently noop.
 func (s *Signer) GetDBAccessor() certdb.Accessor {
-	return nil
+	return s.dbAccessor
 }
 
 // SetReqModifier sets the function to call to modify the HTTP request prior to sending it


### PR DESCRIPTION
CFSSL does not create cert record in SQL database if
signed in remote mode (i.e. using multirootca). With
this mod all certs will be saved id DB regardless of
signing mode (local/remote).

Author-Change-Id: IB#1094762