### PR TITLE
bundler: temporarily remove `leafRSA3072` testcases.

### DIFF
--- a/bundler/bundle_from_file_test.go
+++ b/bundler/bundle_from_file_test.go
@@ -122,13 +122,16 @@ var fileTests = []fileTest{
 		errorCallback:  nil,
 		bundleChecking: ExpectBundleLength(3),
 	},
-	{
-		cert:           leafRSA3072,
-		caBundleFile:   testCFSSLRootBundle,
-		intBundleFile:  testCFSSLIntBundle,
-		errorCallback:  nil,
-		bundleChecking: ExpectBundleLength(3),
-	},
+	/*
+		TODO: Re-enable once leafRSA3072 is regenerated with new expiry.
+		{
+			cert:           leafRSA3072,
+			caBundleFile:   testCFSSLRootBundle,
+			intBundleFile:  testCFSSLIntBundle,
+			errorCallback:  nil,
+			bundleChecking: ExpectBundleLength(3),
+		},
+	*/
 	{
 		cert:           leafRSA4096,
 		caBundleFile:   testCFSSLRootBundle,
@@ -170,14 +173,17 @@ var fileTests = []fileTest{
 		errorCallback:  nil,
 		bundleChecking: ExpectBundleLength(3),
 	},
-	{
-		cert:           leafRSA3072,
-		key:            leafKeyRSA3072,
-		caBundleFile:   testCFSSLRootBundle,
-		intBundleFile:  testCFSSLIntBundle,
-		errorCallback:  nil,
-		bundleChecking: ExpectBundleLength(3),
-	},
+	/*
+			TODO: Re-enable once leafRSA3072 is regenerated with new expiry.
+		{
+			cert:           leafRSA3072,
+			key:            leafKeyRSA3072,
+			caBundleFile:   testCFSSLRootBundle,
+			intBundleFile:  testCFSSLIntBundle,
+			errorCallback:  nil,
+			bundleChecking: ExpectBundleLength(3),
+		},
+	*/
 	{
 		cert:           leafRSA4096,
 		key:            leafKeyRSA4096,
@@ -343,7 +349,7 @@ func TestBundleFromFile(t *testing.T) {
 			test.errorCallback(t, err)
 		} else {
 			if err != nil {
-				t.Fatalf("expected no error. but an error occurred: %v", err)
+				t.Fatalf("expected no error bundling %q. but an error occurred: %v", test.cert, err)
 			}
 			if test.bundleChecking != nil {
 				test.bundleChecking(t, bundle)


### PR DESCRIPTION
The `leafRSA3072` test file, (`bundler/testdata/cfssl-leaf-rsa3072.pem`) expired and breaks tests. A proper fix would be to regenerate this test file but in the meantime removing the testcases fixes CI.

This branch also updates `TestBundleFromFile` to print the filename of the failing certificate when there is a bundling error. This may help identify which piece of testdata is at fault when CI fails.

Resolves https://github.com/cloudflare/cfssl/issues/1110