### PR TITLE
CI: bump actions version, fix node 12 deprecation warning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,10 +50,10 @@ jobs:
       - run: psql -c 'create database certdb_development;' -U postgres;
       - run: mysql -e 'create database certdb_development;' -u root;
       - run: mysql -e 'SET global sql_mode = 0;' -u root;
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
 
@@ -70,7 +70,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - uses: actions/checkout@v3

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: make snapshot
       - name: Archive snapshot artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Changes

- Bump `actions/checkout` from `v2` (Node 12) to `v3` (Node 16). [This will fix the Node 12 deprecation warning in actions].
- Bump `actions/setup-go` to `v4`.















