### PR TITLE
Update csr.go to fix Name.OID parsing field tags

### DIFF
--- a/csr/csr.go
+++ b/csr/csr.go
@@ -42,7 +42,7 @@ type Name struct {
 	OU           string            `json:"OU,omitempty" yaml:"OU,omitempty"` // OrganisationalUnitName
 	E            string            `json:"E,omitempty" yaml:"E,omitempty"`
 	SerialNumber string            `json:"SerialNumber,omitempty" yaml:"SerialNumber,omitempty"`
-	OID          map[string]string `json:"OID,omitempty", yaml:"OID,omitempty"`
+	OID          map[string]string `json:"OID,omitempty" yaml:"OID,omitempty"`
 }
 
 // A KeyRequest contains the algorithm and key size for a new private key.


### PR DESCRIPTION
In the current definition, a comma (`json:"OID,omitempty"**,** yaml:"OID,omitempty"`) that breaks the reflection.