### PR TITLE
Support for E attribute (emailAddress) in CSR

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -37,6 +37,7 @@ type Name struct {
 	L            string            `json:"L,omitempty" yaml:"L,omitempty"`   // Locality
 	O            string            `json:"O,omitempty" yaml:"O,omitempty"`   // OrganisationName
 	OU           string            `json:"OU,omitempty" yaml:"OU,omitempty"` // OrganisationalUnitName
+    E            string            `json:"E,omitempty" yaml:"E,omitempty"`
 	SerialNumber string            `json:"SerialNumber,omitempty" yaml:"SerialNumber,omitempty"`
 	OID          map[string]string `json:"OID,omitempty", yaml:"OID,omitempty"`
 }
@@ -195,6 +196,9 @@ func (cr *CertificateRequest) Name() (pkix.Name, error) {
 			}
 			name.ExtraNames = append(name.ExtraNames, pkix.AttributeTypeAndValue{Type: oid, Value: v})
 		}
+        if n.E != "" {
+            name.ExtraNames = append(name.ExtraNames, pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 1}, Value: n.E})
+        }
 	}
 	name.SerialNumber = cr.SerialNumber
 	return name, nil


### PR DESCRIPTION
The patch adds support for E attribute (emailAddress) in CSR. Partially closes #826 

JSON-File for testing:

```
{
    "hosts": [
        "server.example.com",
        "server"
    ],
    "key": {
        "algo": "rsa",
        "size": 2048
    },
    "names": [
        {
            "C": "DE",
            "ST": "Hessen",
            "O": "My big enterprise",
            "OU": "My small team",
            "L": "Frankfurt",
            "E": "email@example.com"
        }
    ]
}
```

"Vanilla" cfssl (no email in the subject line):

```
$ /usr/local/bin/cfssl genkey example.json | cfssljson -bare example
2021/02/08 13:21:23 [INFO] generate received request
2021/02/08 13:21:23 [INFO] received CSR
2021/02/08 13:21:23 [INFO] generating key: rsa-2048
2021/02/08 13:21:23 [INFO] encoded CSR
$ openssl req -noout -text -in example.csr
Certificate Request:
    Data:
        Version: 0 (0x0)
        Subject: C=DE, ST=Hessen, L=Frankfurt, O=My big enterprise, OU=My small team
        Subject Public Key Info:
...
```

With the patch:

```
$ ~/bin/cfssl genkey example.json | cfssljson -bare example
2021/02/08 13:22:43 [INFO] generate received request
2021/02/08 13:22:43 [INFO] received CSR
2021/02/08 13:22:43 [INFO] generating key: rsa-2048
2021/02/08 13:22:43 [INFO] encoded CSR
$ openssl req -noout -text -in example.csr
Certificate Request:
    Data:
        Version: 0 (0x0)
        Subject: C=DE, ST=Hessen, L=Frankfurt, O=My big enterprise, OU=My small team/emailAddress=email@example.com
        Subject Public Key Info:
...
```