### PR TITLE
Correctly check for different golang versions #1076

### DIFF
--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -240,7 +240,8 @@ func TestWrap(t *testing.T) {
 	if err.ErrorCode != int(CertificateError)+int(VerifyFailed)+certificateInvalid+int(x509.Expired) {
 		t.Fatal("Error code construction failed.")
 	}
-	if err.Message != "x509: certificate has expired or is not yet valid" {
+	errorString := "x509: certificate has expired or is not yet valid:"
+	if err.Message[:49] != errorString[:49] {
 		t.Fatal("Error message construction failed.")
 	}
 


### PR DESCRIPTION
This test was failing for golang 1.14. With this, it only checks the string until it differs due to https://github.com/golang/go/commit/30d7b6400860d87d810a0db3593b28dfb72879f2