### PR TITLE
Add s390x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ matrix:
   include:
     - go: 1.12.x
     - go: 1.13.x
+    - arch: s390x
+      go: 1.12.x
+    - arch: s390x
+      go: 1.13.x
 
 # Install g++-4.8 to support std=c++11 for github.com/google/certificate-transparency/go/merkletree
 addons:
@@ -33,6 +37,16 @@ branches:
 
 before_script:
   - make bin/golint
+  #Setup postgresql for s390x environment
+  - if [[ $(uname -m) == 's390x' ]]; then
+      sudo apt-get --purge remove postgresql-*;
+      sudo rm -Rf /etc/postgresql /var/lib/postgresql;
+      sudo apt-get update;
+      sudo apt-get install -y postgresql-9.5;
+      sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/9.5/main/pg_hba.conf;
+      sudo service postgresql restart;
+      sudo -u postgres createuser travis;
+    fi  
   # Setup DBs + run migrations
   # The sql_mode adjustment is to remove a sql_mode that was added in MySQL 5.7, this mode applies a rule that does:
   # > The NO_ZERO_DATE mode affects whether the server permits '0000-00-00' as a valid date.


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.