### PR TITLE
feat(cfssljson): Add `-output` argument to save files in another directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ filenames in the following way:
 * if __bundle__       is specified,                    __basename-bundle.pem__   will be produced.
 * if __ocspResponse__ is specified,                    __basename-response.der__ will be produced.
 
+If you want to save the files in another directory, you can pass the
+folder path using the `-output` argument.
+
 Instead of saving to a file, you can pass `-stdout` to output the encoded
 contents to standard output.
 

--- a/cmd/cfssljson/cfssljson.go
+++ b/cmd/cfssljson/cfssljson.go
@@ -33,7 +33,7 @@ func writeFile(filespec, contents string, perms os.FileMode) {
 func isDirectory(path string) (bool, error) {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
-		return false, fmt.Errorf("failed to stat the directory (--output=%s): %v", path, err)
+		return false, fmt.Errorf("failed to stat the directory (--output=%s): %v\n", path, err)
 	}
 
 	return fileInfo.IsDir(), nil

--- a/cmd/cfssljson/cfssljson_test.go
+++ b/cmd/cfssljson/cfssljson_test.go
@@ -18,3 +18,38 @@ func TestReadFile(t *testing.T) {
 		t.Fatal("File not read correctly")
 	}
 }
+
+func TestIsDirectory(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		ok, err := isDirectory("testdata")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if ok == false {
+			t.Fatal("should be a directory")
+		}
+	})
+
+	t.Run("NOK - Not a directory", func(t *testing.T) {
+		ok, err := isDirectory("cfssljson.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if ok == true {
+			t.Fatal("should not be a directory")
+		}
+	})
+
+	t.Run("NOK - File not present", func(t *testing.T) {
+		ok, err := isDirectory("notpresent")
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if ok == true {
+			t.Fatal("should not exist")
+		}
+	})
+}


### PR DESCRIPTION
   ## Problem
Currently, `cfssljson` doesn't provide any way to write the separate `key`, `certificate`, `csr`, and `bundle` files in a specific folder. This is inconvenient if we want to output the certificates in a different directory.

A workaround would be to use the `-stdout` argument, which writes every file in the standard output separated by a blank line. Then, redirect the output to a specific folder.
**Example**:
```
cfssl gencert -initca ca_csr.json | cfssljson -bare -stdout ca > path/to/folder/certs
```
But, this approach writes every entity in one file, then requires us to re-process the output of `cfssjson` to separate the `key`, `certificate`, `csr`, and `bundle`.

This PR adds an `--output` argument to the `cfssljson` tool to place output files into a specific directory.