### PR TITLE
also output sha256 digest when generating certificate

### DIFF
--- a/api/generator/generator.go
+++ b/api/generator/generator.go
@@ -4,6 +4,7 @@ package generator
 import (
 	"crypto/md5"
 	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -35,6 +36,7 @@ specifically, section 10.2.3 ("Information Requirements").`
 type Sum struct {
 	MD5  string `json:"md5"`
 	SHA1 string `json:"sha-1"`
+	SHA256 string `json:"sha-256"`
 }
 
 // Validator is a type of function that contains the logic for validating
@@ -97,8 +99,10 @@ func computeSum(in []byte) (sum Sum, err error) {
 
 	md5Sum := md5.Sum(data)
 	sha1Sum := sha1.Sum(data)
+	sha256Sum := sha256.Sum256(data)
 	sum.MD5 = fmt.Sprintf("%X", md5Sum[:])
 	sum.SHA1 = fmt.Sprintf("%X", sha1Sum[:])
+	sum.SHA256 = fmt.Sprintf("%X", sha256Sum[:])
 	return
 }
 

--- a/doc/api/endpoint_newcert.txt
+++ b/doc/api/endpoint_newcert.txt
@@ -50,11 +50,13 @@ Example:
         "sums": {
             "certificate": {
                 "md5": "E9308D1892F1B77E6721EA2F79C026BE",
-                "sha-1": "4640E6DEC2C40B74F46C409C1D31928EE0073D25"
+                "sha-1": "4640E6DEC2C40B74F46C409C1D31928EE0073D25",
+                "sha-256": "8812010B59EB8C00CDD9292078717216B131A710703F18A4DFB94AC166F507DF"
             },
             "certificate_request": {
                 "md5": "AA924136405006E36CEE39FED9CBA5D7",
-                "sha-1": "DF955A43DF669D38E07BF0479789D13881DC9024"
+                "sha-1": "DF955A43DF669D38E07BF0479789D13881DC9024",
+                "sha-256": "C7600A68BDB689346E2E4438A374606DFC3FFD3B6B9722E0A8CB32AA88FBA686"
             }
         }
     },

--- a/doc/api/endpoint_newkey.txt
+++ b/doc/api/endpoint_newkey.txt
@@ -46,7 +46,8 @@ Example:
         "sums": {
             "certificate_request": {
                 "md5": "95E25336DA65B58DA250C3B5FAA4B97F",
-                "sha-1": "5F1ACE9D14F55E95FAA246A80474873C14E0F42F"
+                "sha-1": "5F1ACE9D14F55E95FAA246A80474873C14E0F42F",
+                "sha-256": "EA8409AE9117FE62A91DBD64F2C7496DC4CF3A06C5D513D5811A1CC1E8B2D180"
             }
         }
     },


### PR DESCRIPTION
The newkey and newcert endpoints now will print the sha256 digest in addition to md5 and sha1