### PR TITLE
Certificate Policies support added in signing profiles

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,15 +44,15 @@ type OID asn1.ObjectIdentifier
 // https://tools.ietf.org/html/rfc3280.html#page-106.
 // Valid values of Type are "id-qt-unotice" and "id-qt-cps"
 type CertificatePolicy struct {
-	ID         OID
-	Qualifiers []CertificatePolicyQualifier
+	ID         OID `json:"id"`
+	Qualifiers []CertificatePolicyQualifier `json:"qualifiers"`
 }
 
 // CertificatePolicyQualifier represents a single qualifier from an ASN.1
 // PolicyInformation structure.
 type CertificatePolicyQualifier struct {
-	Type  string
-	Value string
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }
 
 // AuthRemote is an authenticated remote signer.
@@ -105,7 +105,7 @@ type SigningProfile struct {
 	// is.
 	IgnoredLints []string `json:"ignored_lints"`
 
-	Policies                    []CertificatePolicy
+	Policies                    []CertificatePolicy `json:"cert_policies"`
 	Expiry                      time.Duration
 	Backdate                    time.Duration
 	Provider                    auth.Provider

--- a/doc/cmd/cfssl.txt
+++ b/doc/cmd/cfssl.txt
@@ -163,6 +163,25 @@ blank.
     + name_whitelist: if provided, this should be a regular expression
       for permitted SANs.
 
+    + cert_policies: a list of Certificate Policies (RFC 5280
+      4.2.1.4); example:
+
+      "cert_policies": [
+          {
+              "id": "1.2.3",
+              "qualifiers": [
+                  {
+                      "type": "id-qt-cps",
+                      "value": "http://example.com/cps"
+                  },
+                  {
+                      "type": "id-qt-unotice",
+                      "value": "CPS available on http://example.com/cps"
+                  }
+              ]
+          }
+      ]
+
 The signing profiles reside in the "signing" dictionary. This may
 contain a "default" field which contains the profile to use by default
 for requests, and a "profiles" dictionary mapping profile names to


### PR DESCRIPTION
This mod adds support for Certificate Policies (RFC 5280
4.2.1.4) in CFSS signing profiles.

Author-Change-Id: IB#1094764