### PR TITLE
docs: add go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ And to simply install __all__ of the programs in this repo:
 $ go get github.com/cloudflare/cfssl/cmd/...
 ```
 
+if you are above go 1.18:
+
+```
+$ go install github.com/cloudflare/cfssl/cmd/...@latest
+```
+
 This will download, build, and install all of the utility programs
 (including `cfssl`, `cfssljson`, and `mkbundle` among others).
 


### PR DESCRIPTION
go get fails with the following if you're above go 1.18

```shell
go get github.com/cloudflare/cfssl/cmd/...
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

This fixes this to an alternate (go install) - as `go get` is deprecated to install binaries

```shell
go install github.com/cloudflare/cfssl/cmd/...@latest
go: downloading github.com/go-sql-driver/mysql v1.6.0
go: downloading github.com/lib/pq v1.10.1
.
.
.
```