### PR TITLE
add copy_extensions configuration to local signer to allow 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 *.deb
 *.rpm
 test
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ profile.out
 bin
 *.deb
 *.rpm
+test

--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ type SigningProfile struct {
 	ExpiryString        string       `json:"expiry"`
 	BackdateString      string       `json:"backdate"`
 	AuthKeyName         string       `json:"auth_key"`
+	CopyExtensions      bool         `json:"copy_extensions"`
 	PrevAuthKeyName     string       `json:"prev_auth_key"` // to suppport key rotation
 	RemoteName          string       `json:"remote"`
 	NotBefore           time.Time    `json:"not_before"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -256,6 +256,25 @@ var validLocalConfigsWithCAConstraint = []string{
 	}`,
 }
 
+var copyExtensionWantedlLocalConfig = `
+{
+	"signing": {
+		"default": {
+			"expiry": "8000h",
+			"copy_extensions": true
+		}
+	}
+}`
+
+var copyExtensionNotWantedlLocalConfig = `
+{
+	"signing": {
+		"default": {
+			"expiry": "8000h"
+		}
+	}
+}`
+
 func TestInvalidProfile(t *testing.T) {
 	if invalidProfileConfig.Signing.Profiles["invalid"].validProfile(false) {
 		t.Fatal("invalid profile accepted as valid")
@@ -565,5 +584,27 @@ func TestValidCAConstraint(t *testing.T) {
 		if err != nil {
 			t.Fatal("can't parse valid ca constraint")
 		}
+	}
+}
+
+func TestWantCopyExtension(t *testing.T) {
+	localConfig, err := LoadConfig([]byte(copyExtensionWantedlLocalConfig))
+	if localConfig.Signing.Default.CopyExtensions != true {
+		t.Fatal("incorrect TestWantCopyExtension().")
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDontWantCopyExtension(t *testing.T) {
+	localConfig, err := LoadConfig([]byte(copyExtensionNotWantedlLocalConfig))
+	if localConfig.Signing.Default.CopyExtensions != false {
+		t.Fatal("incorrect TestDontWantCopyExtension().")
+	}
+
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
 	"io/ioutil"
@@ -110,11 +111,43 @@ func TestParseRequest(t *testing.T) {
 		},
 		Hosts:      []string{"cloudflare.com", "www.cloudflare.com", "192.168.0.1", "jdoe@example.com", "https://www.cloudflare.com"},
 		KeyRequest: NewKeyRequest(),
+		Extensions: []pkix.Extension{
+			pkix.Extension{
+				Id: asn1.ObjectIdentifier{1, 2, 3, 4, 5},
+				Value: []byte("AgEB"),
+			},
+		},
 	}
 
-	_, _, err := ParseRequest(cr)
+	csrBytes, _, err := ParseRequest(cr)
 	if err != nil {
 		t.Fatalf("%v", err)
+	}
+	
+	block, _ := pem.Decode(csrBytes)
+	if block == nil {
+		t.Fatalf("%v", err)
+	}
+
+	if block.Type != "CERTIFICATE REQUEST" {
+		t.Fatalf("Incorrect block type: %s", block.Type)
+	}
+
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	found := false
+	for _, ext := range csr.Extensions {
+		if ext.Id.Equal(asn1.ObjectIdentifier{1, 2, 3, 4, 5}) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("CSR did not include Custom Extension")
 	}
 }
 

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -288,6 +288,7 @@ func OverrideHosts(template *x509.Certificate, hosts []string) {
 // certificate or certificate request with the signing profile,
 // specified by profileName.
 func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
+	log.Debug("sign ", req)
 	profile, err := signer.Profile(s, req.Profile)
 	if err != nil {
 		return

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -288,7 +288,6 @@ func OverrideHosts(template *x509.Certificate, hosts []string) {
 // certificate or certificate request with the signing profile,
 // specified by profileName.
 func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
-	log.Debug("sign ", req)
 	profile, err := signer.Profile(s, req.Profile)
 	if err != nil {
 		return
@@ -304,7 +303,7 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 			cferr.BadRequest, errors.New("not a csr"))
 	}
 
-	csrTemplate, err := signer.ParseCertificateRequest(s, block.Bytes)
+	csrTemplate, err := signer.ParseCertificateRequest(s, profile, block.Bytes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This Pull Requests add `copy_extensions` to the local signer so that you can specify if you want to copy the additional extensions presented in a CSR. This way a client can make a request say with `qcStatement` and get a certificate issued with those extensions included.

This makes it possible to produce eIDAS like certificates where the details are included in the CSR and the signer can then validate those details before issuing the certificate,

```
{
	"signing": {
		"default": {
			"expiry": "8000h",
			"copy_extensions": true
		}
	}
}
```