### PR TITLE
Add documentation for API health endpoint

### DIFF
--- a/doc/api/endpoint_health.txt
+++ b/doc/api/endpoint_health.txt
@@ -1,0 +1,14 @@
+THE HEALTH ENDPOINT
+
+Endpoint: /api/v1/cfssl/health
+Method:   GET
+
+Result:
+
+    The returned result is a JSON object with a single key:
+
+    * healthy: a bool indicating if the API server is healthy
+
+Example:
+
+    $ curl ${CFSSL_HOST}/api/v1/cfssl/health


### PR DESCRIPTION
Adds a new documentation file for the health endpoint. It's a simple document as the endpoint is straight forward, but by adding a file for it, it will make it more discoverable by developers reading the other documentation.

This completes #1144 issue report.