### PR TITLE
Fix race condition in revoke

### DIFF
--- a/revoke/revoke.go
+++ b/revoke/revoke.go
@@ -133,13 +133,13 @@ func getIssuer(cert *x509.Certificate) *x509.Certificate {
 // check a cert against a specific CRL. Returns the same bool pair
 // as revCheck, plus an error if one occurred.
 func certIsRevokedCRL(cert *x509.Certificate, url string) (revoked, ok bool, err error) {
+	crlLock.Lock()
 	crl, ok := CRLSet[url]
 	if ok && crl == nil {
 		ok = false
-		crlLock.Lock()
 		delete(CRLSet, url)
-		crlLock.Unlock()
 	}
+	crlLock.Unlock()
 
 	var shouldFetchCRL = true
 	if ok {


### PR DESCRIPTION
This change fixes a race condition in revoke where read operation to CRLSet is not protected by its associated mutex.

There is an open issue for the same problem already:

https://github.com/cloudflare/cfssl/issues/1031
