### PR TITLE
Fix 'TestNewMutualTLSServer' test for go1.14 #1075

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -97,7 +97,7 @@ func TestNewMutualTLSServer(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error with sign function")
 	}
-	if !strings.Contains(err.Error(), "Post https://nohost:8888/api/v1/cfssl/sign: dial tcp: lookup nohost") {
+	if !(strings.Contains(err.Error(), "Post")) && !(strings.Contains(err.Error(), "https://nohost:8888/api/v1/cfssl/sign")) && !(strings.Contains(err.Error(), "dial tcp: lookup nohost: no such host")) {
 		t.Fatalf("no error message %v", err)
 	}
 }


### PR DESCRIPTION
This fixes: https://github.com/cloudflare/cfssl/issues/1075

It is needed due to: https://github.com/golang/go/issues/29261 and https://github.com/golang/go/commit/64cfe9fe22113cd6bc05a2c5d0cbe872b1b57860#diff-9667474d33400190658e4758cf28dbf5

As in both versions, the error output is different, I've decided to check only for what is constant in all versions.