### PR TITLE
pick columns to get revoked/unexpired certs

### DIFF
--- a/certdb/certdb.go
+++ b/certdb/certdb.go
@@ -77,6 +77,7 @@ type Accessor interface {
 	GetUnexpiredCertificates() ([]CertificateRecord, error)
 	GetRevokedAndUnexpiredCertificates() ([]CertificateRecord, error)
 	GetRevokedAndUnexpiredCertificatesByLabel(label string) ([]CertificateRecord, error)
+	GetRevokedAndUnexpiredCertificatesByLabelSelectColumns(label string) ([]CertificateRecord, error)
 	RevokeCertificate(serial, aki string, reasonCode int) error
 	InsertOCSP(rr OCSPRecord) error
 	GetOCSP(serial, aki string) ([]OCSPRecord, error)

--- a/certdb/sql/sql_test.go
+++ b/certdb/sql/sql_test.go
@@ -280,6 +280,17 @@ func testUpdateCertificateAndGetCertificate(ta TestAccessor, t *testing.T) {
 		want.PEM != got.PEM {
 		t.Errorf("want Certificate %+v, got %+v", want, got)
 	}
+
+	rets, err = ta.Accessor.GetRevokedAndUnexpiredCertificatesByLabelSelectColumns("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got = rets[0]
+	// reflection comparison with zero time objects are not stable as it seems
+	if want.Serial != got.Serial || got.RevokedAt.IsZero() {
+		t.Errorf("want Certificate %+v, got %+v", want, got)
+	}
 }
 
 func testInsertOCSPAndGetOCSP(ta TestAccessor, t *testing.T) {


### PR DESCRIPTION
Selecting all columns to get all revoked and unexpired certificates is expensive and unnecessary. 
This PR adds a function updating existing database accessor function to select only serial_number and revoked_at