### PR TITLE
Fixing MySQL issue while trying to save unsupported 0000-00-00 timestamp to RevokedAt field

### DIFF
--- a/api/certadd/insert.go
+++ b/api/certadd/insert.go
@@ -55,7 +55,7 @@ type AddRequest struct {
 	Status       string         `json:"status"`
 	Reason       int            `json:"reason"`
 	Expiry       time.Time      `json:"expiry"`
-	RevokedAt    time.Time      `json:"revoked_at"`
+	RevokedAt    *time.Time     `json:"revoked_at"`
 	PEM          string         `json:"pem"`
 	IssuedAt     *time.Time     `json:"issued_at"`
 	NotBefore    *time.Time     `json:"not_before"`
@@ -106,7 +106,7 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if ocsp.StatusCode[req.Status] == stdocsp.Revoked {
-		if req.RevokedAt == (time.Time{}) {
+		if *req.RevokedAt == (time.Time{}) {
 			return errors.NewBadRequestString("Revoked certificate should specify when it was revoked")
 		}
 
@@ -180,7 +180,7 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) error {
 			Certificate: cert,
 			Status:      req.Status,
 			Reason:      req.Reason,
-			RevokedAt:   req.RevokedAt,
+			RevokedAt:   *req.RevokedAt,
 		}
 		ocspResponse, err := h.signer.Sign(sr)
 		if err != nil {

--- a/api/crl/crl_test.go
+++ b/api/crl/crl_test.go
@@ -26,13 +26,14 @@ const (
 func prepDB() (certdb.Accessor, error) {
 	db := testdb.SQLiteDB("../../certdb/testdb/certstore_development.db")
 	expirationTime := time.Now().AddDate(1, 0, 0)
+	timeNow := time.Now()
 	var cert = certdb.CertificateRecord{
 		Serial:    "1",
 		AKI:       fakeAKI,
 		Expiry:    expirationTime,
 		PEM:       "revoked cert",
 		Status:    "revoked",
-		RevokedAt: time.Now(),
+		RevokedAt: &timeNow,
 		Reason:    4,
 	}
 

--- a/certdb/certdb.go
+++ b/certdb/certdb.go
@@ -11,14 +11,14 @@ import (
 // CertificateRecord encodes a certificate and its metadata
 // that will be recorded in a database.
 type CertificateRecord struct {
-	Serial    string    `db:"serial_number"`
-	AKI       string    `db:"authority_key_identifier"`
-	CALabel   string    `db:"ca_label"`
-	Status    string    `db:"status"`
-	Reason    int       `db:"reason"`
-	Expiry    time.Time `db:"expiry"`
-	RevokedAt time.Time `db:"revoked_at"`
-	PEM       string    `db:"pem"`
+	Serial    string     `db:"serial_number"`
+	AKI       string     `db:"authority_key_identifier"`
+	CALabel   string     `db:"ca_label"`
+	Status    string     `db:"status"`
+	Reason    int        `db:"reason"`
+	Expiry    time.Time  `db:"expiry"`
+	RevokedAt *time.Time `db:"revoked_at"`
+	PEM       string     `db:"pem"`
 	// the following fields will be empty for data inserted before migrate 002 has been run.
 	IssuedAt     *time.Time     `db:"issued_at"`
 	NotBefore    *time.Time     `db:"not_before"`

--- a/certdb/mysql/migrations/001_CreateCertificates.sql
+++ b/certdb/mysql/migrations/001_CreateCertificates.sql
@@ -7,8 +7,8 @@ CREATE TABLE certificates (
   ca_label                 varbinary(128),
   status                   varbinary(128) NOT NULL,
   reason                   int,
-  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
-  revoked_at               timestamp DEFAULT '0000-00-00 00:00:00',
+  expiry                   timestamp DEFAULT NULL,
+  revoked_at               timestamp DEFAULT NULL,
   pem                      varbinary(4096) NOT NULL,
   PRIMARY KEY(serial_number, authority_key_identifier)
 );
@@ -17,7 +17,7 @@ CREATE TABLE ocsp_responses (
   serial_number            varbinary(128) NOT NULL,
   authority_key_identifier varbinary(128) NOT NULL,
   body                     varbinary(4096) NOT NULL,
-  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
+  expiry                   timestamp DEFAULT NULL,
   PRIMARY KEY(serial_number, authority_key_identifier)
 );
 

--- a/certdb/mysql/migrations/002_AddMetadataToCertificates.sql
+++ b/certdb/mysql/migrations/002_AddMetadataToCertificates.sql
@@ -1,8 +1,8 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 ALTER TABLE certificates
-ADD COLUMN issued_at timestamp DEFAULT '0000-00-00 00:00:00',
-    ADD COLUMN not_before timestamp DEFAULT '0000-00-00 00:00:00',
+ADD COLUMN issued_at timestamp DEFAULT NULL,
+    ADD COLUMN not_before timestamp DEFAULT NULL,
     ADD COLUMN metadata JSON,
     ADD COLUMN sans JSON,
     ADD COLUMN common_name TEXT;

--- a/certdb/sql/database_accessor.go
+++ b/certdb/sql/database_accessor.go
@@ -107,7 +107,7 @@ func (d *Accessor) InsertCertificate(cr certdb.CertificateRecord) error {
 		return err
 	}
 
-	var issuedAt, notBefore *time.Time
+	var issuedAt, notBefore, revokedAt *time.Time
 	if cr.IssuedAt != nil {
 		t := cr.IssuedAt.UTC()
 		issuedAt = &t
@@ -116,6 +116,11 @@ func (d *Accessor) InsertCertificate(cr certdb.CertificateRecord) error {
 		t := cr.NotBefore.UTC()
 		notBefore = &t
 	}
+	if cr.RevokedAt != nil {
+		t := cr.RevokedAt.UTC()
+		revokedAt = &t
+	}
+
 	res, err := d.db.NamedExec(insertSQL, &certdb.CertificateRecord{
 		Serial:       cr.Serial,
 		AKI:          cr.AKI,
@@ -123,7 +128,7 @@ func (d *Accessor) InsertCertificate(cr certdb.CertificateRecord) error {
 		Status:       cr.Status,
 		Reason:       cr.Reason,
 		Expiry:       cr.Expiry.UTC(),
-		RevokedAt:    cr.RevokedAt.UTC(),
+		RevokedAt:    revokedAt,
 		PEM:          cr.PEM,
 		IssuedAt:     issuedAt,
 		NotBefore:    notBefore,

--- a/cli/crl/crl_test.go
+++ b/cli/crl/crl_test.go
@@ -23,13 +23,15 @@ const (
 func prepDB() (err error) {
 	db := testdb.SQLiteDB("../../certdb/testdb/certstore_development.db")
 	expirationTime := time.Now().AddDate(1, 0, 0)
+
+	timeNow := time.Now()
 	var cert = certdb.CertificateRecord{
 		Serial:    "1",
 		AKI:       fakeAKI,
 		Expiry:    expirationTime,
 		PEM:       "revoked cert",
 		Status:    "revoked",
-		RevokedAt: time.Now(),
+		RevokedAt: &timeNow,
 		Reason:    4,
 	}
 

--- a/cli/ocsprefresh/ocsprefresh.go
+++ b/cli/ocsprefresh/ocsprefresh.go
@@ -78,7 +78,7 @@ func ocsprefreshMain(args []string, c cli.Config) error {
 
 		if certRecord.Status == "revoked" {
 			req.Reason = int(certRecord.Reason)
-			req.RevokedAt = certRecord.RevokedAt
+			req.RevokedAt = *certRecord.RevokedAt
 		}
 
 		resp, err := s.Sign(req)

--- a/crl/crl.go
+++ b/crl/crl.go
@@ -87,7 +87,7 @@ func NewCRLFromDB(certs []certdb.CertificateRecord, issuerCert *x509.Certificate
 		serialInt.SetString(certRecord.Serial, 10)
 		tempCert := pkix.RevokedCertificate{
 			SerialNumber:   serialInt,
-			RevocationTime: certRecord.RevokedAt,
+			RevocationTime: *certRecord.RevokedAt,
 		}
 		revokedCerts = append(revokedCerts, tempCert)
 	}


### PR DESCRIPTION
Fixing MySQL issue while trying to save unsupported 0000-00-00 timestamp to RevokedAt field. Also making default values for timestamps NULL. After the change NULL will be saved to database instead of zeros. 