### PR TITLE
Build staticly with musl for better compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,9 @@ builds:
     main: ./cmd/cfssl
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: cfssl-windows
     binary: cfssl
     env:
@@ -58,6 +61,9 @@ builds:
     main: ./cmd/cfssl-bundle
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: cfssl-bundle-windows
     binary: cfssl-bundle
     env:
@@ -91,6 +97,9 @@ builds:
     main: ./cmd/cfssl-certinfo
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: cfssl-certinfo-windows
     binary: cfssl-certinfo
     env:
@@ -124,6 +133,9 @@ builds:
     main: ./cmd/cfssl-newkey
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: cfssl-newkey-windows
     binary: cfssl-newkey
     env:
@@ -157,6 +169,9 @@ builds:
     main: ./cmd/cfssl-scan
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: cfssl-scan-windows
     binary: cfssl-scan
     env:
@@ -190,6 +205,9 @@ builds:
     main: ./cmd/cfssljson
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: cfssljson-windows
     binary: cfssljson
     env:
@@ -223,6 +241,9 @@ builds:
     main: ./cmd/mkbundle
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: mkbundle-windows
     binary: mkbundle
     env:
@@ -256,6 +277,9 @@ builds:
     main: ./cmd/multirootca
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
+      - -linkmode external -extldflags "-static"
+    env:
+      - CC=/usr/bin/musl-gcc
   - id: multirootca-windows
     binary: multirootca
     env:

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,14 @@ __check_defined = \
 	$(if $(value $1),, \
 		$(error Undefined $1$(if $2, ($2))))
 
+.PHONY: snapshot
+snapshot:
+	docker run --rm  -v $(PWD):/workdir -w /workdir cbroglie/goreleaser-cgo:1.12.12-musl goreleaser --rm-dist --snapshot --skip-publish
+
 .PHONY: release
 release:
 	@:$(call check_defined, GITHUB_TOKEN)
-	docker run -e GITHUB_TOKEN=$(GITHUB_TOKEN) --rm  -v $(PWD):/workdir -w /workdir cbroglie/goreleaser-cgo:1.12.12 goreleaser --rm-dist
+	docker run -e GITHUB_TOKEN=$(GITHUB_TOKEN) --rm  -v $(PWD):/workdir -w /workdir cbroglie/goreleaser-cgo:1.12.12-musl goreleaser --rm-dist
 
 BUILD_PATH   := $(CURDIR)/build
 INSTALL_PATH := $(BUILD_PATH)/usr/local/bin


### PR DESCRIPTION
As mentioned in #1053 static compilation will increase compatibility with older Linux distros by removing the dependency on a newer version of glibc.

Running these builds will require musl to be installed (`musl-tools` on Ubuntu, `musl` on Arch)

In my testing, the file sizes are similar to the current (dynamically linked) versions.