### PR TITLE
generate ocsp response when a cert is generated

### DIFF
--- a/api/sign/sign.go
+++ b/api/sign/sign.go
@@ -47,5 +47,5 @@ func NewAuthHandler(caFile, caKeyFile string, policy *config.Signing) (http.Hand
 		return nil, err
 	}
 
-	return signhandler.NewAuthHandlerFromSigner(s)
+	return signhandler.NewAuthHandlerFromSigner(s, nil)
 }

--- a/cli/ocsprefresh/ocsprefresh.go
+++ b/cli/ocsprefresh/ocsprefresh.go
@@ -105,7 +105,7 @@ func SignerFromConfig(c cli.Config) (ocsp.Signer, error) {
 	if k == "" {
 		k = c.KeyFile
 	}
-	return ocsp.NewSignerFromFile(c.CAFile, c.ResponderFile, k, time.Duration(c.Interval))
+	return ocsp.NewSignerFromFile(c.CAFile, c.ResponderFile, k, time.Duration(c.Interval), nil)
 }
 
 // Command assembles the definition of Command 'ocsprefresh'

--- a/cli/ocspsign/ocspsign.go
+++ b/cli/ocspsign/ocspsign.go
@@ -2,6 +2,7 @@
 package ocspsign
 
 import (
+	"github.com/jmoiron/sqlx"
 	"io/ioutil"
 	"time"
 
@@ -62,7 +63,7 @@ func ocspSignerMain(args []string, c cli.Config) (err error) {
 		}
 	}
 
-	s, err := SignerFromConfig(c)
+	s, err := SignerFromConfig(c, nil)
 	if err != nil {
 		log.Critical("Unable to create OCSP signer: ", err)
 		return
@@ -79,14 +80,15 @@ func ocspSignerMain(args []string, c cli.Config) (err error) {
 }
 
 // SignerFromConfig creates a signer from a cli.Config as a helper for cli and serve
-func SignerFromConfig(c cli.Config) (ocsp.Signer, error) {
+func SignerFromConfig(c cli.Config, db *sqlx.DB) (ocsp.Signer, error) {
 	//if this is called from serve then we need to use the specific responder key file
 	//fallback to key for backwards-compatibility
 	k := c.ResponderKeyFile
 	if k == "" {
 		k = c.KeyFile
 	}
-	return ocsp.NewSignerFromFile(c.CAFile, c.ResponderFile, k, time.Duration(c.Interval))
+
+	return ocsp.NewSignerFromFile(c.CAFile, c.ResponderFile, k, time.Duration(c.Interval), db)
 }
 
 // Command assembles the definition of Command 'ocspsign'

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -142,7 +142,7 @@ var endpoints = map[string]func() (http.Handler, error){
 			return nil, errBadSigner
 		}
 
-		h, err := signhandler.NewAuthHandlerFromSigner(s)
+		h, err := signhandler.NewAuthHandlerFromSigner(s, ocspSigner)
 		if err != nil {
 			return nil, err
 		}
@@ -309,7 +309,7 @@ func serverMain(args []string, c cli.Config) error {
 		log.Warningf("couldn't initialize signer: %v", err)
 	}
 
-	if ocspSigner, err = ocspsign.SignerFromConfig(c); err != nil {
+	if ocspSigner, err = ocspsign.SignerFromConfig(c, db); err != nil {
 		log.Warningf("couldn't initialize ocsp signer: %v", err)
 	}
 


### PR DESCRIPTION
This PR adds support for generating an OCSP response and inserting it into the db as soon as a cert is signed, if a ocsp signer keypair is provided in serve mode.