### PR TITLE
Build binaries and container images for ppc64le.

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/cfssl
     ldflags:
@@ -63,6 +64,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/cfssl-bundle
     ldflags:
@@ -100,6 +102,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/cfssl-certinfo
     ldflags:
@@ -137,6 +140,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/cfssl-newkey
     ldflags:
@@ -174,6 +178,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/cfssl-scan
     ldflags:
@@ -211,6 +216,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/cfssljson
     ldflags:
@@ -248,6 +254,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/mkbundle
     ldflags:
@@ -285,6 +292,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
       - s390x
     main: ./cmd/multirootca
     ldflags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" 
 
-LABEL org.opencontainers.image.source https://github.com/cloudflare/cfssl
-LABEL org.opencontainers.image.description "Cloudflare's PKI toolkit"
+LABEL org.opencontainers.image.source=https://github.com/cloudflare/cfssl
+LABEL org.opencontainers.image.description="Cloudflare's PKI toolkit"
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
#### Changes in this PR:
1.  Add support to build binaries and images for ppc64le architecture.

2. Address warnings regarding labels in `LegacyKeyValueFormat` used in the image:
```
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 7)
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 8)
```
Fixed and validated through a build.
```
            "Labels": {
                "org.opencontainers.image.description": "Cloudflare's PKI toolkit",
                "org.opencontainers.image.source": "https://github.com/cloudflare/cfssl"
            }
```