### PR TITLE
Replace pkg.cfssl.org with 'Packages' tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 dist/*
-cli/serve/static.rice-box.go
+cli/serve/rice-box.go
 coverage.txt
 profile.out
 bin

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,13 @@ export GOPROXY := off
 .PHONY: all
 all: bin/cfssl bin/cfssl-bundle bin/cfssl-certinfo bin/cfssl-newkey bin/cfssl-scan bin/cfssljson bin/mkbundle bin/multirootca
 
-bin/%: $(shell find . -type f -name '*.go')
+bin/%: $(shell find . -type f -name '*.go') cli/serve/rice-box.go
 	@mkdir -p $(dir $@)
 	go build -o $@ ./cmd/$(@F)
+
+cli/serve/rice-box.go: bin/rice $(shell find cli/serve/static -type f)
+cli/serve/rice-box.go:
+	./bin/rice embed-go -i=./cli/serve
 
 .PHONY: install
 install: install-cfssl install-cfssl-bundle install-cfssl-certinfo install-cfssl-newkey install-cfssl-scan install-cfssljson install-mkbundle install-multirootca
@@ -15,15 +19,20 @@ install: install-cfssl install-cfssl-bundle install-cfssl-certinfo install-cfssl
 install-%:
 	go install ./cmd/$(@F:install-%=%)
 
-bin/rice: $(shell find . -type f -name '*.go')
+.PHONY: serve
+serve: bin/cfssl
+serve:
+	./bin/cfssl serve
+
+bin/rice: $(shell find vendor -type f -name '*.go')
 	@mkdir -p $(dir $@)
 	go build -o $@ ./vendor/github.com/GeertJohan/go.rice/rice
 
-bin/golint: $(shell find . -type f -name '*.go')
+bin/golint: $(shell find vendor -type f -name '*.go')
 	@mkdir -p $(dir $@)
 	go build -o $@ ./vendor/golang.org/x/lint/golint
 
-bin/goose: $(shell find . -type f -name '*.go')
+bin/goose: $(shell find vendor -type f -name '*.go')
 	@mkdir -p $(dir $@)
 	go build -o $@ ./vendor/bitbucket.org/liamstask/goose/cmd/goose
 

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -108,8 +108,9 @@ func (hb *httpBox) Open(name string) (http.File, error) {
 // staticBox is the box containing all static assets.
 var staticBox = &httpBox{
 	redirects: map[string]string{
-		"/scan":   "/index.html",
-		"/bundle": "/index.html",
+		"/scan":     "/index.html",
+		"/bundle":   "/index.html",
+		"/packages": "/index.html",
 	},
 }
 

--- a/cli/serve/static/assets/cfssl.js
+++ b/cli/serve/static/assets/cfssl.js
@@ -121,7 +121,7 @@
               navLink('a', '/bundle', Tformat('bundle.title'))
             ]),
             m('ul.nav.navbar-nav.navbar-right', [
-              m('li', m('a[href="https://pkg.cfssl.org"]', Tformat('common.packages'))),
+              navLink('a', '/packages', Tformat('common.packages')),
               m('li', m('a[href="https://github.com/cloudflare/cfssl"]', 'GitHub')),
             ])
           ])
@@ -226,12 +226,29 @@
     },
     view: function() {
       return appWrapper([
-        m('h1.page-header', 'CFSSL: CloudFlare\'s PKI toolkit'), m('p', [
+        m('h1.page-header', 'CFSSL: Cloudflare\'s PKI toolkit'), m('p', [
           'See ',
           m('a[href="https://blog.cloudflare.com/introducing-cfssl"]', 'blog post'),
           ' or ',
           m('a[href="https://github.com/cloudflare/cfssl"]', 'contribute on GitHub'),
           '.'
+        ])
+      ]);
+    }
+  };
+
+  var packages = {
+    controller: function() {
+      page.title(Tformat('common.packages'));
+      return;
+    },
+    view: function() {
+      return appWrapper([
+        m('h1.page-header', Tformat('common.packages')),
+        m('ul', [
+          m('li', m('a[href="https://github.com/cloudflare/cfssl/releases"]', 'Download binaries (GitHub)')),
+          m('li', m('a[href="https://hub.docker.com/r/cloudflare/cfssl"]', 'Docker images')),
+          m('li', m('a[href="https://pkg.cloudflare.com/"]', 'Install from apt or yum'))
         ])
       ]);
     }
@@ -708,7 +725,8 @@
     '/bundle': bundle,
     '/bundle/:domain': bundle,
     '/scan': scan,
-    '/scan/:domain': scan
+    '/scan/:domain': scan,
+    '/packages': packages
   });
 
   window.scan = scan;


### PR DESCRIPTION
This replaces the defunct http://pkg.cfssl.org/ link with a new tab containing separate links to download binaries directly from the GitHub release, Docker images, and .deb/.rpm packages from pkg.cloudflare.com.