### PR TITLE
Column created_at added to certdb; added indexes on created_at and revoked_at columns

### DIFF
--- a/certdb/certdb.go
+++ b/certdb/certdb.go
@@ -12,6 +12,7 @@ type CertificateRecord struct {
 	CALabel   string    `db:"ca_label"`
 	Status    string    `db:"status"`
 	Reason    int       `db:"reason"`
+	CreatedAt time.Time `db:"created_at"`
 	Expiry    time.Time `db:"expiry"`
 	RevokedAt time.Time `db:"revoked_at"`
 	PEM       string    `db:"pem"`

--- a/certdb/mysql/migrations/001_CreateCertificates.sql
+++ b/certdb/mysql/migrations/001_CreateCertificates.sql
@@ -7,6 +7,7 @@ CREATE TABLE certificates (
   ca_label                 varbinary(128),
   status                   varbinary(128) NOT NULL,
   reason                   int,
+  created_at               timestamp DEFAULT '0000-00-00 00:00:00',
   expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
   revoked_at               timestamp DEFAULT '0000-00-00 00:00:00',
   pem                      varbinary(4096) NOT NULL,

--- a/certdb/mysql/migrations/001_CreateCertificates.sql
+++ b/certdb/mysql/migrations/001_CreateCertificates.sql
@@ -11,7 +11,9 @@ CREATE TABLE certificates (
   expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
   revoked_at               timestamp DEFAULT '0000-00-00 00:00:00',
   pem                      varbinary(4096) NOT NULL,
-  PRIMARY KEY(serial_number, authority_key_identifier)
+  PRIMARY KEY(serial_number, authority_key_identifier),
+  INDEX certificates_created_at (created_at),
+  INDEX certificates_revoked_at (revoked_at)
 );
 
 CREATE TABLE ocsp_responses (

--- a/certdb/pg/migrations/001_CreateCertificates.sql
+++ b/certdb/pg/migrations/001_CreateCertificates.sql
@@ -7,6 +7,7 @@ CREATE TABLE certificates (
   ca_label                 bytea,
   status                   bytea NOT NULL,
   reason                   int,
+  created_at               timestamptz,
   expiry                   timestamptz,
   revoked_at               timestamptz,
   pem                      bytea NOT NULL,

--- a/certdb/pg/migrations/001_CreateCertificates.sql
+++ b/certdb/pg/migrations/001_CreateCertificates.sql
@@ -13,6 +13,28 @@ CREATE TABLE certificates (
   pem                      bytea NOT NULL,
   PRIMARY KEY(serial_number, authority_key_identifier)
 );
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE LOWER(indexname) = LOWER('certificates_created_at')
+    ) THEN
+    CREATE INDEX certificates_created_at ON certificates (created_at);
+END IF;
+END$$;
+;
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE LOWER(indexname) = LOWER('certificates_revoked_at')
+    ) THEN
+    CREATE INDEX certificates_revoked_at ON certificates (revoked_at);
+END IF;
+END$$;
+;
 
 CREATE TABLE ocsp_responses (
   serial_number            bytea NOT NULL,

--- a/certdb/sql/database_accessor.go
+++ b/certdb/sql/database_accessor.go
@@ -19,8 +19,8 @@ func init() {
 
 const (
 	insertSQL = `
-INSERT INTO certificates (serial_number, authority_key_identifier, ca_label, status, reason, expiry, revoked_at, pem)
-	VALUES (:serial_number, :authority_key_identifier, :ca_label, :status, :reason, :expiry, :revoked_at, :pem);`
+INSERT INTO certificates (serial_number, authority_key_identifier, ca_label, status, reason, created_at, expiry, revoked_at, pem)
+	VALUES (:serial_number, :authority_key_identifier, :ca_label, :status, :reason, CURRENT_TIMESTAMP, :expiry, :revoked_at, :pem);`
 
 	selectSQL = `
 SELECT %s FROM certificates

--- a/certdb/sqlite/migrations/001_CreateCertificates.sql
+++ b/certdb/sqlite/migrations/001_CreateCertificates.sql
@@ -7,6 +7,7 @@ CREATE TABLE certificates (
   ca_label                 blob,
   status                   blob NOT NULL,
   reason                   int,
+  created_at               timestamp,
   expiry                   timestamp,
   revoked_at               timestamp,
   pem                      blob NOT NULL,

--- a/certdb/sqlite/migrations/001_CreateCertificates.sql
+++ b/certdb/sqlite/migrations/001_CreateCertificates.sql
@@ -13,6 +13,8 @@ CREATE TABLE certificates (
   pem                      blob NOT NULL,
   PRIMARY KEY(serial_number, authority_key_identifier)
 );
+CREATE INDEX certificates_created_at ON certificates (created_at);
+CREATE INDEX certificates_revoked_at ON certificates (revoked_at);
 
 CREATE TABLE ocsp_responses (
   serial_number            blob NOT NULL,


### PR DESCRIPTION
This mod adds created_at column to certbd. Helpful for
auditing and selections based on cert creation time.

Indexes for created_at and revoked_at columns added for faster
searches in large databases.

Author-Change-Id: IB#1095303