### PR TITLE
Allow API client to provide serial and detect duplicate entry error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/log"
 	ocspConfig "github.com/cloudflare/cfssl/ocsp/config"
+
 	// empty import of zlint/v3 required to have lints registered.
 	_ "github.com/zmap/zlint/v3"
 	"github.com/zmap/zlint/v3/lint"
@@ -121,7 +122,7 @@ type SigningProfile struct {
 	CSRWhitelist                *CSRWhitelist
 	NameWhitelist               *regexp.Regexp
 	ExtensionWhitelist          map[string]bool
-	ClientProvidesSerialNumbers bool
+	ClientProvidesSerialNumbers bool `json:"client_provides_serial_numbers"`
 	// LintRegistry is the collection of lints that should be used if
 	// LintErrLevel is configured. By default all ZLint lints are used. If
 	// ExcludeLints or ExcludeLintSources are set then this registry will be

--- a/errors/error.go
+++ b/errors/error.go
@@ -210,6 +210,9 @@ const (
 	// RecordNotFound occurs when a SQL query targeting on one unique
 	// record failes to update the specified row in the table.
 	RecordNotFound
+	// DuplicateEntry occurs when SQL query tries to insert or update
+	// using key that must be unique in db table but already exists there.
+	DuplicateEntry
 )
 
 // The error interface implementation, which formats to a JSON object string.


### PR DESCRIPTION
This mod adds access to `ClientProvidesSerialNumbers` cert profile field from JSON profile config with `client_provides_serial_numbers` option. When enabled, cert serial must be provided by API client in request.

This mod adds also specific API error code in case of sign request failure caused by already taken serial number. For MySQL/MariaDB and SQLite only (to be done separately for PostgreSQL by devs using this DB engine).

Author-Change-Id: IB#1137304