### PR TITLE
fix: do not trim notBefore

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,7 +112,7 @@ type SigningProfile struct {
 
 	Policies                    []CertificatePolicy
 	Expiry                      time.Duration
-	Backdate                    time.Duration
+	Backdate                    *time.Duration
 	Provider                    auth.Provider
 	PrevProvider                auth.Provider // to suppport key rotation
 	RemoteProvider              auth.Provider
@@ -210,7 +210,7 @@ func (p *SigningProfile) populate(cfg *Config) error {
 				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
 			}
 
-			p.Backdate = dur
+			p.Backdate = &dur
 		}
 
 		if !p.NotBefore.IsZero() && !p.NotAfter.IsZero() && p.NotAfter.Before(p.NotBefore) {

--- a/initca/initca.go
+++ b/initca/initca.go
@@ -57,7 +57,7 @@ func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
 		}
 
 		if req.CA.Backdate != "" {
-			policy.Default.Backdate, err = time.ParseDuration(req.CA.Backdate)
+			*policy.Default.Backdate, err = time.ParseDuration(req.CA.Backdate)
 			if err != nil {
 				return
 			}
@@ -251,7 +251,7 @@ func Update(ca *x509.Certificate, priv crypto.Signer) (cert []byte, err error) {
 	}
 
 	validity := ca.NotAfter.Sub(ca.NotBefore)
-	copy.NotBefore = time.Now().Round(time.Minute).Add(-5 * time.Minute)
+	copy.NotBefore = time.Now().Round(time.Second)
 	copy.NotAfter = copy.NotBefore.Add(validity)
 	cert, err = x509.CreateCertificate(rand.Reader, copy, copy, priv.Public(), priv)
 	if err != nil {

--- a/selfsign/selfsign.go
+++ b/selfsign/selfsign.go
@@ -117,7 +117,7 @@ func Sign(priv crypto.Signer, csrPEM []byte, profile *config.SigningProfile) ([]
 	}
 
 	template.SerialNumber = serialNumber
-	template.NotBefore = now.Add(-5 * time.Minute).UTC()
+	template.NotBefore = now.Round(time.Second).UTC()
 	template.NotAfter = now.Add(expiry).UTC()
 	template.KeyUsage = ku
 	template.ExtKeyUsage = eku

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -328,12 +328,10 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 		if !profile.NotBefore.IsZero() {
 			notBefore = profile.NotBefore
 		} else {
-			if backdate = profile.Backdate; backdate == 0 {
-				backdate = -5 * time.Minute
-			} else {
-				backdate = -1 * profile.Backdate
+			if profile.Backdate != nil {
+				backdate = -1 * (*profile.Backdate)
 			}
-			notBefore = time.Now().Round(time.Minute).Add(backdate)
+			notBefore = time.Now().Round(time.Second).Add(backdate)
 		}
 	}
 	notBefore = notBefore.UTC()


### PR DESCRIPTION
Fix: https://github.com/cloudflare/cfssl/issues/1064

## Motivation
Today, I attempted to use cfssl to generate my certificate and key, with a validity period of 5 minutes, and then setup that to my program, I got the following log:
```
Caused by: sun.security.validator.ValidatorException: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
	at sun.security.validator.PKIXValidator.doValidate(PKIXValidator.java:369) ~[?:?]
	at sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:275) ~[?:?]
	at sun.security.validator.Validator.validate(Validator.java:264) ~[?:?]
	at sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:285) ~[?:?]
	at sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:144) ~[?:?]
	at io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.checkServerTrusted(EnhancingX509ExtendedTrustManager.java:69) ~[netty-handler-4.1.105.Final.jar:4.1.105.Final]
	at io.netty.handler.ssl.ReferenceCountedOpenSslClientContext$ExtendedTrustManagerVerifyCallback.verify(ReferenceCountedOpenSslClientContext.java:235) ~[netty-handler-4.1.105.Final.jar:4.1.105.Final]
	at io.netty.handler.ssl.ReferenceCountedOpenSslContext$AbstractCertificateVerifier.verify(ReferenceCountedOpenSslContext.java:790) ~[netty-handler-4.1.105.Final.jar:4.1.105.Final]
```

You see this cert has expired, and then I tried to check the cfssl, and I found the notBefore has been trimmed with 5m. I know that trimming the notBefore is a good idea to void the clock issue, but this will cause some accidents. So I suggest that do not trim notBefore.

The following is the reproduced script:
```
echo '{"CN":"CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - |cfssljson -bare ca -
echo '{"signing":{"default":{"expiry":"5m","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
echo '{"CN":"broker","hosts":["localhost"],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem - | cfssljson -bare broker
echo '{"CN":"localhost","hosts":["localhost"],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem - | cfssljson -bare client
openssl pkcs8 -topk8 -inform PEM -outform PEM \
      -in broker-key.pem -out broker-key-pk8.pem -nocrypt
openssl pkcs8 -topk8 -inform PEM -outform PEM \
      -in client-key.pem -out client-key-pk8.pem -nocrypt

echo "now: $(date -u)"
echo "------"
cfssl certinfo -cert client.pem | grep not
```

And then you can see the `not_after` is very close to the now. 

## Alternative
Add backdate to the `ca-config.json`:
```
echo '{"signing":{"default":{"backdate": "1s", "expiry":"5m","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
```

