### PR TITLE
chore: remove uses of deprecated io/ioutil

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,7 +3,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/cloudflare/cfssl/errors"
@@ -92,7 +92,7 @@ func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func readRequestBlob(r *http.Request) (map[string]string, error) {
 	var blob map[string]string
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +52,7 @@ func post(t *testing.T, obj map[string]interface{}, ts *httptest.Server) (resp *
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func get(t *testing.T, ts *httptest.Server) (resp *http.Response, body []byte) {
 		t.Fatal(err)
 	}
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/bundle/bundle_test.go
+++ b/api/bundle/bundle_test.go
@@ -3,9 +3,10 @@ package bundle
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/cloudflare/cfssl/api"
@@ -39,14 +40,14 @@ func testBundleFile(t *testing.T, domain, ip, certFile, keyFile, flavor string) 
 	var certPEM, keyPEM []byte
 	if certFile != "" {
 		var err error
-		certPEM, err = ioutil.ReadFile(certFile)
+		certPEM, err = os.ReadFile(certFile)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 	if keyFile != "" {
 		var err error
-		keyPEM, err = ioutil.ReadFile(keyFile)
+		keyPEM, err = os.ReadFile(keyFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -75,7 +76,7 @@ func testBundleFile(t *testing.T, domain, ip, certFile, keyFile, flavor string) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/certadd/insert.go
+++ b/api/certadd/insert.go
@@ -3,9 +3,10 @@ package certadd
 import (
 	"bytes"
 	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"time"
@@ -16,8 +17,6 @@ import (
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/ocsp"
 	"github.com/jmoiron/sqlx/types"
-
-	"encoding/base64"
 
 	stdocsp "golang.org/x/crypto/ocsp"
 )
@@ -81,7 +80,7 @@ var validReasons = map[int]bool{
 
 // Handle handles HTTP requests to add certificates
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/api/certadd/insert_test.go
+++ b/api/certadd/insert_test.go
@@ -6,10 +6,11 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -20,8 +21,6 @@ import (
 	"github.com/cloudflare/cfssl/certdb/sql"
 	"github.com/cloudflare/cfssl/certdb/testdb"
 	"github.com/cloudflare/cfssl/ocsp"
-
-	"encoding/base64"
 
 	stdocsp "golang.org/x/crypto/ocsp"
 )
@@ -47,7 +46,7 @@ func makeRequest(t *testing.T, dbAccessor certdb.Accessor, signer ocsp.Signer, r
 		t.Fatal(err)
 	}
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	stderr "errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -158,7 +158,7 @@ func (srv *server) post(url string, jsonData []byte) (*api.Response, error) {
 	}
 	defer req.Body.Close()
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(errors.APIClientError, errors.IOError, err)
 	}

--- a/api/crl/crl_test.go
+++ b/api/crl/crl_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -61,7 +61,7 @@ func testGetCRL(t *testing.T, dbAccessor certdb.Accessor, expiry string) (resp *
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/gencrl/gencrl.go
+++ b/api/gencrl/gencrl.go
@@ -5,16 +5,17 @@ import (
 	"crypto/rand"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"github.com/cloudflare/cfssl/api"
-	"github.com/cloudflare/cfssl/errors"
-	"github.com/cloudflare/cfssl/helpers"
-	"github.com/cloudflare/cfssl/log"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
 )
 
 // This type is meant to be unmarshalled from JSON
@@ -32,7 +33,7 @@ func gencrlHandler(w http.ResponseWriter, r *http.Request) error {
 	var oneWeek = time.Duration(604800) * time.Second
 	var newExpiryTime = time.Now()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/api/gencrl/gencrl_test.go
+++ b/api/gencrl/gencrl_test.go
@@ -3,11 +3,13 @@ package gencrl
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/cloudflare/cfssl/api"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+
+	"github.com/cloudflare/cfssl/api"
 )
 
 const (
@@ -55,7 +57,7 @@ func testCRLCreation(t *testing.T, issuingKey, certFile string, expiry string, s
 	obj := map[string]interface{}{}
 
 	if certFile != "" {
-		c, err := ioutil.ReadFile(certFile)
+		c, err := os.ReadFile(certFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -65,7 +67,7 @@ func testCRLCreation(t *testing.T, issuingKey, certFile string, expiry string, s
 	obj["serialNumber"] = serialList
 
 	if issuingKey != "" {
-		c, err := ioutil.ReadFile(issuingKey)
+		c, err := os.ReadFile(issuingKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +85,7 @@ func testCRLCreation(t *testing.T, issuingKey, certFile string, expiry string, s
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,5 +105,4 @@ func TestCRL(t *testing.T) {
 		t.Logf("failed to read response body: %v", err)
 		t.Fatal(resp.Status, tester.ExpectedHTTPStatus, message)
 	}
-
 }

--- a/api/generator/generator.go
+++ b/api/generator/generator.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/cloudflare/cfssl/api"
@@ -107,7 +107,7 @@ func computeSum(in []byte) (sum Sum, err error) {
 // these requests is documented in the API documentation.
 func (g *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 	log.Info("request for CSR")
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Warningf("failed to read request body: %v", err)
 		return errors.NewBadRequest(err)
@@ -228,7 +228,7 @@ func (cg *CertGeneratorHandler) Handle(w http.ResponseWriter, r *http.Request) e
 	req := new(genSignRequest)
 	req.Request = csr.New()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Warningf("failed to read request body: %v", err)
 		return errors.NewBadRequest(err)

--- a/api/info/info.go
+++ b/api/info/info.go
@@ -3,7 +3,7 @@ package info
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/cloudflare/cfssl/api"
@@ -34,7 +34,7 @@ func NewHandler(s signer.Signer) (http.Handler, error) {
 // a list containing information on each root certificate.
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 	req := new(info.Req)
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Warningf("failed to read request body: %v", err)
 		return errors.NewBadRequest(err)
@@ -84,7 +84,7 @@ func NewMultiHandler(signers map[string]signer.Signer, defaultLabel string) (htt
 // the label is empty, the default label is used.
 func (h *MultiHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 	req := new(info.Req)
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Warningf("failed to read request body: %v", err)
 		return errors.NewBadRequest(err)

--- a/api/info/info_test.go
+++ b/api/info/info_test.go
@@ -3,7 +3,7 @@ package info
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -92,7 +92,7 @@ func testInfoFile(t *testing.T, req map[string]interface{}) (resp *http.Response
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func testMultiInfoFile(t *testing.T, req map[string]interface{}) (resp *http.Res
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/initca/initca.go
+++ b/api/initca/initca.go
@@ -3,7 +3,7 @@ package initca
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/cloudflare/cfssl/api"
@@ -26,7 +26,7 @@ type NewCA struct {
 // suitable for creating intermediate certificates.
 func initialCAHandler(w http.ResponseWriter, r *http.Request) error {
 	log.Info("setting up initial CA handler")
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Warningf("failed to read request body: %v", err)
 		return errors.NewBadRequest(err)

--- a/api/ocsp/ocspsign.go
+++ b/api/ocsp/ocspsign.go
@@ -3,11 +3,10 @@ package ocsp
 
 import (
 	"crypto"
-	"net/http"
-
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
+	"net/http"
 	"time"
 
 	"github.com/cloudflare/cfssl/api"
@@ -56,7 +55,7 @@ var nameToHash = map[string]crypto.Hash{
 // is revoked then it also adds reason and revoked_at. The response is
 // base64 encoded.
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/api/ocsp/ocspsign_test.go
+++ b/api/ocsp/ocspsign_test.go
@@ -4,17 +4,18 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/cloudflare/cfssl/api"
-	"github.com/cloudflare/cfssl/ocsp"
-	goocsp "golang.org/x/crypto/ocsp"
-
 	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/ocsp"
+
+	goocsp "golang.org/x/crypto/ocsp"
 )
 
 const (
@@ -49,7 +50,7 @@ func testSignFile(t *testing.T, certFile, status string, reason int, revokedAt s
 
 	obj := map[string]interface{}{}
 	if certFile != "" {
-		c, err := ioutil.ReadFile(certFile)
+		c, err := os.ReadFile(certFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +74,7 @@ func testSignFile(t *testing.T, certFile, status string, reason int, revokedAt s
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +211,7 @@ func TestSign(t *testing.T) {
 			t.Fatal(resp.Status, test.ExpectedHTTPStatus, b64Resp)
 		}
 
-		//should default to good
+		// should default to good
 		if test.Status == "" {
 			test.Status = "good"
 		}

--- a/api/revoke/revoke.go
+++ b/api/revoke/revoke.go
@@ -3,7 +3,7 @@ package revoke
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -55,7 +55,7 @@ type jsonRevokeRequest struct {
 // Handle responds to revocation requests. It attempts to revoke
 // a certificate with a given serial number
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/api/revoke/revoke_test.go
+++ b/api/revoke/revoke_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -70,7 +70,7 @@ func testRevokeCert(t *testing.T, dbAccessor certdb.Accessor, serial, aki, reaso
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,9 +142,9 @@ func TestOCSPGeneration(t *testing.T) {
 		Subject: pkix.Name{
 			Organization: []string{"cfssl unit test"},
 		},
-		AuthorityKeyId: []byte{42, 42, 42, 42},
-		KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		IsCA:           true,
+		AuthorityKeyId:        []byte{42, 42, 42, 42},
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 	}
 	issuerBytes, err := x509.CreateCertificate(rand.Reader, &issuerTemplate, &issuerTemplate, &privKey.PublicKey, privKey)
@@ -250,7 +250,7 @@ func TestOCSPGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/sign/sign_test.go
+++ b/api/sign/sign_test.go
@@ -3,9 +3,10 @@ package sign
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -197,7 +198,7 @@ func testSignFileOldInterface(t *testing.T, hostname, csrFile string) (resp *htt
 	var csrPEM []byte
 	if csrFile != "" {
 		var err error
-		csrPEM, err = ioutil.ReadFile(csrFile)
+		csrPEM, err = os.ReadFile(csrFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -219,7 +220,7 @@ func testSignFileOldInterface(t *testing.T, hostname, csrFile string) (resp *htt
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +233,7 @@ func testSignFile(t *testing.T, hosts []string, subject *signer.Subject, csrFile
 	var csrPEM []byte
 	if csrFile != "" {
 		var err error
-		csrPEM, err = ioutil.ReadFile(csrFile)
+		csrPEM, err = os.ReadFile(csrFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -257,7 +258,7 @@ func testSignFile(t *testing.T, hosts []string, subject *signer.Subject, csrFile
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,7 +447,7 @@ func testAuthSignFile(t *testing.T, hosts []string, subject *signer.Subject, csr
 	var csrPEM []byte
 	if csrFile != "" {
 		var err error
-		csrPEM, err = ioutil.ReadFile(csrFile)
+		csrPEM, err = os.ReadFile(csrFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -483,7 +484,7 @@ func testAuthSignFile(t *testing.T, hosts []string, subject *signer.Subject, csr
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/signhandler/signhandler.go
+++ b/api/signhandler/signhandler.go
@@ -3,7 +3,7 @@ package signhandler
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 
@@ -114,7 +114,7 @@ func jsonReqToTrue(js jsonSignRequest) signer.SignRequest {
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 	log.Info("signature request received")
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (h *AuthHandler) SetBundler(caBundleFile, intBundleFile string) (err error)
 func (h *AuthHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 	log.Info("signature request received")
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf("failed to read response body: %v", err)
 		return err

--- a/api/signhandler/signhandler_test.go
+++ b/api/signhandler/signhandler_test.go
@@ -3,9 +3,10 @@ package signhandler
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/cloudflare/cfssl/api"
@@ -67,7 +68,7 @@ func TestSignerDBPersistence(t *testing.T) {
 	defer ts.Close()
 
 	var csrPEM, body []byte
-	csrPEM, err = ioutil.ReadFile(testCSRFile)
+	csrPEM, err = os.ReadFile(testCSRFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +84,7 @@ func TestSignerDBPersistence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -52,7 +51,7 @@ func New(key string, ad []byte) (*Standard, error) {
 		case "env":
 			key = os.Getenv(splitKey[1])
 		case "file":
-			data, err := ioutil.ReadFile(splitKey[1])
+			data, err := os.ReadFile(splitKey[1])
 			if err != nil {
 				return nil, err
 			}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -107,7 +107,7 @@ func TestNullRequest(t *testing.T) {
 
 // Sanity check: verify a pre-generated authenticated request.
 func TestPreGenerated(t *testing.T) {
-	in, err := ioutil.ReadFile("testdata/authrequest.json")
+	in, err := os.ReadFile("testdata/authrequest.json")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -126,7 +126,7 @@ func TestPreGenerated(t *testing.T) {
 var bmRequest []byte
 
 func TestLoadBenchmarkRequest(t *testing.T) {
-	in, err := ioutil.ReadFile("testdata/request.json")
+	in, err := os.ReadFile("testdata/request.json")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/bundler/bundler.go
+++ b/bundler/bundler.go
@@ -12,7 +12,7 @@ import (
 	"encoding/pem"
 	goerr "errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -99,7 +99,7 @@ func NewBundler(caBundleFile, intBundleFile string, opt ...Option) (*Bundler, er
 
 	if caBundleFile != "" {
 		log.Debug("Loading CA bundle: ", caBundleFile)
-		caBundle, err = ioutil.ReadFile(caBundleFile)
+		caBundle, err = os.ReadFile(caBundleFile)
 		if err != nil {
 			log.Errorf("root bundle failed to load: %v", err)
 			return nil, errors.Wrap(errors.RootError, errors.ReadFailed, err)
@@ -108,7 +108,7 @@ func NewBundler(caBundleFile, intBundleFile string, opt ...Option) (*Bundler, er
 
 	if intBundleFile != "" {
 		log.Debug("Loading Intermediate bundle: ", intBundleFile)
-		intBundle, err = ioutil.ReadFile(intBundleFile)
+		intBundle, err = os.ReadFile(intBundleFile)
 		if err != nil {
 			log.Errorf("intermediate bundle failed to load: %v", err)
 			return nil, errors.Wrap(errors.IntermediatesError, errors.ReadFailed, err)
@@ -199,7 +199,7 @@ func (b *Bundler) VerifyOptions() x509.VerifyOptions {
 // and returns the bundle built from that key and the certificate(s).
 func (b *Bundler) BundleFromFile(bundleFile, keyFile string, flavor BundleFlavor, password string) (*Bundle, error) {
 	log.Debug("Loading Certificate: ", bundleFile)
-	certsRaw, err := ioutil.ReadFile(bundleFile)
+	certsRaw, err := os.ReadFile(bundleFile)
 	if err != nil {
 		return nil, errors.Wrap(errors.CertificateError, errors.ReadFailed, err)
 	}
@@ -208,7 +208,7 @@ func (b *Bundler) BundleFromFile(bundleFile, keyFile string, flavor BundleFlavor
 	// Load private key PEM only if a file is given
 	if keyFile != "" {
 		log.Debug("Loading private key: ", keyFile)
-		keyPEM, err = ioutil.ReadFile(keyFile)
+		keyPEM, err = os.ReadFile(keyFile)
 		if err != nil {
 			log.Debugf("failed to read private key: ", err)
 			return nil, errors.Wrap(errors.PrivateKeyError, errors.ReadFailed, err)
@@ -344,7 +344,7 @@ func fetchRemoteCertificate(certURL string) (fi *fetchedIntermediate, err error)
 
 	defer resp.Body.Close()
 	var certData []byte
-	certData, err = ioutil.ReadAll(resp.Body)
+	certData, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Debugf("failed to read response body: %v", err)
 		return
@@ -442,7 +442,7 @@ func (b *Bundler) verifyChain(chain []*fetchedIntermediate) bool {
 
 			log.Debugf("write intermediate to stash directory: %s", fileName)
 			// If the write fails, verification should not fail.
-			err = ioutil.WriteFile(fileName, pem.EncodeToMemory(&block), 0644)
+			err = os.WriteFile(fileName, pem.EncodeToMemory(&block), 0644)
 			if err != nil {
 				log.Errorf("failed to write new intermediate: %v", err)
 			} else {

--- a/bundler/bundler_sha1_deprecation_test.go
+++ b/bundler/bundler_sha1_deprecation_test.go
@@ -3,7 +3,7 @@ package bundler
 // This test file contains tests on checking Bundle.Status with SHA-1 deprecation warning.
 import (
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -33,7 +33,7 @@ func TestChromeWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	csrBytes, err := ioutil.ReadFile(leafCSR)
+	csrBytes, err := os.ReadFile(leafCSR)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestSHA2Preferences(t *testing.T) {
 	sha1InterBytes := signCSRFile(sha1CASigner, intermediateCSR, t)
 	sha2InterBytes := signCSRFile(sha2CASigner, intermediateCSR, t)
 
-	interKeyBytes, err := ioutil.ReadFile(intermediateKey)
+	interKeyBytes, err := os.ReadFile(intermediateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,12 +124,12 @@ func TestSHA2Preferences(t *testing.T) {
 }
 
 func makeCASignerFromFile(certFile, keyFile string, sigAlgo x509.SignatureAlgorithm, t *testing.T) signer.Signer {
-	certBytes, err := ioutil.ReadFile(certFile)
+	certBytes, err := os.ReadFile(certFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	keyBytes, err := ioutil.ReadFile(keyFile)
+	keyBytes, err := os.ReadFile(keyFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func makeCASigner(certBytes, keyBytes []byte, sigAlgo x509.SignatureAlgorithm, t
 }
 
 func signCSRFile(s signer.Signer, csrFile string, t *testing.T) []byte {
-	csrBytes, err := ioutil.ReadFile(csrFile)
+	csrBytes, err := os.ReadFile(csrFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bundler/bundler_test.go
+++ b/bundler/bundler_test.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -176,14 +176,14 @@ func TestBundleWithECDSAKeyMarshalJSON(t *testing.T) {
 	}
 
 	key := obj["key"].(string)
-	keyBytes, _ := ioutil.ReadFile(leafKeyECDSA256)
+	keyBytes, _ := os.ReadFile(leafKeyECDSA256)
 	keyBytes = bytes.Trim(keyBytes, " \n")
 	if key != string(keyBytes) {
 		t.Fatal("key is not recovered.")
 	}
 
 	cert := obj["crt"].(string)
-	certBytes, _ := ioutil.ReadFile(leafECDSA256)
+	certBytes, _ := os.ReadFile(leafECDSA256)
 	certBytes = bytes.Trim(certBytes, " \n")
 	if cert != string(certBytes) {
 		t.Fatal("cert is not recovered.")
@@ -212,7 +212,7 @@ func TestBundleWithRSAKeyMarshalJSON(t *testing.T) {
 	}
 
 	key := obj["key"].(string)
-	keyBytes, _ := ioutil.ReadFile(leafKeyRSA2048)
+	keyBytes, _ := os.ReadFile(leafKeyRSA2048)
 	keyBytes = bytes.Trim(keyBytes, " \n")
 	if key != string(keyBytes) {
 		t.Error("key is", key)
@@ -221,7 +221,7 @@ func TestBundleWithRSAKeyMarshalJSON(t *testing.T) {
 	}
 
 	cert := obj["crt"].(string)
-	certBytes, _ := ioutil.ReadFile(leafRSA2048)
+	certBytes, _ := os.ReadFile(leafRSA2048)
 	certBytes = bytes.Trim(certBytes, " \n")
 	if cert != string(certBytes) {
 		t.Fatal("cert is not recovered.")
@@ -373,7 +373,7 @@ func TestForceBundle(t *testing.T) {
 	interL1Bytes := signCSRFile(caSigner, interL1CSR, t)
 
 	// create a inter L1 signer
-	interL1KeyBytes, err := ioutil.ReadFile(interL1Key)
+	interL1KeyBytes, err := os.ReadFile(interL1Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,7 +384,7 @@ func TestForceBundle(t *testing.T) {
 	interL2Bytes := signCSRFile(interL1Signer, interL2CSR, t)
 
 	// create a inter L2 signer
-	interL2KeyBytes, err := ioutil.ReadFile(interL2Key)
+	interL2KeyBytes, err := os.ReadFile(interL2Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +396,7 @@ func TestForceBundle(t *testing.T) {
 
 	// create two platforms
 	// both trust the CA cert and L1 intermediate
-	caBytes, err := ioutil.ReadFile(testCAFile)
+	caBytes, err := os.ReadFile(testCAFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestUpdateIntermediate(t *testing.T) {
 	caSigner := makeCASignerFromFile(testCAFile, testCAKeyFile, x509.SHA256WithRSA, t)
 	sha2InterBytes := signCSRFile(caSigner, interL1CSR, t)
 
-	interKeyBytes, err := ioutil.ReadFile(interL1Key)
+	interKeyBytes, err := os.ReadFile(interL1Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestUpdateIntermediate(t *testing.T) {
 	leafBytes := signCSRFile(sha2InterSigner, leafCSR, t)
 
 	// read CA cert bytes
-	caCertBytes, err := ioutil.ReadFile(testCAFile)
+	caCertBytes, err := os.ReadFile(testCAFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -522,7 +522,7 @@ func TestForceBundleNoFallback(t *testing.T) {
 	caSigner := makeCASignerFromFile(testCAFile, testCAKeyFile, x509.SHA256WithRSA, t)
 	sha2InterBytes := signCSRFile(caSigner, interL1CSR, t)
 
-	interKeyBytes, err := ioutil.ReadFile(interL1Key)
+	interKeyBytes, err := os.ReadFile(interL1Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -533,7 +533,7 @@ func TestForceBundleNoFallback(t *testing.T) {
 	leafBytes := signCSRFile(sha2InterSigner, leafCSR, t)
 
 	// read CA cert bytes
-	caCertBytes, err := ioutil.ReadFile(testCAFile)
+	caCertBytes, err := os.ReadFile(testCAFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -566,7 +566,7 @@ func TestSHA2HomogeneityAgainstUbiquity(t *testing.T) {
 	interL1Bytes := signCSRFile(caSigner, interL1CSR, t)
 
 	// create a inter L1 signer
-	interL1KeyBytes, err := ioutil.ReadFile(interL1Key)
+	interL1KeyBytes, err := os.ReadFile(interL1Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -577,7 +577,7 @@ func TestSHA2HomogeneityAgainstUbiquity(t *testing.T) {
 	interL2Bytes := signCSRFile(interL1Signer, interL2CSR, t)
 
 	// create a inter L2 signer
-	interL2KeyBytes, err := ioutil.ReadFile(interL2Key)
+	interL2KeyBytes, err := os.ReadFile(interL2Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -590,7 +590,7 @@ func TestSHA2HomogeneityAgainstUbiquity(t *testing.T) {
 	// create two platforms
 	// platform A trusts the CA cert and L1 intermediate
 	// platform B trusts the CA cert
-	caBytes, err := ioutil.ReadFile(testCAFile)
+	caBytes, err := os.ReadFile(testCAFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +708,7 @@ func TestSHA2Warning(t *testing.T) {
 	sha2InterBytes := signCSRFile(caSigner, interL1CSR, t)
 
 	// read CA cert bytes
-	caCertBytes, err := ioutil.ReadFile(testCAFile)
+	caCertBytes, err := os.ReadFile(testCAFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -752,7 +752,7 @@ func TestECDSAWarning(t *testing.T) {
 
 // readCert read a PEM file and returns a cert.
 func readCert(filename string) *x509.Certificate {
-	bytes, _ := ioutil.ReadFile(filename)
+	bytes, _ := os.ReadFile(filename)
 	cert, _ := helpers.ParseCertificatePEM(bytes)
 	return cert
 }
@@ -784,7 +784,7 @@ func newCustomizedBundlerFromFile(t *testing.T, caBundle, intBundle, adhocInters
 		t.Fatal(err)
 	}
 	if adhocInters != "" {
-		moreIntersPEM, err := ioutil.ReadFile(adhocInters)
+		moreIntersPEM, err := os.ReadFile(adhocInters)
 		if err != nil {
 			t.Fatalf("Read additional intermediates failed. %v",
 				err)

--- a/certdb/dbconf/db_config.go
+++ b/certdb/dbconf/db_config.go
@@ -3,7 +3,7 @@ package dbconf
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	cferr "github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/log"
@@ -26,7 +26,7 @@ func LoadFile(path string) (cfg *DBConfig, err error) {
 	}
 
 	var body []byte
-	body, err = ioutil.ReadFile(path)
+	body, err = os.ReadFile(path)
 	if err != nil {
 		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("could not read configuration file"))
 	}

--- a/certinfo/certinfo.go
+++ b/certinfo/certinfo.go
@@ -6,8 +6,8 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -41,7 +41,7 @@ type Name struct {
 	StreetAddress      string        `json:"street_address,omitempty"`
 	PostalCode         string        `json:"postal_code,omitempty"`
 	Names              []interface{} `json:"names,omitempty"`
-	//ExtraNames         []interface{} `json:"extra_names,omitempty"`
+	// ExtraNames         []interface{} `json:"extra_names,omitempty"`
 }
 
 // ParseName parses a new name from a *pkix.Name
@@ -105,7 +105,7 @@ func ParseCertificate(cert *x509.Certificate) *Certificate {
 
 // ParseCertificateFile parses x509 certificate file.
 func ParseCertificateFile(certFile string) (*Certificate, error) {
-	certPEM, err := ioutil.ReadFile(certFile)
+	certPEM, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func ParseCSRPEM(csrPEM []byte) (*x509.CertificateRequest, error) {
 
 // ParseCSRFile uses the helper to parse an x509 CSR PEM file.
 func ParseCSRFile(csrFile string) (*x509.CertificateRequest, error) {
-	csrPEM, err := ioutil.ReadFile(csrFile)
+	csrPEM, err := os.ReadFile(csrFile)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -30,7 +30,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/cloudflare/cfssl/config"
@@ -151,9 +151,9 @@ func Start(cmds map[string]*Command) error {
 // ReadStdin reads from stdin if the file is "-"
 func ReadStdin(filename string) ([]byte, error) {
 	if filename == "-" {
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	}
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 // PrintCert outputs a cert, key and csr to stdout

--- a/cli/gencert/gencert_test.go
+++ b/cli/gencert/gencert_test.go
@@ -1,7 +1,6 @@
 package gencert
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -86,8 +85,8 @@ func TestGencertFile(t *testing.T) {
 }
 
 func TestGencertEnv(t *testing.T) {
-	tempCaCert, _ := ioutil.ReadFile("../testdata/ca.pem")
-	tempCaKey, _ := ioutil.ReadFile("../testdata/ca-key.pem")
+	tempCaCert, _ := os.ReadFile("../testdata/ca.pem")
+	tempCaKey, _ := os.ReadFile("../testdata/ca-key.pem")
 	os.Setenv("ca", string(tempCaCert))
 	os.Setenv("ca_key", string(tempCaKey))
 
@@ -124,8 +123,8 @@ func TestGencertEnv(t *testing.T) {
 }
 
 func TestBadGencertEnv(t *testing.T) {
-	tempCaCert, _ := ioutil.ReadFile("../testdata/ca.pem")
-	tempCaKey, _ := ioutil.ReadFile("../testdata/ca-key.pem")
+	tempCaCert, _ := os.ReadFile("../testdata/ca.pem")
+	tempCaKey, _ := os.ReadFile("../testdata/ca-key.pem")
 	os.Setenv("ca", string(tempCaCert))
 	os.Setenv("ca_key", string(tempCaKey))
 

--- a/cli/gencsr/gencsr_test.go
+++ b/cli/gencsr/gencsr_test.go
@@ -3,7 +3,7 @@ package gencsr
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -36,7 +36,7 @@ func newStdoutRedirect() (*stdoutRedirect, error) {
 func (pipe *stdoutRedirect) readAll() ([]byte, error) {
 	pipe.w.Close()
 	os.Stdout = pipe.saved
-	return ioutil.ReadAll(pipe.r)
+	return io.ReadAll(pipe.r)
 }
 
 func checkResponse(out []byte) error {

--- a/cli/genkey/genkey_test.go
+++ b/cli/genkey/genkey_test.go
@@ -3,7 +3,7 @@ package genkey
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -30,7 +30,7 @@ func newStdoutRedirect() (*stdoutRedirect, error) {
 func (pipe *stdoutRedirect) readAll() ([]byte, error) {
 	pipe.w.Close()
 	os.Stdout = pipe.saved
-	return ioutil.ReadAll(pipe.r)
+	return io.ReadAll(pipe.r)
 }
 
 func checkResponse(out []byte) error {

--- a/cli/ocsprefresh/ocsprefresh_test.go
+++ b/cli/ocsprefresh/ocsprefresh_test.go
@@ -2,6 +2,7 @@ package ocsprefresh
 
 import (
 	"encoding/hex"
+	"os"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/helpers"
 	"golang.org/x/crypto/ocsp"
-	"io/ioutil"
 )
 
 var dbAccessor certdb.Accessor
@@ -19,7 +19,7 @@ var dbAccessor certdb.Accessor
 func TestOCSPRefreshMain(t *testing.T) {
 	db := testdb.SQLiteDB("../../certdb/testdb/certstore_development.db")
 
-	certPEM, err := ioutil.ReadFile("../../ocsp/testdata/cert.pem")
+	certPEM, err := os.ReadFile("../../ocsp/testdata/cert.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/ocspsign/ocspsign.go
+++ b/cli/ocspsign/ocspsign.go
@@ -2,7 +2,7 @@
 package ocspsign
 
 import (
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/cloudflare/cfssl/cli"
@@ -27,7 +27,7 @@ var ocspSignerFlags = []string{"ca", "responder", "responder-key", "reason", "st
 // ocspSignerMain is the main CLI of OCSP signer functionality.
 func ocspSignerMain(args []string, c cli.Config) (err error) {
 	// Read the cert to be revoked from file
-	certBytes, err := ioutil.ReadFile(c.CertFile)
+	certBytes, err := os.ReadFile(c.CertFile)
 	if err != nil {
 		log.Critical("Unable to read certificate: ", err)
 		return
@@ -80,8 +80,8 @@ func ocspSignerMain(args []string, c cli.Config) (err error) {
 
 // SignerFromConfig creates a signer from a cli.Config as a helper for cli and serve
 func SignerFromConfig(c cli.Config) (ocsp.Signer, error) {
-	//if this is called from serve then we need to use the specific responder key file
-	//fallback to key for backwards-compatibility
+	// if this is called from serve then we need to use the specific responder key file
+	// fallback to key for backwards-compatibility
 	k := c.ResponderKeyFile
 	if k == "" {
 		k = c.KeyFile

--- a/cli/sign/sign.go
+++ b/cli/sign/sign.go
@@ -4,7 +4,7 @@ package sign
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/cloudflare/cfssl/certdb/dbconf"
 	certsql "github.com/cloudflare/cfssl/certdb/sql"
@@ -127,7 +127,7 @@ func signerMain(args []string, c cli.Config) (err error) {
 		}
 
 		var subjectJSON []byte
-		subjectJSON, err = ioutil.ReadFile(subjectFile)
+		subjectJSON, err = os.ReadFile(subjectFile)
 		if err != nil {
 			return
 		}

--- a/cmd/cfssljson/cfssljson.go
+++ b/cmd/cfssljson/cfssljson.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/cloudflare/cfssl/cli/version"
@@ -15,13 +15,13 @@ import (
 
 func readFile(filespec string) ([]byte, error) {
 	if filespec == "-" {
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	}
-	return ioutil.ReadFile(filespec)
+	return os.ReadFile(filespec)
 }
 
 func writeFile(filespec, contents string, perms os.FileMode) {
-	err := ioutil.WriteFile(filespec, []byte(contents), perms)
+	err := os.WriteFile(filespec, []byte(contents), perms)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
@@ -184,7 +184,7 @@ func main() {
 	}
 
 	if contents, ok := input["ocspResponse"]; ok {
-		//ocspResponse is base64 encoded
+		// ocspResponse is base64 encoded
 		resp, err := base64.StdEncoding.DecodeString(contents.(string))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to parse ocspResponse: %v\n", err)

--- a/cmd/mkbundle/mkbundle.go
+++ b/cmd/mkbundle/mkbundle.go
@@ -2,6 +2,7 @@
 // All certificates in the input file paths are checked for revocation and bundled together.
 //
 // Usage:
+//
 //	mkbundle -f bundle_file -nw number_of_workers certificate_file_path ...
 package main
 
@@ -9,7 +10,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -32,7 +32,7 @@ func worker(paths chan string, bundler chan *x509.Certificate, pool *sync.WaitGr
 
 		log.Infof("Loading %s", path)
 
-		fileData, err := ioutil.ReadFile(path)
+		fileData, err := os.ReadFile(path)
 		if err != nil {
 			log.Warningf("%v", err)
 			continue

--- a/cmd/multirootca/api.go
+++ b/cmd/multirootca/api.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 
@@ -82,7 +82,7 @@ func dispatchRequest(w http.ResponseWriter, req *http.Request) {
 	}
 
 	defer req.Body.Close()
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		fail(w, req, http.StatusInternalServerError, 1, err.Error(), "while reading request body")
 		return

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -699,7 +699,7 @@ func LoadFile(path string) (*Config, error) {
 		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("invalid path"))
 	}
 
-	body, err := ioutil.ReadFile(path)
+	body, err := os.ReadFile(path)
 	if err != nil {
 		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("could not read configuration file"))
 	}

--- a/crl/crl_test.go
+++ b/crl/crl_test.go
@@ -2,7 +2,7 @@ package crl
 
 import (
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -16,17 +16,17 @@ const (
 
 func TestNewCRLFromFile(t *testing.T) {
 
-	tryTwoKeyBytes, err := ioutil.ReadFile(tryTwoKey)
+	tryTwoKeyBytes, err := os.ReadFile(tryTwoKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tryTwoCertBytes, err := ioutil.ReadFile(tryTwoCert)
+	tryTwoCertBytes, err := os.ReadFile(tryTwoCert)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	serialListBytes, err := ioutil.ReadFile(serialList)
+	serialListBytes, err := os.ReadFile(serialList)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,12 +49,12 @@ func TestNewCRLFromFile(t *testing.T) {
 }
 
 func TestNewCRLFromFileWithoutRevocations(t *testing.T) {
-	tryTwoKeyBytes, err := ioutil.ReadFile(tryTwoKey)
+	tryTwoKeyBytes, err := os.ReadFile(tryTwoKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tryTwoCertBytes, err := ioutil.ReadFile(tryTwoCert)
+	tryTwoCertBytes, err := os.ReadFile(tryTwoCert)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/csr/csr_test.go
+++ b/csr/csr_test.go
@@ -9,18 +9,16 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/helpers"
 )
 
-//TestNew validate the CertificateRequest created to return with a KeyRequest
-//in KeyRequest field
-
+// TestNew validate the CertificateRequest created to return with a KeyRequest
+// in KeyRequest field
 func TestNew(t *testing.T) {
-
 	if cr := New(); cr.KeyRequest == nil {
 		t.Fatalf("Should create a new, empty certificate request with KeyRequest")
 	}
@@ -755,7 +753,7 @@ func TestBadReGenerate(t *testing.T) {
 var testECDSACertificateFile = "testdata/test-ecdsa-ca.pem"
 
 func TestExtractCertificateRequest(t *testing.T) {
-	certPEM, err := ioutil.ReadFile(testECDSACertificateFile)
+	certPEM, err := os.ReadFile(testECDSACertificateFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/doc/transport.txt
+++ b/doc/transport.txt
@@ -79,7 +79,7 @@ configuration. The example programs use the code
         // conf is a string contain the path to a JSON configuration
         // file.
         var id = new(core.Identity)
-        data, err := ioutil.ReadFile(conf)
+        data, err := os.ReadFile(conf)
         if err != nil {
                 exlib.Err(1, err, "reading config file")
         }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -15,14 +15,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-
-	ct "github.com/google/certificate-transparency-go"
-	cttls "github.com/google/certificate-transparency-go/tls"
-	ctx509 "github.com/google/certificate-transparency-go/x509"
-	"golang.org/x/crypto/ocsp"
-
 	"strings"
 	"time"
 
@@ -30,6 +23,11 @@ import (
 	cferr "github.com/cloudflare/cfssl/errors"
 	"github.com/cloudflare/cfssl/helpers/derhelpers"
 	"github.com/cloudflare/cfssl/log"
+
+	ct "github.com/google/certificate-transparency-go"
+	cttls "github.com/google/certificate-transparency-go/tls"
+	ctx509 "github.com/google/certificate-transparency-go/x509"
+	"golang.org/x/crypto/ocsp"
 	"golang.org/x/crypto/pkcs12"
 )
 
@@ -345,7 +343,7 @@ func LoadPEMCertPool(certsFile string) (*x509.CertPool, error) {
 	if certsFile == "" {
 		return nil, nil
 	}
-	pemCerts, err := ioutil.ReadFile(certsFile)
+	pemCerts, err := os.ReadFile(certsFile)
 	if err != nil {
 		return nil, err
 	}
@@ -591,13 +589,13 @@ func SCTListFromOCSPResponse(response *ocsp.Response) ([]ct.SignedCertificateTim
 func ReadBytes(valFile string) ([]byte, error) {
 	switch splitVal := strings.SplitN(valFile, ":", 2); len(splitVal) {
 	case 1:
-		return ioutil.ReadFile(valFile)
+		return os.ReadFile(valFile)
 	case 2:
 		switch splitVal[0] {
 		case "env":
 			return []byte(os.Getenv(splitVal[1])), nil
 		case "file":
-			return ioutil.ReadFile(splitVal[1])
+			return os.ReadFile(splitVal[1])
 		default:
 			return nil, fmt.Errorf("unknown prefix: %s", splitVal[0])
 		}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -10,14 +10,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/ocsp"
-
 	"github.com/google/certificate-transparency-go"
+	"golang.org/x/crypto/ocsp"
 )
 
 const (
@@ -52,7 +51,7 @@ const (
 func TestParseCertificatesDER(t *testing.T) {
 	var password = []string{"password", "", ""}
 	for i, testFile := range []string{testPKCS12Passwordispassword, testPKCS12EmptyPswd, testCertDERFile} {
-		testDER, err := ioutil.ReadFile(testFile)
+		testDER, err := os.ReadFile(testFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -65,7 +64,7 @@ func TestParseCertificatesDER(t *testing.T) {
 		}
 	}
 
-	testDER, err := ioutil.ReadFile(testEmptyPKCS7DER)
+	testDER, err := os.ReadFile(testEmptyPKCS7DER)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +88,7 @@ func TestKeyLength(t *testing.T) {
 		t.Fatal("KeyLength malfunctioning on nonsense input")
 	}
 
-	//test the ecdsa branch
+	// test the ecdsa branch
 	ecdsaPriv, _ := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
 	ecdsaIn, _ := ecdsaPriv.Public().(*ecdsa.PublicKey)
 	expEcdsa := ecdsaIn.Curve.Params().BitSize
@@ -98,7 +97,7 @@ func TestKeyLength(t *testing.T) {
 		t.Fatal("KeyLength malfunctioning on ecdsa input")
 	}
 
-	//test the rsa branch
+	// test the rsa branch
 	rsaPriv, _ := rsa.GenerateKey(rand.Reader, 256)
 	rsaIn, _ := rsaPriv.Public().(*rsa.PublicKey)
 	expRsa := rsaIn.N.BitLen()
@@ -118,8 +117,8 @@ func TestExpiryTime(t *testing.T) {
 		t.Fatal("Expiry time is malfunctioning on empty input")
 	}
 
-	//read a pem file and use that expiry date
-	bytes, _ := ioutil.ReadFile(testBundleFile)
+	// read a pem file and use that expiry date
+	bytes, _ := os.ReadFile(testBundleFile)
 	certs, err := ParseCertificatesPEM(bytes)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -269,7 +268,7 @@ func TestSignatureString(t *testing.T) {
 
 func TestParseCertificatePEM(t *testing.T) {
 	for _, testFile := range []string{testCertFile, testExtraWSCertFile, testSinglePKCS7} {
-		certPEM, err := ioutil.ReadFile(testFile)
+		certPEM, err := os.ReadFile(testFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -280,7 +279,7 @@ func TestParseCertificatePEM(t *testing.T) {
 		}
 	}
 	for _, testFile := range []string{testBundleFile, testMessedUpCertFile, testEmptyPKCS7PEM, testEmptyCertFile, testMultiplePKCS7} {
-		certPEM, err := ioutil.ReadFile(testFile)
+		certPEM, err := os.ReadFile(testFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -294,7 +293,7 @@ func TestParseCertificatePEM(t *testing.T) {
 func TestParseCertificatesPEM(t *testing.T) {
 	// expected cases
 	for _, testFile := range []string{testBundleFile, testExtraWSBundleFile, testSinglePKCS7, testMultiplePKCS7} {
-		bundlePEM, err := ioutil.ReadFile(testFile)
+		bundlePEM, err := os.ReadFile(testFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -308,7 +307,7 @@ func TestParseCertificatesPEM(t *testing.T) {
 	// test failure cases
 	// few lines deleted, then headers removed
 	for _, testFile := range []string{testMessedUpBundleFile, testEmptyPKCS7PEM, testNoHeaderCert} {
-		bundlePEM, err := ioutil.ReadFile(testFile)
+		bundlePEM, err := os.ReadFile(testFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -320,7 +319,7 @@ func TestParseCertificatesPEM(t *testing.T) {
 }
 
 func TestSelfSignedCertificatePEM(t *testing.T) {
-	testPEM, err := ioutil.ReadFile(testCertFile)
+	testPEM, err := os.ReadFile(testCertFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +329,7 @@ func TestSelfSignedCertificatePEM(t *testing.T) {
 	}
 
 	// a few lines deleted from the pem file
-	wrongPEM, err := ioutil.ReadFile(testMessedUpCertFile)
+	wrongPEM, err := os.ReadFile(testMessedUpCertFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +352,7 @@ func TestSelfSignedCertificatePEM(t *testing.T) {
 func TestParsePrivateKeyPEM(t *testing.T) {
 
 	// expected cases
-	testRSAPEM, err := ioutil.ReadFile(testPrivateRSAKey)
+	testRSAPEM, err := os.ReadFile(testPrivateRSAKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +361,7 @@ func TestParsePrivateKeyPEM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testECDSAPEM, err := ioutil.ReadFile(testPrivateECDSAKey)
+	testECDSAPEM, err := os.ReadFile(testPrivateECDSAKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +370,7 @@ func TestParsePrivateKeyPEM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testEd25519PEM, err := ioutil.ReadFile(testPrivateEd25519Key)
+	testEd25519PEM, err := os.ReadFile(testPrivateEd25519Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +380,7 @@ func TestParsePrivateKeyPEM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testOpenSSLECKey, err := ioutil.ReadFile(testPrivateOpenSSLECKey)
+	testOpenSSLECKey, err := os.ReadFile(testPrivateOpenSSLECKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +399,7 @@ func TestParsePrivateKeyPEM(t *testing.T) {
 	}
 
 	for _, fname := range errCases {
-		testPEM, _ := ioutil.ReadFile(fname)
+		testPEM, _ := os.ReadFile(fname)
 		_, err = ParsePrivateKeyPEM(testPEM)
 		if err == nil {
 			t.Fatal("Incorrect private key failed to produce an error")
@@ -413,7 +412,7 @@ func TestParsePrivateKeyPEM(t *testing.T) {
 const ecdsaTestCSR = "testdata/ecdsa256.csr"
 
 func TestParseCSRPEM(t *testing.T) {
-	in, err := ioutil.ReadFile(ecdsaTestCSR)
+	in, err := os.ReadFile(ecdsaTestCSR)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -432,7 +431,7 @@ func TestParseCSRPEM(t *testing.T) {
 }
 
 func TestParseCSRPEMMore(t *testing.T) {
-	csrPEM, err := ioutil.ReadFile(testCSRPEM)
+	csrPEM, err := os.ReadFile(testCSRPEM)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +440,7 @@ func TestParseCSRPEMMore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	csrPEM, err = ioutil.ReadFile(testCSRPEMBad)
+	csrPEM, err = os.ReadFile(testCSRPEMBad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +458,7 @@ func TestParseCSRPEMMore(t *testing.T) {
 const rsaOldTestCSR = "testdata/rsa-old.csr"
 
 func TestParseOldCSR(t *testing.T) {
-	in, err := ioutil.ReadFile(rsaOldTestCSR)
+	in, err := os.ReadFile(rsaOldTestCSR)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -508,7 +507,7 @@ func TestLoadPEMCertPool(t *testing.T) {
 		t.Fatal("Empty file name should not generate error or a cert pool")
 	}
 
-	in, err := ioutil.ReadFile(testEmptyPem)
+	in, err := os.ReadFile(testEmptyPem)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -519,7 +518,7 @@ func TestLoadPEMCertPool(t *testing.T) {
 		t.Fatal("Expected error for empty file")
 	}
 
-	in, err = ioutil.ReadFile(testEmptyCertFile)
+	in, err = os.ReadFile(testEmptyCertFile)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -530,7 +529,7 @@ func TestLoadPEMCertPool(t *testing.T) {
 		t.Fatal("Expected error for empty cert")
 	}
 
-	in, err = ioutil.ReadFile(clientCertFile)
+	in, err = os.ReadFile(clientCertFile)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/helpers/testsuite/testing_helpers.go
+++ b/helpers/testsuite/testing_helpers.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -324,7 +323,7 @@ func createTempFile(data []byte) (fileName string, err error) {
 	}
 
 	readWritePermissions := os.FileMode(0664)
-	err = ioutil.WriteFile(tempFileName, data, readWritePermissions)
+	err = os.WriteFile(tempFileName, data, readWritePermissions)
 	if err != nil {
 		return "", err
 	}

--- a/helpers/testsuite/testing_helpers_test.go
+++ b/helpers/testsuite/testing_helpers_test.go
@@ -3,7 +3,6 @@ package testsuite
 import (
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -154,7 +153,7 @@ func TestCreateCertificateChain(t *testing.T) {
 	// the same request data.
 
 	CLIOutputFile := preMadeOutput
-	CLIOutput, err := ioutil.ReadFile(CLIOutputFile)
+	CLIOutput, err := os.ReadFile(CLIOutputFile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -291,7 +290,7 @@ func TestCreateSelfSignedCert(t *testing.T) {
 	// and is called ca_csr.json.
 
 	CLIOutputFile := preMadeOutput
-	CLIOutput, err := ioutil.ReadFile(CLIOutputFile)
+	CLIOutput, err := os.ReadFile(CLIOutputFile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -64,7 +64,7 @@ var invalidCryptoParams = []csr.KeyRequest{
 func TestInitCA(t *testing.T) {
 	var req *csr.CertificateRequest
 	hostname := "cloudflare.com"
-	crl := "http://crl.cloudflare.com/655c6a9b-01c6-4eea-bf21-be690cc315e0.crl" //cert_uuid.crl
+	crl := "http://crl.cloudflare.com/655c6a9b-01c6-4eea-bf21-be690cc315e0.crl" // cert_uuid.crl
 	for _, param := range validKeyParams {
 		for _, caconfig := range validCAConfigs {
 			req = &csr.CertificateRequest{
@@ -162,7 +162,7 @@ func TestInitCA(t *testing.T) {
 
 			// Sign RSA and ECDSA customer CSRs.
 			for _, csrFile := range csrFiles {
-				csrBytes, err := ioutil.ReadFile(csrFile)
+				csrBytes, err := os.ReadFile(csrFile)
 				if err != nil {
 					t.Fatal("CSR loading error:", err)
 				}
@@ -356,7 +356,7 @@ func TestRenewMismatch(t *testing.T) {
 }
 
 func TestRenew(t *testing.T) {
-	in, err := ioutil.ReadFile(testECDSACAFile)
+	in, err := os.ReadFile(testECDSACAFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestRenew(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	in, err = ioutil.ReadFile(testECDSACAKeyFile)
+	in, err = os.ReadFile(testECDSACAKeyFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/multiroot/config/config.go
+++ b/multiroot/config/config.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -131,7 +130,7 @@ func LoadRoot(cfg map[string]string) (*Root, error) {
 		return nil, err
 	}
 
-	in, err := ioutil.ReadFile(certPath)
+	in, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +181,7 @@ func parsePrivateKeySpec(spec string, cfg map[string]string) (crypto.Signer, err
 		// stored in the Path field.
 		log.Debug("loading private key file", specURL.Path)
 		path := filepath.Join(specURL.Host, specURL.Path)
-		in, err := ioutil.ReadFile(path)
+		in, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +201,7 @@ func parsePrivateKeySpec(spec string, cfg map[string]string) (crypto.Signer, err
 	case "rofile":
 		log.Warning("Red October support is currently experimental")
 		path := filepath.Join(specURL.Host, specURL.Path)
-		in, err := ioutil.ReadFile(path)
+		in, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -1,9 +1,7 @@
 /*
-
 Package ocsp exposes OCSP signing functionality, much like the signer
 package does for certificate signing.  It also provies a basic OCSP
 responder stack for serving pre-signed OCSP responses.
-
 */
 package ocsp
 
@@ -12,7 +10,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -113,12 +111,12 @@ func NewSignerFromFile(issuerFile, responderFile, keyFile string, interval time.
 		return nil, err
 	}
 	log.Debug("Loading responder cert: ", responderFile)
-	responderBytes, err := ioutil.ReadFile(responderFile)
+	responderBytes, err := os.ReadFile(responderFile)
 	if err != nil {
 		return nil, err
 	}
 	log.Debug("Loading responder key: ", keyFile)
-	keyBytes, err := ioutil.ReadFile(keyFile)
+	keyBytes, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, cferr.Wrap(cferr.CertificateError, cferr.ReadFailed, err)
 	}

--- a/ocsp/ocsp_test.go
+++ b/ocsp/ocsp_test.go
@@ -1,13 +1,13 @@
 package ocsp
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/ocsp"
-
 	"github.com/cloudflare/cfssl/helpers"
+
+	"golang.org/x/crypto/ocsp"
 )
 
 const (
@@ -65,7 +65,7 @@ func TestNewSignerFromFile(t *testing.T) {
 
 func setup(t *testing.T) (SignRequest, time.Duration) {
 	dur, _ := time.ParseDuration("1ms")
-	certPEM, err := ioutil.ReadFile(otherCertFile)
+	certPEM, err := os.ReadFile(otherCertFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ocsp/responder.go
+++ b/ocsp/responder.go
@@ -15,9 +15,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"time"
 
@@ -131,7 +132,7 @@ func (src DBSource) Response(req *ocsp.Request) ([]byte, http.Header, error) {
 // PEM without headers or whitespace).  Invalid responses are ignored.
 // This function pulls the entire file into an InMemorySource.
 func NewSourceFromFile(responseFile string) (Source, error) {
-	fileContents, err := ioutil.ReadFile(responseFile)
+	fileContents, err := os.ReadFile(responseFile)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +310,7 @@ func (rs Responder) ServeHTTP(response http.ResponseWriter, request *http.Reques
 			return
 		}
 	case "POST":
-		requestBody, err = ioutil.ReadAll(request.Body)
+		requestBody, err = io.ReadAll(request.Body)
 		if err != nil {
 			log.Errorf("Problem reading body of POST: %s", err)
 			response.WriteHeader(http.StatusBadRequest)

--- a/ocsp/responder_test.go
+++ b/ocsp/responder_test.go
@@ -2,10 +2,10 @@ package ocsp
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -210,11 +210,11 @@ func TestSqliteTrivial(t *testing.T) {
 	// an OCSP request.
 	certFile := "testdata/sqlite_ca.pem"
 	issuerFile := "testdata/ca.pem"
-	certContent, err := ioutil.ReadFile(certFile)
+	certContent, err := os.ReadFile(certFile)
 	if err != nil {
 		t.Errorf("Error reading cert file: %s", err)
 	}
-	issuerContent, err := ioutil.ReadFile(issuerFile)
+	issuerContent, err := os.ReadFile(issuerFile)
 	if err != nil {
 		t.Errorf("Error reading issuer file: %s", err)
 	}
@@ -274,11 +274,11 @@ func TestSqliteRealResponse(t *testing.T) {
 
 	certFile := "testdata/cert.pem"
 	issuerFile := "testdata/ca.pem"
-	certContent, err := ioutil.ReadFile(certFile)
+	certContent, err := os.ReadFile(certFile)
 	if err != nil {
 		t.Errorf("Error reading cert file: %s", err)
 	}
-	issuerContent, err := ioutil.ReadFile(issuerFile)
+	issuerContent, err := os.ReadFile(issuerFile)
 	if err != nil {
 		t.Errorf("Error reading issuer file: %s", err)
 	}
@@ -308,7 +308,7 @@ func TestSqliteRealResponse(t *testing.T) {
 		ThisUpdate:   time.Now(),
 		NextUpdate:   time.Now().AddDate(0, 1, 0),
 	}
-	keyPEM, err := ioutil.ReadFile("testdata/ca-key.pem")
+	keyPEM, err := os.ReadFile("testdata/ca-key.pem")
 	if err != nil {
 		t.Errorf("Error reading private key file: %s", err)
 	}

--- a/revoke/revoke.go
+++ b/revoke/revoke.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	neturl "net/url"
 	"sync"
@@ -318,21 +317,21 @@ func sendOCSPRequest(server string, req []byte, leaf, issuer *x509.Certificate) 
 	return ocsp.ParseResponseForCert(body, leaf, issuer)
 }
 
-var crlRead = ioutil.ReadAll
+var crlRead = io.ReadAll
 
 // SetCRLFetcher sets the function to use to read from the http response body
 func SetCRLFetcher(fn func(io.Reader) ([]byte, error)) {
 	crlRead = fn
 }
 
-var remoteRead = ioutil.ReadAll
+var remoteRead = io.ReadAll
 
 // SetRemoteFetcher sets the function to use to read from the http response body
 func SetRemoteFetcher(fn func(io.Reader) ([]byte, error)) {
 	remoteRead = fn
 }
 
-var ocspRead = ioutil.ReadAll
+var ocspRead = io.ReadAll
 
 // SetOCSPFetcher sets the function to use to read from the http response body
 func SetOCSPFetcher(fn func(io.Reader) ([]byte, error)) {

--- a/scan/crypto/md5/gen.go
+++ b/scan/crypto/md5/gen.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 // This program generates md5block.go
@@ -18,7 +19,6 @@ import (
 	"bytes"
 	"flag"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"strings"
 	"text/template"
@@ -40,7 +40,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = ioutil.WriteFile(*filename, data, 0644)
+	err = os.WriteFile(*filename, data, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scan/crypto/tls/handshake_test.go
+++ b/scan/crypto/tls/handshake_test.go
@@ -11,8 +11,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -156,7 +156,7 @@ func parseTestData(r io.Reader) (flows [][]byte, err error) {
 
 // tempFile creates a temp file containing contents and returns its path.
 func tempFile(contents string) string {
-	file, err := ioutil.TempFile("", "go-tls-test")
+	file, err := os.CreateTemp("", "go-tls-test")
 	if err != nil {
 		panic("failed to create temp file: " + err.Error())
 	}

--- a/scan/crypto/tls/tls.go
+++ b/scan/crypto/tls/tls.go
@@ -18,8 +18,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -176,11 +176,11 @@ func Dial(network, addr string, config *Config) (*Conn, error) {
 // Certificate.Leaf will be nil because the parsed form of the certificate is
 // not retained.
 func LoadX509KeyPair(certFile, keyFile string) (Certificate, error) {
-	certPEMBlock, err := ioutil.ReadFile(certFile)
+	certPEMBlock, err := os.ReadFile(certFile)
 	if err != nil {
 		return Certificate{}, err
 	}
-	keyPEMBlock, err := ioutil.ReadFile(keyFile)
+	keyPEMBlock, err := os.ReadFile(keyFile)
 	if err != nil {
 		return Certificate{}, err
 	}

--- a/selfsign/selfsign_test.go
+++ b/selfsign/selfsign_test.go
@@ -3,9 +3,9 @@ package selfsign
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -22,11 +22,11 @@ const (
 )
 
 func TestDefaultSign(t *testing.T) {
-	csrBytes, err := ioutil.ReadFile(csrFile)
+	csrBytes, err := os.ReadFile(csrFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	keyBytes, err := ioutil.ReadFile(keyFile)
+	keyBytes, err := os.ReadFile(keyFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,11 +47,11 @@ func TestDefaultSign(t *testing.T) {
 
 func TestSANs(t *testing.T) {
 	t.Skip("broken relating to https://github.com/cloudflare/cfssl/issues/1230")
-	csrBytes, err := ioutil.ReadFile(csr2File)
+	csrBytes, err := os.ReadFile(csr2File)
 	if err != nil {
 		t.Fatal(err)
 	}
-	keyBytes, err := ioutil.ReadFile(keyFile)
+	keyBytes, err := os.ReadFile(keyFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/remote/remote_test.go
+++ b/signer/remote/remote_test.go
@@ -5,10 +5,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -130,7 +130,7 @@ func verifyRemoteInfo(t *testing.T, remoteConfig *config.Config) {
 		t.Fatal("remote info failed:", err)
 	}
 
-	caBytes, err := ioutil.ReadFile(testCaFile)
+	caBytes, err := os.ReadFile(testCaFile)
 	caBytes = bytes.TrimSpace(caBytes)
 	if err != nil {
 		t.Fatal("fail to read test CA cert:", err)
@@ -187,7 +187,7 @@ func verifyRemoteSign(t *testing.T, remoteConfig *config.Config) {
 
 	hosts := []string{"cloudflare.com"}
 	for _, test := range testsuite.CSRTests {
-		csr, err := ioutil.ReadFile(test.File)
+		csr, err := os.ReadFile(test.File)
 		if err != nil {
 			t.Fatal("CSR loading error:", err)
 		}
@@ -224,7 +224,7 @@ func TestRemoteSignBadServerAndOverride(t *testing.T) {
 	s := newRemoteSigner(t, remoteConfig.Signing)
 
 	hosts := []string{"cloudflare.com"}
-	csr, err := ioutil.ReadFile("../local/testdata/rsa2048.csr")
+	csr, err := os.ReadFile("../local/testdata/rsa2048.csr")
 	if err != nil {
 		t.Fatal("CSR loading error:", err)
 	}

--- a/signer/universal/universal_test.go
+++ b/signer/universal/universal_test.go
@@ -2,10 +2,10 @@ package universal
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -300,7 +300,7 @@ func checkInfo(t *testing.T, s signer.Signer, name string, profile *config.Signi
 		t.Fatalf("Expected usage for profile %s to be %+v, got %+v", name, profile.Usage, resp.Usage)
 	}
 
-	caBytes, err := ioutil.ReadFile(testCaFile)
+	caBytes, err := os.ReadFile(testCaFile)
 	caBytes = bytes.TrimSpace(caBytes)
 	if err != nil {
 		t.Fatal("fail to read test CA cert:", err)
@@ -375,7 +375,7 @@ func TestUniversalRemoteAndLocalSign(t *testing.T) {
 	checkSign := func(name string, profile *config.SigningProfile) {
 		hosts := []string{"cloudflare.com"}
 		for _, test := range testsuite.CSRTests {
-			csr, err := ioutil.ReadFile(test.File)
+			csr, err := os.ReadFile(test.File)
 			if err != nil {
 				t.Fatalf("CSR loading error (%s): %v", name, err)
 			}

--- a/transport/example/maclient/client.go
+++ b/transport/example/maclient/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/cloudflare/cfssl/transport"
 	"github.com/cloudflare/cfssl/transport/core"
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	var id = new(core.Identity)
-	data, err := ioutil.ReadFile(conf)
+	data, err := os.ReadFile(conf)
 	if err != nil {
 		exlib.Err(1, err, "reading config file")
 	}

--- a/transport/example/maserver/server.go
+++ b/transport/example/maserver/server.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/transport"
@@ -23,7 +23,7 @@ func main() {
 	flag.Parse()
 
 	var id = new(core.Identity)
-	data, err := ioutil.ReadFile(conf)
+	data, err := os.ReadFile(conf)
 	if err != nil {
 		exlib.Err(1, err, "reading config file")
 	}

--- a/transport/kp/key_provider.go
+++ b/transport/kp/key_provider.go
@@ -22,7 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/cloudflare/cfssl/csr"
@@ -288,7 +288,7 @@ func (sp *StandardProvider) Load() (err error) {
 		}
 	}()
 
-	sp.internal.keyPEM, err = ioutil.ReadFile(sp.Paths.KeyFile)
+	sp.internal.keyPEM, err = os.ReadFile(sp.Paths.KeyFile)
 	if err != nil {
 		return
 	}
@@ -300,7 +300,7 @@ func (sp *StandardProvider) Load() (err error) {
 
 	clearKey = false
 
-	sp.internal.certPEM, err = ioutil.ReadFile(sp.Paths.CertFile)
+	sp.internal.certPEM, err = os.ReadFile(sp.Paths.CertFile)
 	if err != nil {
 		return ErrCertificateUnavailable
 	}
@@ -384,12 +384,12 @@ func (sp *StandardProvider) Store() error {
 		return errors.New("transport: provider does not have a key and certificate")
 	}
 
-	err := ioutil.WriteFile(sp.Paths.CertFile, sp.internal.certPEM, 0644)
+	err := os.WriteFile(sp.Paths.CertFile, sp.internal.certPEM, 0644)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(sp.Paths.KeyFile, sp.internal.keyPEM, 0600)
+	return os.WriteFile(sp.Paths.KeyFile, sp.internal.keyPEM, 0600)
 }
 
 // X509KeyPair returns a tls.Certificate for the provider.

--- a/transport/roots/provider.go
+++ b/transport/roots/provider.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/transport/core"
@@ -114,7 +114,7 @@ func TrustPEM(metadata map[string]string) ([]*x509.Certificate, error) {
 		return nil, errors.New("transport: PEM source requires a source file")
 	}
 
-	in, err := ioutil.ReadFile(sourceFile)
+	in, err := os.ReadFile(sourceFile)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/roots/system/root_plan9.go
+++ b/transport/roots/system/root_plan9.go
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build plan9
 // +build plan9
 
 package system
 
 import (
 	"crypto/x509"
-	"io/ioutil"
 )
 
 // Possible certificate files; stop after finding one.
@@ -18,7 +18,7 @@ var certFiles = []string{
 
 func initSystemRoots() (roots []*x509.Certificate) {
 	for _, file := range certFiles {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err == nil {
 			roots, _ = appendPEM(roots, data)
 			return

--- a/transport/roots/system/root_unix.go
+++ b/transport/roots/system/root_unix.go
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build dragonfly || freebsd || linux || nacl || netbsd || openbsd || solaris
 // +build dragonfly freebsd linux nacl netbsd openbsd solaris
 
 package system
 
 import (
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 )
 
 // Possible directories with certificate files; stop after successfully
@@ -20,7 +21,7 @@ var certDirectories = []string{
 func initSystemRoots() []*x509.Certificate {
 	var roots []*x509.Certificate
 	for _, file := range certFiles {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err == nil {
 			roots, _ = appendPEM(roots, data)
 			return roots
@@ -28,14 +29,14 @@ func initSystemRoots() []*x509.Certificate {
 	}
 
 	for _, directory := range certDirectories {
-		fis, err := ioutil.ReadDir(directory)
+		fis, err := os.ReadDir(directory)
 		if err != nil {
 			continue
 		}
 		rootsAdded := false
 		for _, fi := range fis {
 			var ok bool
-			data, err := ioutil.ReadFile(directory + "/" + fi.Name())
+			data, err := os.ReadFile(directory + "/" + fi.Name())
 			if err == nil {
 				if roots, ok = appendPEM(roots, data); ok {
 					rootsAdded = true

--- a/ubiquity/ubiquity_platform.go
+++ b/ubiquity/ubiquity_platform.go
@@ -9,7 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -93,7 +93,7 @@ func (p *Platform) ParseAndLoad() (ok bool) {
 	p.KeyAlgoUbiquity = p.keyAlgoUbiquity()
 	p.KeyStore = map[string]bool{}
 	if p.KeyStoreFile != "" {
-		pemBytes, err := ioutil.ReadFile(p.KeyStoreFile)
+		pemBytes, err := os.ReadFile(p.KeyStoreFile)
 		if err != nil {
 			log.Error(err)
 			return false
@@ -140,7 +140,7 @@ func LoadPlatforms(filename string) error {
 	relativePath := filepath.Dir(filename)
 	// Attempt to load root certificate metadata
 	log.Debug("Loading platform metadata: ", filename)
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("platform metadata failed to load: %v", err)
 	}

--- a/ubiquity/ubiquity_test.go
+++ b/ubiquity/ubiquity_test.go
@@ -3,7 +3,7 @@ package ubiquity
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -24,7 +24,7 @@ const (
 var rsa1024Cert, rsa2048Cert, rsa3072Cert, rsa4096Cert, ecdsa256Cert, ecdsa384Cert, ecdsa521Cert *x509.Certificate
 
 func readCert(filename string) *x509.Certificate {
-	bytes, _ := ioutil.ReadFile(filename)
+	bytes, _ := os.ReadFile(filename)
 	cert, _ := helpers.ParseCertificatePEM(bytes)
 	return cert
 }

--- a/whitelist/http_test.go
+++ b/whitelist/http_test.go
@@ -1,7 +1,7 @@
 package whitelist
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -31,7 +31,7 @@ func testHTTPResponse(url string, t *testing.T) string {
 		t.Fatalf("%v", err)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/whitelist/whitelist_test.go
+++ b/whitelist/whitelist_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -199,7 +199,7 @@ func TestNetConn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	body, err := ioutil.ReadAll(conn)
+	body, err := io.ReadAll(conn)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -213,7 +213,7 @@ func TestNetConn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	body, err = ioutil.ReadAll(conn)
+	body, err = io.ReadAll(conn)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Grouped per top-level package; there's one remaining use in transport/ca/localca, which is being removed in https://github.com/cloudflare/cfssl/pull/1257