### PR TITLE
Improve IPv6 address handling in ocspserve

### DIFF
--- a/cli/ocspserve/ocspserve.go
+++ b/cli/ocspserve/ocspserve.go
@@ -3,8 +3,9 @@ package ocspserve
 
 import (
 	"errors"
-	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/log"
@@ -53,7 +54,7 @@ func ocspServerMain(args []string, c cli.Config) error {
 	log.Info("Registering OCSP responder handler")
 	http.Handle(c.Path, ocsp.NewResponder(src, nil))
 
-	addr := fmt.Sprintf("%s:%d", c.Address, c.Port)
+	addr := net.JoinHostPort(c.Address, strconv.Itoa(c.Port))
 	log.Info("Now listening on ", addr)
 	return http.ListenAndServe(addr, nil)
 }


### PR DESCRIPTION
When setting an IPv6 address to listing on via the `-address` command-line argument for both `serve` and `ocspserve`, the latter errors unless the address is escaped:

```shell
# cfssl ocspserve -db-config=db-config.json -responses=responses.txt -address=::1 -port=8889
2021/05/08 17:00:00 [INFO] Now listening on ::1:8889
listen tcp: address ::1:8889: too many colons in address
```

However, `serve` uses the `net` library to process the address and port, which results in the enforced escaping of IPv6 addresses regardless of if the address is already enclosed in square brackets (e.g. `[::1]`):

```shell
# cfssl serve -config=config.json -db-config=db-config.json -ca=ca.pem -ca-key=ca-key.pem -address=::1 -port 8888
2021/05/08 17:00:00 [INFO] Now listening on [::1]:8888
# cfssl serve -config=config.json -db-config=db-config.json -ca=ca.pem -ca-key=ca-key.pem -address=[::1] -port 8888
2021/05/08 17:00:00 [INFO] Now listening on [[::1]]:8888
listen tcp: address [[::1]]:8888: missing port in address
```

This Pull Request changes `oscpserve` to use the same `net` library call as `serve` to provide consistency between the two modes when handling IPv6 addresses.

I'm unsure as to the level of "breaking change" this could be considered as. This does directly change the handling of an already existing command-line argument, but there is no documentation that I can see regarding `-address` (other than it exists and defaults to `127.0.0.1` if not set). More importantly, I don't see anything specific to `-address` and IPv6 addresses, or the differences in handling between `serve` and `ocspserve`.

I don't know if some more specific configuration on the handling of `-address` may be required as part of this to clean up handling between the modes?