### PR TITLE
fix: cfssl provider support SAN URI

### DIFF
--- a/transport/ca/cfssl_provider.go
+++ b/transport/ca/cfssl_provider.go
@@ -206,13 +206,17 @@ func (cap *CFSSL) SignCSR(csrPEM []byte) (cert []byte, err error) {
 		return nil, err
 	}
 
-	hosts := make([]string, len(csr.DNSNames), len(csr.DNSNames)+len(csr.IPAddresses))
+	hosts := make([]string, len(csr.DNSNames), len(csr.DNSNames)+len(csr.IPAddresses)+len(csr.URIs))
 	copy(hosts, csr.DNSNames)
 
 	for i := range csr.IPAddresses {
 		hosts = append(hosts, csr.IPAddresses[i].String())
 	}
 
+	for i := range csr.URIs {
+		hosts = append(hosts, csr.URIs[i].String())
+	}
+	
 	sreq := &signer.SignRequest{
 		Hosts:   hosts,
 		Request: string(csrPEM),


### PR DESCRIPTION
`transport` package doesn't send `URIs` column in CSR, change this behavior.