### PR TITLE
Modified to store all SANs fields in the database.

### DIFF
--- a/signer/local/local.go
+++ b/signer/local/local.go
@@ -525,7 +525,22 @@ func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
 		if err := certRecord.SetMetadata(req.Metadata); err != nil {
 			return nil, err
 		}
-		if err := certRecord.SetSANs(certTBS.DNSNames); err != nil {
+
+		var ipStrings []string
+		for _, ip := range certTBS.IPAddresses {
+			ipStrings = append(ipStrings, ip.String())
+		}
+
+		var uriStrings []string
+		for _, uri := range certTBS.URIs {
+			uriStrings = append(uriStrings, uri.String())
+		}
+
+		allSANs := append(certTBS.DNSNames, certTBS.EmailAddresses...)
+		allSANs = append(allSANs, ipStrings...)
+		allSANs = append(allSANs, uriStrings...)
+
+		if err := certRecord.SetSANs(allSANs); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
When issuing certificates, the CN (Common Name) is set to the user ID, and SANs (Subject Alternative Names) are set to the user’s email. However, only the Domain Name (DNSName) was being stored in the SANs field in the database, while other items like email, IP address, and URI were ignored. I have modified the code to ensure that all SANs fields are now saved in the sans column of the database.