### PR TITLE
fix architecture for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM --platform=${BUILDPLATFORM} golang:1.20
+FROM golang:1.20
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" 
 
 LABEL org.opencontainers.image.source https://github.com/cloudflare/cfssl
 LABEL org.opencontainers.image.description "Cloudflare's PKI toolkit"


### PR DESCRIPTION
it seems that specifying the platform arg is not needed / incorrect for github actions: https://github.com/docker/build-push-action/issues/668#issuecomment-1213063705

resolves #1287