### PR TITLE
Support for DelegationUsage extension

### DIFF
--- a/cli/testdata/csr.json
+++ b/cli/testdata/csr.json
@@ -18,5 +18,6 @@
                 "1.2.3.4.5": "abc"
             }
         }
-    ]
+    ],
+    "delegation_enabled": true
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -39,6 +39,16 @@ const OneYear = 8760 * time.Hour
 // OneDay is a time.Duration representing a day's worth of seconds.
 const OneDay = 24 * time.Hour
 
+// DelegationUsage  is the OID for the DelegationUseage extensions
+var DelegationUsage = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 44363, 44}
+
+// DelegationExtension
+var DelegationExtension = pkix.Extension{
+	Id:       DelegationUsage,
+	Critical: false,
+	Value:    []byte{0x05, 0x00}, // ASN.1 NULL
+}
+
 // InclusiveDate returns the time.Time representation of a date - 1
 // nanosecond. This allows time.After to be used inclusively.
 func InclusiveDate(year int, month time.Month, day int) time.Time {

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/info"
 )
 
@@ -45,7 +46,7 @@ type Extension struct {
 // Extensions provided in the signRequest are copied into the certificate, as
 // long as they are in the ExtensionWhitelist for the signer's policy.
 // Extensions requested in the CSR are ignored, except for those processed by
-// ParseCertificateRequest (mainly subjectAltName).
+// ParseCertificateRequest (mainly subjectAltName) and DelegationUsage.
 type SignRequest struct {
 	Hosts       []string    `json:"hosts"`
 	Request     string      `json:"certificate_request"`
@@ -240,6 +241,8 @@ func ParseCertificateRequest(s Signer, p *config.SigningProfile, csrBytes []byte
 			template.IsCA = constraints.IsCA
 			template.MaxPathLen = constraints.MaxPathLen
 			template.MaxPathLenZero = template.MaxPathLen == 0
+		} else if val.Id.Equal(helpers.DelegationUsage) {
+			template.ExtraExtensions = append(template.ExtraExtensions, val)
 		} else {
 			// If the profile has 'copy_extensions' to true then lets add it
 			if p.CopyExtensions {


### PR DESCRIPTION
This special cases the DelegationUsage extension, copying it to the
output when signing. It also adds support for a flag
delegation_enabled in certificate specifications. I have manually
confirmed this works.