### PR TITLE
CRL distribution points having same CRL should not reject certificate

### DIFF
--- a/revoke/revoke.go
+++ b/revoke/revoke.go
@@ -80,9 +80,8 @@ func revCheck(cert *x509.Certificate) (revoked, ok bool, err error) {
 		}
 
 		if revoked, ok, err := certIsRevokedCRL(cert, url); !ok {
-			log.Warning("error checking revocation via CRL %v", err.Error())
+			log.Warning("error checking revocation via CRL")
 			if NoFailOnUnreachableCRLHost && strings.Contains(err.Error(), "no such host") {
-				log.Warning("skipped error checking revocation via CRL %v", err.Error())
 				continue
 			}
 			if HardFail {

--- a/revoke/revoke_test.go
+++ b/revoke/revoke_test.go
@@ -229,3 +229,18 @@ func TestNoOCSPServers(t *testing.T) {
 		t.Fatalf("OCSP falsely registered as enabled for this certificate")
 	}
 }
+
+func TestNoFailOnUnreachableCRLHost(t *testing.T) {
+	cert := mustParse(goodComodoCA)
+	cert.CRLDistributionPoints[0] = "http://crl.unreachablehost.com/nocrl"
+	if revoked, ok, err := VerifyCertificateError(cert); ok || revoked {
+		t.Fatalf("Fetching error encountered %v", err)
+	}
+
+	NoFailOnUnreachableCRLHost = true
+	if revoked, ok, err := VerifyCertificateError(cert); !ok || revoked {
+		t.Fatalf("Fetching error encountered, unreachable host skipped %v, %v, %v", revoked, ok, err)
+	}
+
+	NoFailOnUnreachableCRLHost = false
+}


### PR DESCRIPTION
**Problem**:There are cases when there is same CRL hosted at multiple locations for high availability.
Some if the URLs(CRL Distribution points) may not be reachable. In this case, it is not required for the certificate to pass every CRL(as the CRL is same in every hosted location).
**Solution**: Verify at least 1 hosted location and not fail if host is not reachable.
If any of the URL is reachable and verified as not revoked then we should not reject the certificate.