### PR TITLE
Allowing CertificateRequest to take CRL url as input which can then be used on a cert

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -139,6 +139,7 @@ type CertificateRequest struct {
 	CA           *CAConfig        `json:"ca,omitempty" yaml:"ca,omitempty"`
 	SerialNumber string           `json:"serialnumber,omitempty" yaml:"serialnumber,omitempty"`
 	Extensions   []pkix.Extension `json:"extensions,omitempty" yaml:"extensions,omitempty"`
+	CRL          string           `json:"crl_url,omitempty" yaml:"crl_url,omitempty"`
 }
 
 // New returns a new, empty CertificateRequest with a

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -69,6 +69,10 @@ func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
 		}
 	}
 
+	if req.CRL != "" {
+		policy.Default.CRL = req.CRL
+	}
+
 	g := &csr.Generator{Validator: validator}
 	csrPEM, key, err = g.ProcessRequest(req)
 	if err != nil {


### PR DESCRIPTION
CertificateRequest Crl member can be added to policy which will allow setting crl on a cert