### PR TITLE
HSM support and debug logging added in mulirootca

### DIFF
--- a/cmd/multirootca/ca.go
+++ b/cmd/multirootca/ca.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/letsencrypt/pkcs11key"
+
 	"github.com/cloudflare/cfssl/api/info"
 	"github.com/cloudflare/cfssl/certdb/sql"
 	"github.com/cloudflare/cfssl/log"
@@ -23,7 +25,7 @@ import (
 func parseSigner(root *config.Root) (signer.Signer, error) {
 	privateKey := root.PrivateKey
 	switch priv := privateKey.(type) {
-	case *rsa.PrivateKey, *ecdsa.PrivateKey:
+	case *rsa.PrivateKey, *ecdsa.PrivateKey, *pkcs11key.Key:
 		s, err := local.NewSigner(priv, root.Certificate, signer.DefaultSigAlgo(priv), nil)
 		if err != nil {
 			return nil, err
@@ -46,12 +48,18 @@ var (
 )
 
 func main() {
+	flagLogLevel := flag.Int("loglevel", log.LevelInfo, "Log level (0 = DEBUG, 5 = FATAL)")
 	flagAddr := flag.String("a", ":8888", "listening address")
 	flagRootFile := flag.String("roots", "", "configuration file specifying root keys")
 	flagDefaultLabel := flag.String("l", "", "specify a default label")
 	flagEndpointCert := flag.String("tls-cert", "", "server certificate")
 	flagEndpointKey := flag.String("tls-key", "", "server private key")
+
 	flag.Parse()
+
+	if *flagLogLevel >= 0 && *flagLogLevel <= 5 {
+		log.Level = *flagLogLevel
+	}
 
 	if *flagRootFile == "" {
 		log.Fatal("no root file specified")


### PR DESCRIPTION
With this mod applied, one can use PKCS #11 token in multirootca
for certs signing (tested succesfully with Nitrokey HSM 2; should
work with other PKCS #11 compatible HSM tokens too). Requires importing

    https://github.com/letsencrypt/pkcs11key

package (not included in this commit; please consider including
upstream).

Example config:

    [ default ]
    private = pkcs11://notused
    module = /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so
    token_label = UserPIN (myhsm)
    pin = 123456
    config = /etc/cfssl/server.json
    certificate = /etc/cfssl/issuer.crt

Note: issuer.crt must contain cert issued for signing key in HSM.

This mod also adds loglevel parameter to multirootca command
to enable easier multirootca execution debug.

Author-Change-Id: IB#1094763