### PR TITLE
Binary enablement for s390x

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/cfssl
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
@@ -60,6 +61,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/cfssl-bundle
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
@@ -95,6 +97,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/cfssl-certinfo
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
@@ -130,6 +133,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/cfssl-newkey
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
@@ -165,6 +169,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/cfssl-scan
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
@@ -200,6 +205,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/cfssljson
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
@@ -235,6 +241,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/mkbundle
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}
@@ -270,6 +277,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     main: ./cmd/multirootca
     ldflags:
       - -s -w -X github.com/cloudflare/cfssl/cli/version.version={{.Version}}


### PR DESCRIPTION
This PR is in continuation of issue #[1225](https://github.com/cloudflare/cfssl/issues/1225).
Updating the yml to generate s390x binaries.