### PR TITLE
feat: can sign ocsp with ed25519

### DIFF
--- a/vendor/golang.org/x/crypto/ocsp/ocsp.go
+++ b/vendor/golang.org/x/crypto/ocsp/ocsp.go
@@ -11,6 +11,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	_ "crypto/sha1"
@@ -151,6 +152,7 @@ var (
 	oidSignatureECDSAWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
 	oidSignatureECDSAWithSHA384 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 3}
 	oidSignatureECDSAWithSHA512 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 4}
+	oidSignatureEd25519         = asn1.ObjectIdentifier{1, 3, 101, 112}
 )
 
 var hashOIDs = map[crypto.Hash]asn1.ObjectIdentifier{
@@ -179,6 +181,7 @@ var signatureAlgorithmDetails = []struct {
 	{x509.ECDSAWithSHA256, oidSignatureECDSAWithSHA256, x509.ECDSA, crypto.SHA256},
 	{x509.ECDSAWithSHA384, oidSignatureECDSAWithSHA384, x509.ECDSA, crypto.SHA384},
 	{x509.ECDSAWithSHA512, oidSignatureECDSAWithSHA512, x509.ECDSA, crypto.SHA512},
+	{x509.PureEd25519, oidSignatureEd25519, x509.Ed25519, crypto.Hash(0)},
 }
 
 // TODO(rlb): This is also from crypto/x509, so same comment as AGL's below
@@ -211,8 +214,16 @@ func signingParamsForPublicKey(pub interface{}, requestedSigAlgo x509.SignatureA
 			err = errors.New("x509: unknown elliptic curve")
 		}
 
+	case ed25519.PublicKey:
+		pubType = x509.Ed25519
+		hashFunc = crypto.SHA512
+		sigAlgo.Algorithm = oidSignatureEd25519 // EdDSA OID
+		sigAlgo.Parameters = asn1.RawValue{
+			Tag: 5,
+		}
+
 	default:
-		err = errors.New("x509: only RSA and ECDSA keys supported")
+		err = errors.New("x509: only RSA, ECDSA and EdDSA keys supported")
 	}
 
 	if err != nil {


### PR DESCRIPTION
**Summary**

This patch adds support for signing OCSP responses with Ed25519 keys in CFSSL's vendored golang.org/x/crypto/ocsp package.

**What's Changed**

- introduced OID for Ed25519 (1.3.101.112) in oidSignatureEd25519
- added support for ed25519.PublicKey in signingParamsForPublicKey
- updated signatureAlgorithmDetails to include x509.PureEd25519
- when ed25519.PublicKey is detected, the appropriate signature algorithm is selected and crypto.SHA512 is set as the hash (dummy value — EdDSA does not use prehashing)
- improved error message to reflect that EdDSA is now supported

**Notes**

- while Ed25519 doesn't require a prehash, crypto.SHA512 is currently used as a placeholder to satisfy interfaces — in practice, the signing code path avoids hashing when Hash(0) is detected.
- this is part of broader support for modern cryptographic algorithms within CFSSL’s OCSP response generation pipeline.

To use with https://github.com/golang/crypto/pull/319