### PR TITLE
Fixed handling of revocation reasons #0 and #10

### DIFF
--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -96,7 +96,7 @@ func ReasonStringToCode(reason string) (reasonCode int, err error) {
 		if err != nil {
 			return
 		}
-		if reasonCode >= ocsp.AACompromise || reasonCode <= ocsp.Unspecified {
+		if reasonCode > ocsp.AACompromise || reasonCode < ocsp.Unspecified {
 			return 0, cferr.New(cferr.OCSPError, cferr.InvalidStatus)
 		}
 	}


### PR DESCRIPTION
This mod fixes bug in cfssl revoke that blocked revoking
certifiate with reasons 0 () and 10 ().

Author-Change-Id: IB#1095452