### PR TITLE
Fix readme still referencing deleted doc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,5 +412,3 @@ Then building with `go build` will use the embedded resources.
 Additional documentation can be found in the "doc" directory:
 
 * `api/intro.txt`: documents the API endpoints
-* `bootstrap.txt`: a walkthrough from building the package to getting
-  up and running


### PR DESCRIPTION
Commit ee73190 removed doc/bootstrap.txt but it is still mentioned in README.md

I would like to suggest replacing the entire "Additional documentation" section with a reference to doc/README.txt to prevent repeating it's content.