### PR TITLE
Add BundleSign and BundleAuthSign methods to client Remote

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"crypto/tls"
-	"github.com/cloudflare/cfssl/auth"
-	"github.com/cloudflare/cfssl/helpers"
 	"net"
 	"strings"
 	"testing"
+
+	"github.com/cloudflare/cfssl/auth"
+	"github.com/cloudflare/cfssl/helpers"
 )
 
 var (
@@ -60,10 +61,20 @@ func TestInvalidPort(t *testing.T) {
 }
 
 func TestAuthSign(t *testing.T) {
-	s := NewServer(".X")
 	testProvider, _ = auth.New(testKey, nil)
+	s := NewAuthServer(".X", nil, testProvider)
 	testRequest := []byte(`testing 1 2 3`)
 	as, err := s.AuthSign(testRequest, testAD, testProvider)
+	if as != nil || err == nil {
+		t.Fatal("expected error with auth sign function")
+	}
+}
+
+func TestBundleAuthSign(t *testing.T) {
+	testProvider, _ = auth.New(testKey, nil)
+	s := NewAuthServer(".X", nil, testProvider)
+	testRequest := []byte(`testing 1 2 3`)
+	as, err := s.BundleAuthSign(testRequest, testAD, testProvider)
 	if as != nil || err == nil {
 		t.Fatal("expected error with auth sign function")
 	}
@@ -82,6 +93,14 @@ func TestDefaultAuthSign(t *testing.T) {
 func TestSign(t *testing.T) {
 	s := NewServer(".X")
 	sign, err := s.Sign([]byte{5, 5, 5, 5})
+	if sign != nil || err == nil {
+		t.Fatalf("expected error with sign function")
+	}
+}
+
+func TestBundleSign(t *testing.T) {
+	s := NewServer(".X")
+	sign, err := s.BundleSign([]byte{5, 5, 5, 5})
 	if sign != nil || err == nil {
 		t.Fatalf("expected error with sign function")
 	}

--- a/api/client/group.go
+++ b/api/client/group.go
@@ -104,9 +104,31 @@ func (g *orderedListGroup) AuthSign(req, id []byte, provider auth.Provider) (res
 	return nil, err
 }
 
+func (g *orderedListGroup) BundleAuthSign(req, id []byte, provider auth.Provider) (resp []byte, err error) {
+	for i := range g.remotes {
+		resp, err = g.remotes[i].BundleAuthSign(req, id, provider)
+		if err == nil {
+			return resp, nil
+		}
+	}
+
+	return nil, err
+}
+
 func (g *orderedListGroup) Sign(jsonData []byte) (resp []byte, err error) {
 	for i := range g.remotes {
 		resp, err = g.remotes[i].Sign(jsonData)
+		if err == nil {
+			return resp, nil
+		}
+	}
+
+	return nil, err
+}
+
+func (g *orderedListGroup) BundleSign(jsonData []byte) (resp []byte, err error) {
+	for i := range g.remotes {
+		resp, err = g.remotes[i].BundleSign(jsonData)
 		if err == nil {
 			return resp, nil
 		}


### PR DESCRIPTION
BundleSign/BundleAuthSign methods can be used like Sign/AuthSign to sign
CSRs but will return the "optimal" bundle instead of only the
certificate.
For that to work, the caller needs to set the "bundle" parameter in the
json POST data to true.

This is definitely not the best way to implement this, but I think it's
the least intrusive one and does not break the interface of the client.