### PR TITLE
fix selecting rows created before migration introduced in #1126

### DIFF
--- a/certdb/certdb.go
+++ b/certdb/certdb.go
@@ -1,6 +1,7 @@
 package certdb
 
 import (
+	"database/sql"
 	"encoding/json"
 	"time"
 
@@ -22,7 +23,7 @@ type CertificateRecord struct {
 	NotBefore    time.Time      `db:"not_before"`
 	MetadataJSON types.JSONText `db:"metadata"`
 	SANsJSON     types.JSONText `db:"sans"`
-	CommonName   string         `db:"common_name"`
+	CommonName   sql.NullString `db:"common_name"`
 }
 
 // SetMetadata sets the metadata json

--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"database/sql"
 	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
@@ -517,7 +518,7 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 			PEM:        string(signedCert),
 			IssuedAt:   time.Now(),
 			NotBefore:  certTBS.NotBefore,
-			CommonName: certTBS.Subject.CommonName,
+			CommonName: sql.NullString{String: certTBS.Subject.CommonName, Valid: true},
 		}
 
 		if err := certRecord.SetMetadata(req.Metadata); err != nil {


### PR DESCRIPTION
fix(certdb): use `sql.NullString` for CertificateRecord.CommonName

Rows inserted before the migration in #1126 will have the `common_name` set to NULL. This fixes selects for those rows.